### PR TITLE
docs(cli): surface CLEAT_RECORD env var in --help output

### DIFF
--- a/crates/cleat/Cargo.toml
+++ b/crates/cleat/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 ghostty-vt = []
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 comfy-table = "7"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -27,7 +27,7 @@ pub enum Command {
         cwd: Option<PathBuf>,
         #[arg(long)]
         cmd: Option<String>,
-        #[arg(long)]
+        #[arg(long, env = "CLEAT_RECORD")]
         record: bool,
     },
     Create {
@@ -41,7 +41,7 @@ pub enum Command {
         cwd: Option<PathBuf>,
         #[arg(long)]
         cmd: Option<String>,
-        #[arg(long)]
+        #[arg(long, env = "CLEAT_RECORD")]
         record: bool,
     },
     List {
@@ -108,7 +108,7 @@ pub enum Command {
         cmd: Option<String>,
         #[arg(long)]
         cwd: Option<PathBuf>,
-        #[arg(long)]
+        #[arg(long, env = "CLEAT_RECORD")]
         record: bool,
     },
 }

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -469,7 +469,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
     let mut recorder: Option<crate::recording::SessionRecorder> = None;
     let epoch = Instant::now();
     let mut markers: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
-    if session.record || std::env::var("CLEAT_RECORD").map(|v| v == "1").unwrap_or(false) {
+    if session.record {
         let (cols, rows) = vt_engine.size();
         match crate::recording::SessionRecorder::new(&root.join(id), cols, rows, session.vt_engine.as_str()) {
             Ok(mut r) => {


### PR DESCRIPTION
## Summary
- Use clap's `env` attribute on the `--record` flag so `CLEAT_RECORD` appears in `--help` output automatically
- Remove the manual `std::env::var("CLEAT_RECORD")` fallback in `session.rs` (now handled by clap)
- Add clap `env` feature to Cargo.toml

Closes #16

## Test plan
- [x] `cargo test --workspace` — all 169 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cleat create --help` shows `[env: CLEAT_RECORD=]` on the `--record` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)