### PR TITLE
Add Rust FFI bindings for Ghostty Render State API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 name = "cleat"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "clap",
  "comfy-table",
  "libc",
@@ -204,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "foldhash"
@@ -256,9 +257,9 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -280,9 +281,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -296,9 +297,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -478,9 +479,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -583,9 +584,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -607,9 +608,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -636,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -649,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -659,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -672,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/cleat/Cargo.toml
+++ b/crates/cleat/Cargo.toml
@@ -10,6 +10,7 @@ default = []
 ghostty-vt = []
 
 [dependencies]
+bitflags = "2"
 clap = { version = "4", features = ["derive", "env"] }
 comfy-table = "7"
 serde = { workspace = true }

--- a/crates/cleat/build.rs
+++ b/crates/cleat/build.rs
@@ -28,7 +28,6 @@ fn main() {
     println!("cargo:rustc-env=CLEAT_GHOSTTY_PREFIX={}", install.prefix.display());
     println!("cargo:rustc-link-search=native={}", install.lib_dir.display());
     println!("cargo:rustc-link-lib=dylib=ghostty-vt");
-    #[cfg(target_os = "linux")]
     println!("cargo:rustc-link-arg=-Wl,-rpath,{}", install.lib_dir.display());
 }
 

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -34,7 +34,7 @@ use crate::{
     da::DeviceAttributeTracker,
     protocol::Frame,
     runtime::{RuntimeLayout, SessionMetadata},
-    vt::{self, VtEngine, VtEngineKind},
+    vt::{self, ScreenGrid, VtEngine, VtEngineKind},
 };
 
 const SOCKET_NAME: &str = "socket";
@@ -415,6 +415,10 @@ impl VtEngine for TestReplayProbeVtEngine {
 
     fn screen_text(&self) -> Result<String, String> {
         Ok(format!("probe:{}x{}", self.cols, self.rows))
+    }
+
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
+        Ok(ScreenGrid::default())
     }
 
     fn size(&self) -> (u16, u16) {

--- a/crates/cleat/src/vt/ghostty.rs
+++ b/crates/cleat/src/vt/ghostty.rs
@@ -11,6 +11,8 @@ const DEFAULT_MAX_SCROLLBACK: usize = 10_000;
 pub struct GhosttyVtEngine {
     terminal: TerminalHandle,
     render_state: RenderStateHandle,
+    row_iter: RowIteratorHandle,
+    row_cells: RowCellsHandle,
     cols: u16,
     rows: u16,
     saw_output: bool,
@@ -20,7 +22,9 @@ impl GhosttyVtEngine {
     pub fn new(cols: u16, rows: u16) -> Self {
         let terminal = TerminalHandle::new(cols, rows, DEFAULT_MAX_SCROLLBACK).expect("create ghostty terminal");
         let render_state = RenderStateHandle::new().expect("create ghostty render state");
-        Self { terminal, render_state, cols, rows, saw_output: false }
+        let row_iter = RowIteratorHandle::new().expect("create ghostty row iterator");
+        let row_cells = RowCellsHandle::new().expect("create ghostty row cells");
+        Self { terminal, render_state, row_iter, row_cells, cols, rows, saw_output: false }
     }
 
     fn read_cursor_state(&self) -> Result<CursorState, String> {
@@ -106,35 +110,33 @@ impl VtEngine for GhosttyVtEngine {
 
         let mut cells = Vec::with_capacity((cols as usize) * (rows as usize));
 
-        let mut row_iter = RowIteratorHandle::new()?;
-        self.render_state.populate_row_iterator(&mut row_iter)?;
+        self.render_state.populate_row_iterator(&mut self.row_iter)?;
 
-        let mut row_cells = RowCellsHandle::new()?;
-        while row_iter.next() {
-            row_iter.populate_cells(&mut row_cells)?;
-            while row_cells.next() {
-                let graphemes_len = row_cells.get_graphemes_len()?;
+        while self.row_iter.next() {
+            self.row_iter.populate_cells(&mut self.row_cells)?;
+            while self.row_cells.next() {
+                let graphemes_len = self.row_cells.get_graphemes_len()?;
                 let graphemes = if graphemes_len > 0 {
                     let mut buf = vec![0u32; graphemes_len as usize];
-                    row_cells.get_graphemes_buf(&mut buf)?;
+                    self.row_cells.get_graphemes_buf(&mut buf)?;
                     buf
                 } else {
                     Vec::new()
                 };
 
-                let fg = match row_cells.get_fg_color()? {
+                let fg = match self.row_cells.get_fg_color()? {
                     Some(c) => Rgb { r: c.r, g: c.g, b: c.b },
                     None => default_fg,
                 };
-                let bg = match row_cells.get_bg_color()? {
+                let bg = match self.row_cells.get_bg_color()? {
                     Some(c) => Rgb { r: c.r, g: c.g, b: c.b },
                     None => default_bg,
                 };
 
-                let style = row_cells.get_style()?;
+                let style = self.row_cells.get_style()?;
                 let flags = flags_from_ghostty_style(&style);
 
-                let width = match row_cells.get_wide()? {
+                let width = match self.row_cells.get_wide()? {
                     GhosttyCellWide::Narrow => CellWidth::Narrow,
                     GhosttyCellWide::Wide => CellWidth::Wide,
                     GhosttyCellWide::SpacerTail => CellWidth::SpacerTail,
@@ -185,6 +187,7 @@ fn flags_from_ghostty_style(style: &GhosttyStyle) -> CellFlags {
         flags |= CellFlags::OVERLINE;
     }
     if style.underline != 0 {
+        // 0 = no underline; non-zero values are single/double/curly/dotted/dashed
         flags |= CellFlags::UNDERLINE;
     }
     flags

--- a/crates/cleat/src/vt/ghostty.rs
+++ b/crates/cleat/src/vt/ghostty.rs
@@ -1,12 +1,16 @@
 use super::{
-    ghostty_ffi::{self, GhosttyFormatterFormat, GhosttyFormatterTerminalOptions, TerminalHandle},
-    ClientCapabilities, ColorLevel, ScreenGrid, VtEngine,
+    ghostty_ffi::{
+        self, GhosttyFormatterFormat, GhosttyFormatterTerminalOptions, GhosttyRenderStateCursorVisualStyle, GhosttyRenderStateDirty,
+        GhosttyStyle, RenderStateHandle, RowCellsHandle, RowIteratorHandle, TerminalHandle,
+    },
+    CellFlags, ClientCapabilities, ColorLevel, CursorState, CursorStyle, ResolvedCell, Rgb, ScreenGrid, VtEngine,
 };
 
 const DEFAULT_MAX_SCROLLBACK: usize = 10_000;
 
 pub struct GhosttyVtEngine {
     terminal: TerminalHandle,
+    render_state: RenderStateHandle,
     cols: u16,
     rows: u16,
     saw_output: bool,
@@ -15,7 +19,28 @@ pub struct GhosttyVtEngine {
 impl GhosttyVtEngine {
     pub fn new(cols: u16, rows: u16) -> Self {
         let terminal = TerminalHandle::new(cols, rows, DEFAULT_MAX_SCROLLBACK).expect("create ghostty terminal");
-        Self { terminal, cols, rows, saw_output: false }
+        let render_state = RenderStateHandle::new().expect("create ghostty render state");
+        Self { terminal, render_state, cols, rows, saw_output: false }
+    }
+
+    fn read_cursor_state(&self) -> Result<CursorState, String> {
+        let visible = self.render_state.get_cursor_visible()?;
+        let in_viewport = self.render_state.get_cursor_viewport_has_value()?;
+
+        if !visible || !in_viewport {
+            return Ok(CursorState { visible, ..CursorState::default() });
+        }
+
+        let col = self.render_state.get_cursor_viewport_x()?;
+        let row = self.render_state.get_cursor_viewport_y()?;
+        let style = match self.render_state.get_cursor_visual_style()? {
+            GhosttyRenderStateCursorVisualStyle::Bar => CursorStyle::Bar,
+            GhosttyRenderStateCursorVisualStyle::Block => CursorStyle::Block,
+            GhosttyRenderStateCursorVisualStyle::Underline => CursorStyle::Underline,
+            GhosttyRenderStateCursorVisualStyle::BlockHollow => CursorStyle::BlockHollow,
+        };
+
+        Ok(CursorState { col, row, visible, style })
     }
 }
 
@@ -69,10 +94,89 @@ impl VtEngine for GhosttyVtEngine {
     }
 
     fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
-        todo!("screen_grid: real implementation in Task 3")
+        self.render_state.update(&self.terminal)?;
+        let cols = self.render_state.get_cols()?;
+        let rows = self.render_state.get_rows()?;
+        let colors = self.render_state.get_colors()?;
+
+        let default_fg = Rgb { r: colors.foreground.r, g: colors.foreground.g, b: colors.foreground.b };
+        let default_bg = Rgb { r: colors.background.r, g: colors.background.g, b: colors.background.b };
+
+        let mut cells = Vec::with_capacity((cols as usize) * (rows as usize));
+
+        let mut row_iter = RowIteratorHandle::new()?;
+        self.render_state.populate_row_iterator(&mut row_iter)?;
+
+        let mut row_cells = RowCellsHandle::new()?;
+        while row_iter.next() {
+            row_iter.populate_cells(&mut row_cells)?;
+            while row_cells.next() {
+                let graphemes_len = row_cells.get_graphemes_len()?;
+                let graphemes = if graphemes_len > 0 {
+                    let mut buf = vec![0u32; graphemes_len as usize];
+                    row_cells.get_graphemes_buf(&mut buf)?;
+                    buf
+                } else {
+                    Vec::new()
+                };
+
+                let fg = match row_cells.get_fg_color()? {
+                    Some(c) => Rgb { r: c.r, g: c.g, b: c.b },
+                    None => default_fg,
+                };
+                let bg = match row_cells.get_bg_color()? {
+                    Some(c) => Rgb { r: c.r, g: c.g, b: c.b },
+                    None => default_bg,
+                };
+
+                let style = row_cells.get_style()?;
+                let flags = flags_from_ghostty_style(&style);
+
+                cells.push(ResolvedCell { graphemes, fg, bg, flags });
+            }
+        }
+
+        let cursor = self.read_cursor_state()?;
+
+        // Clear dirty state — cleat is the renderer.
+        self.render_state.set_dirty(GhosttyRenderStateDirty::False)?;
+
+        Ok(ScreenGrid { cells, cols, rows, cursor })
     }
 
     fn size(&self) -> (u16, u16) {
         (self.cols, self.rows)
     }
+}
+
+fn flags_from_ghostty_style(style: &GhosttyStyle) -> CellFlags {
+    let mut flags = CellFlags::empty();
+    if style.bold {
+        flags |= CellFlags::BOLD;
+    }
+    if style.italic {
+        flags |= CellFlags::ITALIC;
+    }
+    if style.faint {
+        flags |= CellFlags::FAINT;
+    }
+    if style.blink {
+        flags |= CellFlags::BLINK;
+    }
+    if style.inverse {
+        flags |= CellFlags::INVERSE;
+    }
+    if style.invisible {
+        flags |= CellFlags::INVISIBLE;
+    }
+    if style.strikethrough {
+        flags |= CellFlags::STRIKETHROUGH;
+    }
+    if style.overline {
+        flags |= CellFlags::OVERLINE;
+    }
+    if style.underline != 0 {
+        flags |= CellFlags::UNDERLINE;
+    }
+    flags
 }

--- a/crates/cleat/src/vt/ghostty.rs
+++ b/crates/cleat/src/vt/ghostty.rs
@@ -1,9 +1,9 @@
 use super::{
     ghostty_ffi::{
-        self, GhosttyFormatterFormat, GhosttyFormatterTerminalOptions, GhosttyRenderStateCursorVisualStyle, GhosttyRenderStateDirty,
-        GhosttyStyle, RenderStateHandle, RowCellsHandle, RowIteratorHandle, TerminalHandle,
+        self, GhosttyCellWide, GhosttyFormatterFormat, GhosttyFormatterTerminalOptions, GhosttyRenderStateCursorVisualStyle,
+        GhosttyRenderStateDirty, GhosttyStyle, RenderStateHandle, RowCellsHandle, RowIteratorHandle, TerminalHandle,
     },
-    CellFlags, ClientCapabilities, ColorLevel, CursorState, CursorStyle, ResolvedCell, Rgb, ScreenGrid, VtEngine,
+    CellFlags, CellWidth, ClientCapabilities, ColorLevel, CursorState, CursorStyle, ResolvedCell, Rgb, ScreenGrid, VtEngine,
 };
 
 const DEFAULT_MAX_SCROLLBACK: usize = 10_000;
@@ -40,7 +40,9 @@ impl GhosttyVtEngine {
             GhosttyRenderStateCursorVisualStyle::BlockHollow => CursorStyle::BlockHollow,
         };
 
-        Ok(CursorState { col, row, visible, style })
+        let wide_tail = self.render_state.get_cursor_viewport_wide_tail()?;
+
+        Ok(CursorState { col, row, visible, style, wide_tail })
     }
 }
 
@@ -132,7 +134,14 @@ impl VtEngine for GhosttyVtEngine {
                 let style = row_cells.get_style()?;
                 let flags = flags_from_ghostty_style(&style);
 
-                cells.push(ResolvedCell { graphemes, fg, bg, flags });
+                let width = match row_cells.get_wide()? {
+                    GhosttyCellWide::Narrow => CellWidth::Narrow,
+                    GhosttyCellWide::Wide => CellWidth::Wide,
+                    GhosttyCellWide::SpacerTail => CellWidth::SpacerTail,
+                    GhosttyCellWide::SpacerHead => CellWidth::SpacerHead,
+                };
+
+                cells.push(ResolvedCell { graphemes, fg, bg, flags, width });
             }
         }
 

--- a/crates/cleat/src/vt/ghostty.rs
+++ b/crates/cleat/src/vt/ghostty.rs
@@ -1,6 +1,6 @@
 use super::{
     ghostty_ffi::{self, GhosttyFormatterFormat, GhosttyFormatterTerminalOptions, TerminalHandle},
-    ClientCapabilities, ColorLevel, VtEngine,
+    ClientCapabilities, ColorLevel, ScreenGrid, VtEngine,
 };
 
 const DEFAULT_MAX_SCROLLBACK: usize = 10_000;
@@ -66,6 +66,10 @@ impl VtEngine for GhosttyVtEngine {
         options.emit = GhosttyFormatterFormat::Plain;
         let payload = ghostty_ffi::format_terminal_alloc(self.terminal.raw(), options)?;
         String::from_utf8(payload).map_err(|err| format!("ghostty plain-text snapshot was not valid utf-8: {err}"))
+    }
+
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
+        todo!("screen_grid: real implementation in Task 3")
     }
 
     fn size(&self) -> (u16, u16) {

--- a/crates/cleat/src/vt/ghostty_ffi.rs
+++ b/crates/cleat/src/vt/ghostty_ffi.rs
@@ -192,6 +192,36 @@ pub enum GhosttyRenderStateRowCellsData {
     FgColor = 6,
 }
 
+pub type GhosttyCell = u64;
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyCellData {
+    Invalid = 0,
+    Codepoint = 1,
+    ContentTag = 2,
+    Wide = 3,
+    HasText = 4,
+    HasStyling = 5,
+    StyleId = 6,
+    HasHyperlink = 7,
+    Protected = 8,
+    SemanticContent = 9,
+    ColorPalette = 10,
+    ColorRgb = 11,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyCellWide {
+    Narrow = 0,
+    Wide = 1,
+    SpacerTail = 2,
+    SpacerHead = 3,
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct GhosttyColorRgb {
@@ -330,6 +360,9 @@ unsafe extern "C" {
         data: GhosttyRenderStateRowCellsData,
         out: *mut c_void,
     ) -> GhosttyResult;
+
+    // --- Cell data ---
+    fn ghostty_cell_get(cell: GhosttyCell, data: GhosttyCellData, out: *mut c_void) -> GhosttyResult;
 }
 
 pub struct TerminalHandle {
@@ -504,6 +537,15 @@ impl RenderStateHandle {
         Ok(style)
     }
 
+    pub fn get_cursor_viewport_wide_tail(&self) -> Result<bool, String> {
+        let mut wide_tail = false;
+        let result = unsafe {
+            ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorViewportWideTail, &mut wide_tail as *mut bool as *mut c_void)
+        };
+        check_result(result, "ghostty_render_state_get(CursorViewportWideTail)")?;
+        Ok(wide_tail)
+    }
+
     pub fn populate_row_iterator(&self, iterator: &mut RowIteratorHandle) -> Result<(), String> {
         let result = unsafe {
             ghostty_render_state_get(
@@ -647,6 +689,23 @@ impl RowCellsHandle {
             GhosttyResult::InvalidValue => Ok(None),
             other => check_result(other, "ghostty_render_state_row_cells_get(FgColor)").map(|_| None),
         }
+    }
+
+    pub fn get_raw_cell(&self) -> Result<GhosttyCell, String> {
+        let mut cell: GhosttyCell = 0;
+        let result = unsafe {
+            ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::Raw, &mut cell as *mut GhosttyCell as *mut c_void)
+        };
+        check_result(result, "ghostty_render_state_row_cells_get(Raw)")?;
+        Ok(cell)
+    }
+
+    pub fn get_wide(&self) -> Result<GhosttyCellWide, String> {
+        let cell = self.get_raw_cell()?;
+        let mut wide = GhosttyCellWide::Narrow;
+        let result = unsafe { ghostty_cell_get(cell, GhosttyCellData::Wide, &mut wide as *mut GhosttyCellWide as *mut c_void) };
+        check_result(result, "ghostty_cell_get(Wide)")?;
+        Ok(wide)
     }
 }
 

--- a/crates/cleat/src/vt/ghostty_ffi.rs
+++ b/crates/cleat/src/vt/ghostty_ffi.rs
@@ -295,11 +295,19 @@ pub struct GhosttyRenderStateColors {
 
 impl GhosttyRenderStateColors {
     pub fn init() -> Self {
+        // Safety: zero-init is valid for this repr(C) struct (all numeric/bool fields);
+        // we then set the size field for the sized-struct ABI.
         let mut s: Self = unsafe { std::mem::zeroed() };
         s.size = std::mem::size_of::<Self>();
         s
     }
 }
+
+// Static asserts: verify Rust layouts match Ghostty's C ABI (from ghostty_type_json()).
+const _: () = assert!(std::mem::size_of::<GhosttyStyleColor>() == 16);
+const _: () = assert!(std::mem::size_of::<GhosttyStyle>() == 72);
+const _: () = assert!(std::mem::size_of::<GhosttyColorRgb>() == 3);
+const _: () = assert!(std::mem::size_of::<GhosttyRenderStateColors>() == 792);
 
 pub enum GhosttyRenderStateOpaque {}
 pub enum GhosttyRowIteratorOpaque {}

--- a/crates/cleat/src/vt/ghostty_ffi.rs
+++ b/crates/cleat/src/vt/ghostty_ffi.rs
@@ -110,6 +110,175 @@ pub enum GhosttyFormatterOpaque {}
 pub type GhosttyTerminal = *mut GhosttyTerminalOpaque;
 pub type GhosttyFormatter = *mut GhosttyFormatterOpaque;
 
+// --- Render state FFI types ---
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateDirty {
+    False = 0,
+    Partial = 1,
+    Full = 2,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateCursorVisualStyle {
+    Bar = 0,
+    Block = 1,
+    Underline = 2,
+    BlockHollow = 3,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateData {
+    Invalid = 0,
+    Cols = 1,
+    Rows = 2,
+    Dirty = 3,
+    RowIterator = 4,
+    ColorBackground = 5,
+    ColorForeground = 6,
+    ColorCursor = 7,
+    ColorCursorHasValue = 8,
+    ColorPalette = 9,
+    CursorVisualStyle = 10,
+    CursorVisible = 11,
+    CursorBlinking = 12,
+    CursorPasswordInput = 13,
+    CursorViewportHasValue = 14,
+    CursorViewportX = 15,
+    CursorViewportY = 16,
+    CursorViewportWideTail = 17,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateOption {
+    Dirty = 0,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateRowData {
+    Invalid = 0,
+    Dirty = 1,
+    Raw = 2,
+    Cells = 3,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateRowOption {
+    Dirty = 0,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateRowCellsData {
+    Invalid = 0,
+    Raw = 1,
+    Style = 2,
+    GraphemesLen = 3,
+    GraphemesBuf = 4,
+    BgColor = 5,
+    FgColor = 6,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GhosttyColorRgb {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub enum GhosttyStyleColorTag {
+    None = 0,
+    Palette = 1,
+    Rgb = 2,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union GhosttyStyleColorValue {
+    pub palette: u8,
+    pub rgb: GhosttyColorRgb,
+    pub _padding: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyStyleColor {
+    pub tag: GhosttyStyleColorTag,
+    pub value: GhosttyStyleColorValue,
+}
+
+/// Sized struct — `size` must be set to `size_of::<Self>()` before use.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyStyle {
+    pub size: usize,
+    pub fg_color: GhosttyStyleColor,
+    pub bg_color: GhosttyStyleColor,
+    pub underline_color: GhosttyStyleColor,
+    pub bold: bool,
+    pub italic: bool,
+    pub faint: bool,
+    pub blink: bool,
+    pub inverse: bool,
+    pub invisible: bool,
+    pub strikethrough: bool,
+    pub overline: bool,
+    pub underline: i32,
+}
+
+impl GhosttyStyle {
+    pub fn init() -> Self {
+        let mut s: Self = unsafe { std::mem::zeroed() };
+        s.size = std::mem::size_of::<Self>();
+        s
+    }
+}
+
+/// Sized struct for bulk color retrieval.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyRenderStateColors {
+    pub size: usize,
+    pub background: GhosttyColorRgb,
+    pub foreground: GhosttyColorRgb,
+    pub cursor: GhosttyColorRgb,
+    pub cursor_has_value: bool,
+    pub palette: [GhosttyColorRgb; 256],
+}
+
+impl GhosttyRenderStateColors {
+    pub fn init() -> Self {
+        let mut s: Self = unsafe { std::mem::zeroed() };
+        s.size = std::mem::size_of::<Self>();
+        s
+    }
+}
+
+pub enum GhosttyRenderStateOpaque {}
+pub enum GhosttyRowIteratorOpaque {}
+pub enum GhosttyRowCellsOpaque {}
+
+pub type GhosttyRenderState = *mut GhosttyRenderStateOpaque;
+pub type GhosttyRenderStateRowIterator = *mut GhosttyRowIteratorOpaque;
+pub type GhosttyRenderStateRowCells = *mut GhosttyRowCellsOpaque;
+
 #[link(name = "ghostty-vt")]
 unsafe extern "C" {
     fn ghostty_terminal_new(allocator: *const c_void, terminal: *mut GhosttyTerminal, options: GhosttyTerminalOptions) -> GhosttyResult;
@@ -125,6 +294,40 @@ unsafe extern "C" {
     ) -> GhosttyResult;
     fn ghostty_formatter_format_buf(formatter: GhosttyFormatter, buf: *mut u8, buf_len: usize, out_written: *mut usize) -> GhosttyResult;
     fn ghostty_formatter_free(formatter: GhosttyFormatter);
+
+    // --- Render state ---
+    fn ghostty_render_state_new(allocator: *const c_void, state: *mut GhosttyRenderState) -> GhosttyResult;
+    fn ghostty_render_state_free(state: GhosttyRenderState);
+    fn ghostty_render_state_update(state: GhosttyRenderState, terminal: GhosttyTerminal) -> GhosttyResult;
+    fn ghostty_render_state_get(state: GhosttyRenderState, data: GhosttyRenderStateData, out: *mut c_void) -> GhosttyResult;
+    fn ghostty_render_state_set(state: GhosttyRenderState, option: GhosttyRenderStateOption, value: *const c_void) -> GhosttyResult;
+    fn ghostty_render_state_colors_get(state: GhosttyRenderState, out_colors: *mut GhosttyRenderStateColors) -> GhosttyResult;
+
+    // --- Row iterator ---
+    fn ghostty_render_state_row_iterator_new(allocator: *const c_void, out_iterator: *mut GhosttyRenderStateRowIterator) -> GhosttyResult;
+    fn ghostty_render_state_row_iterator_free(iterator: GhosttyRenderStateRowIterator);
+    fn ghostty_render_state_row_iterator_next(iterator: GhosttyRenderStateRowIterator) -> bool;
+    fn ghostty_render_state_row_get(
+        iterator: GhosttyRenderStateRowIterator,
+        data: GhosttyRenderStateRowData,
+        out: *mut c_void,
+    ) -> GhosttyResult;
+    fn ghostty_render_state_row_set(
+        iterator: GhosttyRenderStateRowIterator,
+        option: GhosttyRenderStateRowOption,
+        value: *const c_void,
+    ) -> GhosttyResult;
+
+    // --- Row cells ---
+    fn ghostty_render_state_row_cells_new(allocator: *const c_void, out_cells: *mut GhosttyRenderStateRowCells) -> GhosttyResult;
+    fn ghostty_render_state_row_cells_free(cells: GhosttyRenderStateRowCells);
+    fn ghostty_render_state_row_cells_next(cells: GhosttyRenderStateRowCells) -> bool;
+    fn ghostty_render_state_row_cells_select(cells: GhosttyRenderStateRowCells, x: u16) -> GhosttyResult;
+    fn ghostty_render_state_row_cells_get(
+        cells: GhosttyRenderStateRowCells,
+        data: GhosttyRenderStateRowCellsData,
+        out: *mut c_void,
+    ) -> GhosttyResult;
 }
 
 pub struct TerminalHandle {
@@ -193,5 +396,257 @@ fn check_result(result: GhosttyResult, op: &str) -> Result<(), String> {
         GhosttyResult::InvalidValue => Err(format!("{op} failed: invalid value")),
         GhosttyResult::OutOfSpace => Err(format!("{op} failed: out of space")),
         GhosttyResult::NoValue => Err(format!("{op} failed: no value")),
+    }
+}
+
+// --- RAII wrappers for render state ---
+
+pub struct RenderStateHandle {
+    raw: GhosttyRenderState,
+}
+
+impl RenderStateHandle {
+    pub fn new() -> Result<Self, String> {
+        let mut raw = ptr::null_mut();
+        let result = unsafe { ghostty_render_state_new(ptr::null(), &mut raw) };
+        check_result(result, "ghostty_render_state_new")?;
+        Ok(Self { raw })
+    }
+
+    pub fn update(&mut self, terminal: &TerminalHandle) -> Result<(), String> {
+        let result = unsafe { ghostty_render_state_update(self.raw, terminal.raw()) };
+        check_result(result, "ghostty_render_state_update")
+    }
+
+    pub fn get_cols(&self) -> Result<u16, String> {
+        let mut cols: u16 = 0;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::Cols, &mut cols as *mut u16 as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(Cols)")?;
+        Ok(cols)
+    }
+
+    pub fn get_rows(&self) -> Result<u16, String> {
+        let mut rows: u16 = 0;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::Rows, &mut rows as *mut u16 as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(Rows)")?;
+        Ok(rows)
+    }
+
+    pub fn get_dirty(&self) -> Result<GhosttyRenderStateDirty, String> {
+        let mut dirty = GhosttyRenderStateDirty::False;
+        let result = unsafe {
+            ghostty_render_state_get(self.raw, GhosttyRenderStateData::Dirty, &mut dirty as *mut GhosttyRenderStateDirty as *mut c_void)
+        };
+        check_result(result, "ghostty_render_state_get(Dirty)")?;
+        Ok(dirty)
+    }
+
+    pub fn set_dirty(&mut self, dirty: GhosttyRenderStateDirty) -> Result<(), String> {
+        let result = unsafe {
+            ghostty_render_state_set(self.raw, GhosttyRenderStateOption::Dirty, &dirty as *const GhosttyRenderStateDirty as *const c_void)
+        };
+        check_result(result, "ghostty_render_state_set(Dirty)")
+    }
+
+    pub fn get_colors(&self) -> Result<GhosttyRenderStateColors, String> {
+        let mut colors = GhosttyRenderStateColors::init();
+        let result = unsafe { ghostty_render_state_colors_get(self.raw, &mut colors) };
+        check_result(result, "ghostty_render_state_colors_get")?;
+        Ok(colors)
+    }
+
+    pub fn get_cursor_visible(&self) -> Result<bool, String> {
+        let mut visible = false;
+        let result =
+            unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorVisible, &mut visible as *mut bool as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(CursorVisible)")?;
+        Ok(visible)
+    }
+
+    pub fn get_cursor_viewport_has_value(&self) -> Result<bool, String> {
+        let mut has_value = false;
+        let result = unsafe {
+            ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorViewportHasValue, &mut has_value as *mut bool as *mut c_void)
+        };
+        check_result(result, "ghostty_render_state_get(CursorViewportHasValue)")?;
+        Ok(has_value)
+    }
+
+    pub fn get_cursor_viewport_x(&self) -> Result<u16, String> {
+        let mut x: u16 = 0;
+        let result =
+            unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorViewportX, &mut x as *mut u16 as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(CursorViewportX)")?;
+        Ok(x)
+    }
+
+    pub fn get_cursor_viewport_y(&self) -> Result<u16, String> {
+        let mut y: u16 = 0;
+        let result =
+            unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorViewportY, &mut y as *mut u16 as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(CursorViewportY)")?;
+        Ok(y)
+    }
+
+    pub fn get_cursor_visual_style(&self) -> Result<GhosttyRenderStateCursorVisualStyle, String> {
+        let mut style = GhosttyRenderStateCursorVisualStyle::Block;
+        let result = unsafe {
+            ghostty_render_state_get(
+                self.raw,
+                GhosttyRenderStateData::CursorVisualStyle,
+                &mut style as *mut GhosttyRenderStateCursorVisualStyle as *mut c_void,
+            )
+        };
+        check_result(result, "ghostty_render_state_get(CursorVisualStyle)")?;
+        Ok(style)
+    }
+
+    pub fn populate_row_iterator(&self, iterator: &mut RowIteratorHandle) -> Result<(), String> {
+        let result = unsafe {
+            ghostty_render_state_get(
+                self.raw,
+                GhosttyRenderStateData::RowIterator,
+                &mut iterator.raw as *mut GhosttyRenderStateRowIterator as *mut c_void,
+            )
+        };
+        check_result(result, "ghostty_render_state_get(RowIterator)")
+    }
+}
+
+impl Drop for RenderStateHandle {
+    fn drop(&mut self) {
+        unsafe { ghostty_render_state_free(self.raw) };
+    }
+}
+
+pub struct RowIteratorHandle {
+    raw: GhosttyRenderStateRowIterator,
+}
+
+impl RowIteratorHandle {
+    pub fn new() -> Result<Self, String> {
+        let mut raw = ptr::null_mut();
+        let result = unsafe { ghostty_render_state_row_iterator_new(ptr::null(), &mut raw) };
+        check_result(result, "ghostty_render_state_row_iterator_new")?;
+        Ok(Self { raw })
+    }
+
+    pub fn next(&mut self) -> bool {
+        unsafe { ghostty_render_state_row_iterator_next(self.raw) }
+    }
+
+    pub fn get_dirty(&self) -> Result<bool, String> {
+        let mut dirty = false;
+        let result =
+            unsafe { ghostty_render_state_row_get(self.raw, GhosttyRenderStateRowData::Dirty, &mut dirty as *mut bool as *mut c_void) };
+        check_result(result, "ghostty_render_state_row_get(Dirty)")?;
+        Ok(dirty)
+    }
+
+    pub fn populate_cells(&self, cells: &mut RowCellsHandle) -> Result<(), String> {
+        let result = unsafe {
+            ghostty_render_state_row_get(
+                self.raw,
+                GhosttyRenderStateRowData::Cells,
+                &mut cells.raw as *mut GhosttyRenderStateRowCells as *mut c_void,
+            )
+        };
+        check_result(result, "ghostty_render_state_row_get(Cells)")
+    }
+
+    pub fn set_dirty(&mut self, dirty: bool) -> Result<(), String> {
+        let result =
+            unsafe { ghostty_render_state_row_set(self.raw, GhosttyRenderStateRowOption::Dirty, &dirty as *const bool as *const c_void) };
+        check_result(result, "ghostty_render_state_row_set(Dirty)")
+    }
+}
+
+impl Drop for RowIteratorHandle {
+    fn drop(&mut self) {
+        unsafe { ghostty_render_state_row_iterator_free(self.raw) };
+    }
+}
+
+pub struct RowCellsHandle {
+    raw: GhosttyRenderStateRowCells,
+}
+
+impl RowCellsHandle {
+    pub fn new() -> Result<Self, String> {
+        let mut raw = ptr::null_mut();
+        let result = unsafe { ghostty_render_state_row_cells_new(ptr::null(), &mut raw) };
+        check_result(result, "ghostty_render_state_row_cells_new")?;
+        Ok(Self { raw })
+    }
+
+    pub fn next(&mut self) -> bool {
+        unsafe { ghostty_render_state_row_cells_next(self.raw) }
+    }
+
+    pub fn get_graphemes_len(&self) -> Result<u32, String> {
+        let mut len: u32 = 0;
+        let result = unsafe {
+            ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::GraphemesLen, &mut len as *mut u32 as *mut c_void)
+        };
+        check_result(result, "ghostty_render_state_row_cells_get(GraphemesLen)")?;
+        Ok(len)
+    }
+
+    pub fn get_graphemes_buf(&self, buf: &mut [u32]) -> Result<(), String> {
+        let result = unsafe {
+            ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::GraphemesBuf, buf.as_mut_ptr() as *mut c_void)
+        };
+        check_result(result, "ghostty_render_state_row_cells_get(GraphemesBuf)")
+    }
+
+    pub fn get_style(&self) -> Result<GhosttyStyle, String> {
+        let mut style = GhosttyStyle::init();
+        let result = unsafe {
+            ghostty_render_state_row_cells_get(
+                self.raw,
+                GhosttyRenderStateRowCellsData::Style,
+                &mut style as *mut GhosttyStyle as *mut c_void,
+            )
+        };
+        check_result(result, "ghostty_render_state_row_cells_get(Style)")?;
+        Ok(style)
+    }
+
+    pub fn get_bg_color(&self) -> Result<Option<GhosttyColorRgb>, String> {
+        let mut color = GhosttyColorRgb::default();
+        let result = unsafe {
+            ghostty_render_state_row_cells_get(
+                self.raw,
+                GhosttyRenderStateRowCellsData::BgColor,
+                &mut color as *mut GhosttyColorRgb as *mut c_void,
+            )
+        };
+        match result {
+            GhosttyResult::Success => Ok(Some(color)),
+            GhosttyResult::InvalidValue => Ok(None),
+            other => check_result(other, "ghostty_render_state_row_cells_get(BgColor)").map(|_| None),
+        }
+    }
+
+    pub fn get_fg_color(&self) -> Result<Option<GhosttyColorRgb>, String> {
+        let mut color = GhosttyColorRgb::default();
+        let result = unsafe {
+            ghostty_render_state_row_cells_get(
+                self.raw,
+                GhosttyRenderStateRowCellsData::FgColor,
+                &mut color as *mut GhosttyColorRgb as *mut c_void,
+            )
+        };
+        match result {
+            GhosttyResult::Success => Ok(Some(color)),
+            GhosttyResult::InvalidValue => Ok(None),
+            other => check_result(other, "ghostty_render_state_row_cells_get(FgColor)").map(|_| None),
+        }
+    }
+}
+
+impl Drop for RowCellsHandle {
+    fn drop(&mut self) {
+        unsafe { ghostty_render_state_row_cells_free(self.raw) };
     }
 }

--- a/crates/cleat/src/vt/ghostty_ffi.rs
+++ b/crates/cleat/src/vt/ghostty_ffi.rs
@@ -312,6 +312,7 @@ unsafe extern "C" {
         data: GhosttyRenderStateRowData,
         out: *mut c_void,
     ) -> GhosttyResult;
+    #[allow(dead_code)]
     fn ghostty_render_state_row_set(
         iterator: GhosttyRenderStateRowIterator,
         option: GhosttyRenderStateRowOption,
@@ -322,6 +323,7 @@ unsafe extern "C" {
     fn ghostty_render_state_row_cells_new(allocator: *const c_void, out_cells: *mut GhosttyRenderStateRowCells) -> GhosttyResult;
     fn ghostty_render_state_row_cells_free(cells: GhosttyRenderStateRowCells);
     fn ghostty_render_state_row_cells_next(cells: GhosttyRenderStateRowCells) -> bool;
+    #[allow(dead_code)]
     fn ghostty_render_state_row_cells_select(cells: GhosttyRenderStateRowCells, x: u16) -> GhosttyResult;
     fn ghostty_render_state_row_cells_get(
         cells: GhosttyRenderStateRowCells,
@@ -432,6 +434,7 @@ impl RenderStateHandle {
         Ok(rows)
     }
 
+    #[allow(dead_code)]
     pub fn get_dirty(&self) -> Result<GhosttyRenderStateDirty, String> {
         let mut dirty = GhosttyRenderStateDirty::False;
         let result = unsafe {
@@ -535,6 +538,7 @@ impl RowIteratorHandle {
         unsafe { ghostty_render_state_row_iterator_next(self.raw) }
     }
 
+    #[allow(dead_code)]
     pub fn get_dirty(&self) -> Result<bool, String> {
         let mut dirty = false;
         let result =
@@ -554,6 +558,7 @@ impl RowIteratorHandle {
         check_result(result, "ghostty_render_state_row_get(Cells)")
     }
 
+    #[allow(dead_code)]
     pub fn set_dirty(&mut self, dirty: bool) -> Result<(), String> {
         let result =
             unsafe { ghostty_render_state_row_set(self.raw, GhosttyRenderStateRowOption::Dirty, &dirty as *const bool as *const c_void) };

--- a/crates/cleat/src/vt/mod.rs
+++ b/crates/cleat/src/vt/mod.rs
@@ -60,12 +60,22 @@ bitflags::bitflags! {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CellWidth {
+    #[default]
+    Narrow,
+    Wide,
+    SpacerTail,
+    SpacerHead,
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ResolvedCell {
     pub graphemes: Vec<u32>,
     pub fg: Rgb,
     pub bg: Rgb,
     pub flags: CellFlags,
+    pub width: CellWidth,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -83,6 +93,7 @@ pub struct CursorState {
     pub row: u16,
     pub visible: bool,
     pub style: CursorStyle,
+    pub wide_tail: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -110,6 +121,9 @@ impl ScreenGrid {
         let end = start + (self.cols as usize);
         let mut s = String::with_capacity(self.cols as usize);
         for cell in &self.cells[start..end] {
+            if matches!(cell.width, CellWidth::SpacerTail | CellWidth::SpacerHead) {
+                continue;
+            }
             if cell.graphemes.is_empty() {
                 s.push(' ');
             } else {

--- a/crates/cleat/src/vt/mod.rs
+++ b/crates/cleat/src/vt/mod.rs
@@ -108,10 +108,19 @@ impl ScreenGrid {
         }
         let start = (row as usize) * (self.cols as usize);
         let end = start + (self.cols as usize);
-        self.cells[start..end]
-            .iter()
-            .map(|cell| if cell.graphemes.is_empty() { ' ' } else { char::from_u32(cell.graphemes[0]).unwrap_or(' ') })
-            .collect()
+        let mut s = String::with_capacity(self.cols as usize);
+        for cell in &self.cells[start..end] {
+            if cell.graphemes.is_empty() {
+                s.push(' ');
+            } else {
+                for &cp in &cell.graphemes {
+                    if let Some(ch) = char::from_u32(cp) {
+                        s.push(ch);
+                    }
+                }
+            }
+        }
+        s
     }
 }
 

--- a/crates/cleat/src/vt/mod.rs
+++ b/crates/cleat/src/vt/mod.rs
@@ -38,6 +38,83 @@ pub enum ColorLevel {
     TrueColor,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Rgb {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    pub struct CellFlags: u16 {
+        const BOLD          = 1 << 0;
+        const ITALIC        = 1 << 1;
+        const FAINT         = 1 << 2;
+        const BLINK         = 1 << 3;
+        const INVERSE       = 1 << 4;
+        const INVISIBLE     = 1 << 5;
+        const STRIKETHROUGH = 1 << 6;
+        const OVERLINE      = 1 << 7;
+        const UNDERLINE     = 1 << 8;
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ResolvedCell {
+    pub graphemes: Vec<u32>,
+    pub fg: Rgb,
+    pub bg: Rgb,
+    pub flags: CellFlags,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CursorStyle {
+    Bar,
+    #[default]
+    Block,
+    Underline,
+    BlockHollow,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct CursorState {
+    pub col: u16,
+    pub row: u16,
+    pub visible: bool,
+    pub style: CursorStyle,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ScreenGrid {
+    pub cells: Vec<ResolvedCell>,
+    pub cols: u16,
+    pub rows: u16,
+    pub cursor: CursorState,
+}
+
+impl ScreenGrid {
+    pub fn cell(&self, col: u16, row: u16) -> Option<&ResolvedCell> {
+        if col < self.cols && row < self.rows {
+            self.cells.get((row as usize) * (self.cols as usize) + (col as usize))
+        } else {
+            None
+        }
+    }
+
+    pub fn row_text(&self, row: u16) -> String {
+        if row >= self.rows {
+            return String::new();
+        }
+        let start = (row as usize) * (self.cols as usize);
+        let end = start + (self.cols as usize);
+        self.cells[start..end]
+            .iter()
+            .map(|cell| if cell.graphemes.is_empty() { ' ' } else { char::from_u32(cell.graphemes[0]).unwrap_or(' ') })
+            .collect()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum VtEngineKind {
@@ -78,6 +155,7 @@ pub trait VtEngine {
     fn supports_replay(&self) -> bool;
     fn replay_payload(&self, capabilities: &ClientCapabilities) -> Result<Option<Vec<u8>>, String>;
     fn screen_text(&self) -> Result<String, String>;
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String>;
     fn size(&self) -> (u16, u16);
 }
 

--- a/crates/cleat/src/vt/passthrough.rs
+++ b/crates/cleat/src/vt/passthrough.rs
@@ -1,4 +1,4 @@
-use super::{ClientCapabilities, VtEngine};
+use super::{ClientCapabilities, ScreenGrid, VtEngine};
 
 #[derive(Debug, Clone)]
 pub struct PassthroughVtEngine {
@@ -39,6 +39,11 @@ impl VtEngine for PassthroughVtEngine {
 
     fn screen_text(&self) -> Result<String, String> {
         Err("screen text capture is unavailable because vt engine passthrough is a placeholder/test-only engine, not a functional VT engine".to_string())
+    }
+
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
+        Err("screen grid is unavailable because vt engine passthrough is a placeholder/test-only engine, not a functional VT engine"
+            .to_string())
     }
 
     fn size(&self) -> (u16, u16) {

--- a/crates/cleat/tests/vt.rs
+++ b/crates/cleat/tests/vt.rs
@@ -101,6 +101,19 @@ fn vt_ghostty_blank_engine_does_not_emit_replay_payload() {
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
+fn vt_ghostty_screen_grid_returns_correct_dimensions() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    engine.feed(b"hello grid").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    assert_eq!(grid.cols, 40);
+    assert_eq!(grid.rows, 5);
+    assert_eq!(grid.cells.len(), 40 * 5);
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
 fn vt_ghostty_links_against_shared_library() {
     let prefix = PathBuf::from(env!("CLEAT_GHOSTTY_PREFIX"));
     let lib_name = shared_library_filename();

--- a/crates/cleat/tests/vt.rs
+++ b/crates/cleat/tests/vt.rs
@@ -184,6 +184,28 @@ fn vt_passthrough_screen_grid_returns_error() {
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
+fn vt_ghostty_screen_grid_wide_chars_not_doubled_in_row_text() {
+    use cleat::vt::CellWidth;
+
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(20, 3);
+
+    // CJK character 字 is a wide (2-column) glyph
+    engine.feed("字ab".as_bytes()).expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+
+    // Col 0 should be the wide char, col 1 should be the spacer tail
+    assert_eq!(grid.cell(0, 0).unwrap().width, CellWidth::Wide);
+    assert_eq!(grid.cell(1, 0).unwrap().width, CellWidth::SpacerTail);
+    assert_eq!(grid.cell(2, 0).unwrap().width, CellWidth::Narrow);
+
+    // row_text should produce "字ab" not "字 ab"
+    let text = grid.row_text(0);
+    assert!(text.starts_with("字ab"), "expected row_text to start with '字ab', got: {text:?}");
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
 fn vt_ghostty_links_against_shared_library() {
     let prefix = PathBuf::from(env!("CLEAT_GHOSTTY_PREFIX"));
     let lib_name = shared_library_filename();

--- a/crates/cleat/tests/vt.rs
+++ b/crates/cleat/tests/vt.rs
@@ -114,6 +114,76 @@ fn vt_ghostty_screen_grid_returns_correct_dimensions() {
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
+fn vt_ghostty_screen_grid_captures_cell_text() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    engine.feed(b"Hello").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    let text: String = (0..5)
+        .map(|col| {
+            let cell = grid.cell(col, 0).unwrap();
+            if cell.graphemes.is_empty() {
+                ' '
+            } else {
+                char::from_u32(cell.graphemes[0]).unwrap_or('?')
+            }
+        })
+        .collect();
+    assert_eq!(text, "Hello");
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_captures_bold_style() {
+    use cleat::vt::CellFlags;
+
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    engine.feed(b"\x1b[1mbold\x1b[0m plain").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    // 'b' at col 0 should be bold
+    assert!(grid.cell(0, 0).unwrap().flags.contains(CellFlags::BOLD));
+    // 'p' at col 5 (after "bold ") should not be bold
+    assert!(!grid.cell(5, 0).unwrap().flags.contains(CellFlags::BOLD));
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_captures_cursor_position() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    engine.feed(b"Hello").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    assert!(grid.cursor.visible);
+    assert_eq!(grid.cursor.col, 5);
+    assert_eq!(grid.cursor.row, 0);
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_row_text_returns_row_content() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(10, 3);
+
+    engine.feed(b"line one\r\nline two").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    assert_eq!(grid.row_text(0).trim_end(), "line one");
+    assert_eq!(grid.row_text(1).trim_end(), "line two");
+    assert_eq!(grid.row_text(2).trim_end(), "");
+}
+
+#[test]
+fn vt_passthrough_screen_grid_returns_error() {
+    let mut engine = cleat::vt::passthrough::PassthroughVtEngine::new(80, 24);
+    let err = engine.screen_grid().expect_err("passthrough should fail");
+    assert!(err.contains("placeholder/test-only"));
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
 fn vt_ghostty_links_against_shared_library() {
     let prefix = PathBuf::from(env!("CLEAT_GHOSTTY_PREFIX"));
     let lib_name = shared_library_filename();

--- a/crates/cleat/tests/vt_contracts.rs
+++ b/crates/cleat/tests/vt_contracts.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "ghostty-vt")]
 use cleat::vt::ghostty::GhosttyVtEngine;
-use cleat::vt::{passthrough::PassthroughVtEngine, ClientCapabilities, ColorLevel, VtEngine};
+use cleat::vt::{passthrough::PassthroughVtEngine, ClientCapabilities, ColorLevel, ScreenGrid, VtEngine};
 
 pub trait EngineFixture {
     type Engine: VtEngine;
@@ -71,6 +71,10 @@ impl VtEngine for PlaceholderReplayVtEngine {
 
     fn screen_text(&self) -> Result<String, String> {
         Ok("placeholder".to_string())
+    }
+
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
+        Ok(ScreenGrid::default())
     }
 
     fn size(&self) -> (u16, u16) {

--- a/docs/specs/2026-03-23-terminal-screen-introspection.md
+++ b/docs/specs/2026-03-23-terminal-screen-introspection.md
@@ -40,63 +40,45 @@ The core insight: **a terminal screen is not a grid of characters — it is a la
 
 ## Design
 
-### Layer 0: Ghostty C API additions
+### Layer 0: Ghostty Render State C API
 
-Ghostty's internal renderer accesses the terminal via `RenderState` — a module in `src/terminal/render.zig` that copies dirty rows from pages, resolves style IDs into concrete styles (colors, attributes), and presents flat arrays of cells+styles. This is terminal-module functionality, not renderer-module — it lives alongside the screen and page code.
+Ghostty's upstream C API (`include/ghostty/vt/render.h`) already exposes a full render state API. This is included in cleat's pinned ghostty ref and available in `libghostty-vt`. No fork or upstream contribution is needed.
 
-Cleat needs the same access. New C API functions wrapping RenderState:
+The API uses an iterator-based pattern rather than bulk cell copies:
 
-```c
-// Opaque handle to a render state (one per terminal)
-typedef struct GhosttyRenderState* GhosttyRenderState;
+**Lifecycle:**
+- `ghostty_render_state_new()` / `ghostty_render_state_free()` — create/destroy render state
+- `ghostty_render_state_update(state, terminal)` — snapshot terminal state, consumes terminal dirty flags
 
-// Cell data with resolved style — no indirection through style IDs
-typedef struct {
-    uint32_t codepoint;       // Unicode codepoint (21 bits used)
-    uint8_t wide;             // 0=narrow, 1=wide, 2=spacer_head, 3=spacer_tail
-    uint8_t fg_r, fg_g, fg_b; // Resolved foreground color
-    uint8_t bg_r, bg_g, bg_b; // Resolved background color
-    uint16_t flags;           // bold, italic, inverse, underline, etc.
-    // Exact layout TBD — this is the shape, not the ABI
-} GhosttyResolvedCell;
+**Global state** (via `ghostty_render_state_get()`):
+- Viewport dimensions (cols, rows)
+- Dirty state (false / partial / full)
+- Colors: background, foreground, cursor, full 256-color palette
+- Cursor: position, visibility, blinking, visual style (bar/block/underline/hollow), password input, wide-char-tail
 
-// Create a render state for a terminal
-GhosttyResult ghostty_render_state_new(
-    const GhosttyAllocator* allocator,
-    GhosttyRenderState* state,
-    GhosttyTerminal terminal);
+**Row iteration:**
+- `ghostty_render_state_row_iterator_new/free()` — allocate reusable iterator
+- `ghostty_render_state_row_iterator_next()` — advance to next row
+- `ghostty_render_state_row_get()` — query per-row dirty flag, get cells handle
 
-// Update render state — copies dirty rows, resolves styles
-// Returns which rows are dirty via out_dirty_flags (bool per row)
-GhosttyResult ghostty_render_state_update(
-    GhosttyRenderState state,
-    bool* out_dirty_flags,
-    uint16_t num_rows);
+**Cell iteration** (per row):
+- `ghostty_render_state_row_cells_new/free()` — allocate reusable cells container
+- `ghostty_render_state_row_cells_next()` / `_select(x)` — iterate or jump to column
+- `ghostty_render_state_row_cells_get()` — query cell data:
+  - **Grapheme clusters**: `GRAPHEMES_LEN` (codepoint count) + `GRAPHEMES_BUF` (codepoint array) — full multi-codepoint grapheme support, not single codepoints
+  - **Style**: `GhosttyStyle` sized struct with tagged-union colors (none/palette/rgb) for fg, bg, underline; bool flags for bold, italic, faint, blink, inverse, invisible, strikethrough, overline; underline enum (single/double/curly/dotted/dashed)
+  - **Resolved colors**: `BG_COLOR` / `FG_COLOR` as `GhosttyColorRgb` — palette lookups already performed
 
-// Read resolved cells for a range of rows
-// Cells are written contiguously: row0[0..cols], row1[0..cols], ...
-GhosttyResult ghostty_render_state_get_cells(
-    GhosttyRenderState state,
-    uint16_t start_row,
-    uint16_t num_rows,
-    GhosttyResolvedCell* out_cells,
-    size_t out_cells_len);
+**Dirty tracking:**
+- Two-layer: global (false/partial/full) + per-row (bool)
+- Caller is responsible for resetting both layers after reading
+- `ghostty_render_state_set()` to reset global, `ghostty_render_state_row_set()` to reset per-row
 
-// Get cursor state
-GhosttyResult ghostty_render_state_get_cursor(
-    GhosttyRenderState state,
-    uint16_t* out_col,
-    uint16_t* out_row,
-    bool* out_visible,
-    uint8_t* out_style);  // block, bar, underline
+**Key difference from original spec assumption:** The original spec proposed a flat `GhosttyResolvedCell` struct with bulk `get_cells()`. The actual API uses opaque iterators with per-field getters. This is more flexible (forward-compatible via sized structs) but means cleat must iterate and copy into its own types rather than memcpy rows.
 
-// Free render state
-void ghostty_render_state_free(GhosttyRenderState state);
-```
+A complete working example exists at `ghostty/example/c-vt-render/src/main.c` in the ghostty repo.
 
-This mirrors the internal rendering contract: update() detects dirty rows and copies/resolves cells, get_cells() reads the resolved data, and dirty flags are cleared as part of update(). Cleat calls update() on each PTY read cycle (or lazily on inspect).
-
-**Upstream strategy:** Maintain as a fork initially. Submit PR to Ghostty with working cleat usage as motivation. The API shape follows their internal patterns (RenderState is already how the Zig renderer works), so the ask is "expose what you already have" not "build something new."
+See also: [libghostty render state docs](https://libghostty.tip.ghostty.org/group__render.html)
 
 ### Layer 1: Screen grid (in cleat daemon)
 
@@ -107,20 +89,35 @@ pub struct ScreenGrid {
     cells: Vec<ResolvedCell>,  // cols * rows, row-major
     cols: u16,
     rows: u16,
-    cursor_col: u16,
-    cursor_row: u16,
-    cursor_visible: bool,
+    cursor: CursorState,
     generation: u64,           // Incremented on each update
-    row_generations: Vec<u64>, // Per-row generation for change tracking
+}
+
+pub struct ResolvedCell {
+    pub graphemes: Vec<u32>,   // Full grapheme cluster (multiple codepoints)
+    pub fg: Rgb,               // Resolved foreground color
+    pub bg: Rgb,               // Resolved background color
+    pub flags: CellFlags,      // bold, italic, inverse, underline, etc.
+}
+
+pub struct CursorState {
+    pub col: u16,
+    pub row: u16,
+    pub visible: bool,
+    pub style: CursorStyle,    // bar, block, underline, hollow
+    pub blinking: bool,
 }
 ```
 
-On each PTY read cycle (or lazily on first inspect request), the daemon:
-1. Calls `ghostty_render_state_update()` to get dirty flags
-2. Calls `ghostty_render_state_get_cells()` for dirty rows only
-3. Updates its `ScreenGrid`, bumping row generations
+On each update, the daemon:
+1. Calls `ghostty_render_state_update()` to snapshot terminal state
+2. Checks global dirty state — skip if clean
+3. Uses Ghostty's per-row dirty flags as a fast path to identify which rows to check
+4. Iterates dirty rows and copies cell data into the `ScreenGrid`
 
 The `ScreenGrid` is the stable interface that the analysis crate works against. If the Ghostty FFI changes shape, only this update code changes.
+
+**Change tracking (future design needed):** Ghostty provides row-level dirty flags, which tell cleat which rows changed since the last update. But for region detection via temporal co-change analysis (rows that change together are likely in the same region), cleat will need cell-level change tracking — diffing the actual cell content against the previous frame, not just trusting Ghostty's row-dirty hint. Ghostty's row-dirty serves as an optimization to limit which rows to diff, but cleat owns the diff and the change history. The exact model (per-cell generation stamps, ring buffer of change sets, co-change clustering) should be designed when the analysis layer (#23) is built, not prematurely specified here.
 
 ### Layer 2: Screen analysis crate (`crates/terminal-screen`)
 
@@ -252,28 +249,21 @@ This extends the existing inspect infrastructure. The `--screen` flag triggers a
 
 ### VtEngine trait extension
 
-The `VtEngine` trait gets a single new method that atomically updates the screen grid and returns dirty information:
+The `VtEngine` trait gets a method to read the current screen as a grid of resolved cells:
 
 ```rust
-pub struct ScreenUpdate {
-    pub grid: ScreenGrid,
-    pub dirty_rows: Vec<bool>,
-    pub resized: bool,  // true if dimensions changed since last call
-}
-
 pub trait VtEngine {
     // ... existing methods ...
 
-    /// Update the screen grid with current terminal state.
-    /// Returns the full grid, per-row dirty flags, and whether a resize occurred.
-    /// Dirty flags are cleared after this call (cleat is the renderer).
-    fn update_screen(&mut self) -> Result<ScreenUpdate, String>;
+    /// Snapshot the current screen as a grid of resolved cells.
+    /// The engine owns the render state internally; this copies data out.
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String>;
 }
 ```
 
-A single method avoids ambiguous call ordering between separate `screen_grid()` and `dirty_rows()` calls — since dirty flags are cleared during the Ghostty RenderState update, splitting these would create a footgun.
+The Ghostty engine calls `render_state_update()` internally, iterates cells, and populates a `ScreenGrid`. The passthrough engine returns an error. The `ScreenGrid` is an owned snapshot — callers can hold it, diff it against previous snapshots, or pass it to the analysis layer without lifetime concerns.
 
-The passthrough engine returns empty/default results. The Ghostty engine delegates to the new C API. This keeps the VT engine abstraction clean.
+This is intentionally a simple "give me the screen" method. Change tracking, dirty optimization, and incremental update logic belong in the layer above (the daemon or analysis crate), not in the trait itself — different consumers will have different change-tracking needs.
 
 ## Future work
 
@@ -318,9 +308,11 @@ Record inferred regions as a parallel track alongside raw VT output. New frame t
 
 ## Phasing
 
-1. **Ghostty C API** — RenderState wrapper with resolved cells, dirty flags, cursor
-2. **`crates/terminal-screen`** — ScreenGrid type, text search, band detection, box detection
-3. **Wire into cleat** — VtEngine trait extension, `inspect --screen`
-4. **Iterate** — Add detectors, tune confidence, test against real TUIs
-5. **Region tracking** — Stable IDs, matching heuristics (follow-on spec)
-6. **Semantics + events** — Roles, focus, test DSL (follow-on spec)
+1. ~~**Ghostty C API**~~ — Already exists upstream, included in cleat's pinned ref
+2. **FFI bindings + `screen_grid()`** — Rust FFI for render state API, `ScreenGrid`/`ResolvedCell` types, `VtEngine::screen_grid()` method on Ghostty engine
+3. **Transcoding (#29)** — First consumer. Use `screen_grid()` to render `capture --since-marker` as clean text instead of ANSI soup. Validates the FFI bindings against a real use case without needing the analysis layer.
+4. **`crates/terminal-screen`** — ScreenGrid analysis: text search, band detection, box detection. Design the change-tracking model here when we understand the actual access patterns.
+5. **`inspect --screen`** — Wire analysis into the CLI
+6. **Iterate** — Add detectors, tune confidence, test against real TUIs
+7. **Region tracking** — Stable IDs, temporal co-change analysis, matching heuristics (follow-on spec)
+8. **Semantics + events** — Roles, focus, test DSL (follow-on spec)

--- a/docs/superpowers/plans/2026-04-02-render-state-ffi.md
+++ b/docs/superpowers/plans/2026-04-02-render-state-ffi.md
@@ -1,0 +1,968 @@
+# Render State FFI Bindings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Rust FFI bindings for Ghostty's Render State C API and expose a `screen_grid()` method on `GhosttyVtEngine` that returns cleat-native `ScreenGrid`/`ResolvedCell` types.
+
+**Architecture:** The FFI layer in `ghostty_ffi.rs` gets raw `extern "C"` declarations and RAII wrapper types matching the existing `TerminalHandle` pattern. New cleat-native types (`ScreenGrid`, `ResolvedCell`, `CursorState`) live in `vt/mod.rs` and are populated by iterating Ghostty's render state API. The `VtEngine` trait gains a `screen_grid()` method; the passthrough engine returns an error.
+
+**Tech Stack:** Rust, unsafe FFI (`#[link(name = "ghostty-vt")]`), `#[repr(C)]` structs matching Ghostty's ABI.
+
+---
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `crates/cleat/src/vt/mod.rs` | `ScreenGrid`, `ResolvedCell`, `CursorState`, `CellFlags`, `CursorStyle`, `Rgb` types + `screen_grid()` on `VtEngine` trait |
+| `crates/cleat/src/vt/ghostty_ffi.rs` | Raw FFI declarations for render state API, `#[repr(C)]` mirror types, RAII wrappers (`RenderStateHandle`, `RowIteratorHandle`, `RowCellsHandle`) |
+| `crates/cleat/src/vt/ghostty.rs` | `GhosttyVtEngine::screen_grid()` implementation using FFI wrappers |
+| `crates/cleat/src/vt/passthrough.rs` | `PassthroughVtEngine::screen_grid()` returning error |
+| `crates/cleat/tests/vt.rs` | Integration tests for `screen_grid()` |
+| `crates/cleat/tests/vt_contracts.rs` | Contract test helpers updated for `screen_grid()` |
+
+---
+
+### Task 1: Add cleat-native screen types to `vt/mod.rs`
+
+Define the types that consumers will work with. These are pure Rust — no FFI dependency.
+
+**Files:**
+- Modify: `crates/cleat/src/vt/mod.rs`
+
+- [ ] **Step 1: Add the screen types after the existing `ColorLevel` enum**
+
+Add these types to `crates/cleat/src/vt/mod.rs` after line 39 (after the `ColorLevel` enum), before `VtEngineKind`:
+
+```rust
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Rgb {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    pub struct CellFlags: u16 {
+        const BOLD          = 1 << 0;
+        const ITALIC        = 1 << 1;
+        const FAINT         = 1 << 2;
+        const BLINK         = 1 << 3;
+        const INVERSE       = 1 << 4;
+        const INVISIBLE     = 1 << 5;
+        const STRIKETHROUGH = 1 << 6;
+        const OVERLINE      = 1 << 7;
+        const UNDERLINE     = 1 << 8;
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ResolvedCell {
+    pub graphemes: Vec<u32>,
+    pub fg: Rgb,
+    pub bg: Rgb,
+    pub flags: CellFlags,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CursorStyle {
+    Bar,
+    #[default]
+    Block,
+    Underline,
+    BlockHollow,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct CursorState {
+    pub col: u16,
+    pub row: u16,
+    pub visible: bool,
+    pub style: CursorStyle,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ScreenGrid {
+    pub cells: Vec<ResolvedCell>,
+    pub cols: u16,
+    pub rows: u16,
+    pub cursor: CursorState,
+}
+
+impl ScreenGrid {
+    pub fn cell(&self, col: u16, row: u16) -> Option<&ResolvedCell> {
+        if col < self.cols && row < self.rows {
+            self.cells.get((row as usize) * (self.cols as usize) + (col as usize))
+        } else {
+            None
+        }
+    }
+
+    pub fn row_text(&self, row: u16) -> String {
+        if row >= self.rows {
+            return String::new();
+        }
+        let start = (row as usize) * (self.cols as usize);
+        let end = start + (self.cols as usize);
+        self.cells[start..end]
+            .iter()
+            .map(|cell| {
+                if cell.graphemes.is_empty() {
+                    ' '
+                } else {
+                    char::from_u32(cell.graphemes[0]).unwrap_or(' ')
+                }
+            })
+            .collect()
+    }
+}
+```
+
+- [ ] **Step 2: Add `bitflags` dependency to Cargo.toml**
+
+Check if `bitflags` is already a dependency. If not, add it:
+
+Run: `grep bitflags crates/cleat/Cargo.toml`
+
+If not present, add `bitflags = "2"` to `[dependencies]` in `crates/cleat/Cargo.toml`.
+
+- [ ] **Step 3: Add `screen_grid()` to the `VtEngine` trait**
+
+In `crates/cleat/src/vt/mod.rs`, add to the `VtEngine` trait (after `screen_text`):
+
+```rust
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String>;
+```
+
+- [ ] **Step 4: Add `screen_grid()` stub to PassthroughVtEngine**
+
+In `crates/cleat/src/vt/passthrough.rs`, add to the `VtEngine` impl:
+
+```rust
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
+        Err("screen grid is unavailable because vt engine passthrough is a placeholder/test-only engine, not a functional VT engine".to_string())
+    }
+```
+
+Import `ScreenGrid` in the use statement:
+
+```rust
+use super::{ClientCapabilities, ScreenGrid, VtEngine};
+```
+
+- [ ] **Step 5: Add `screen_grid()` to test VtEngine impls**
+
+In `crates/cleat/tests/vt_contracts.rs`, add `screen_grid` to the `PlaceholderReplayVtEngine` impl:
+
+```rust
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
+        Ok(ScreenGrid::default())
+    }
+```
+
+Import `ScreenGrid` in the use statement.
+
+Also in `crates/cleat/src/session.rs`, add `screen_grid` to `TestReplayProbeVtEngine`:
+
+```rust
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
+        Ok(ScreenGrid::default())
+    }
+```
+
+Import `ScreenGrid` in the relevant use statement.
+
+- [ ] **Step 6: Add the public re-exports**
+
+In `crates/cleat/src/vt/mod.rs`, add to the existing re-exports near the top:
+
+```rust
+pub use self::{CellFlags, CursorState, CursorStyle, ResolvedCell, Rgb, ScreenGrid};
+```
+
+- [ ] **Step 7: Verify compilation**
+
+Run: `cargo build --workspace --locked`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cleat/src/vt/mod.rs crates/cleat/src/vt/passthrough.rs crates/cleat/tests/vt_contracts.rs crates/cleat/src/session.rs crates/cleat/Cargo.toml
+git commit -m "vt: add ScreenGrid, ResolvedCell, and screen_grid() trait method"
+```
+
+---
+
+### Task 2: Add render state FFI declarations and RAII wrappers
+
+Add the raw `extern "C"` declarations and safe wrapper types to `ghostty_ffi.rs`.
+
+**Files:**
+- Modify: `crates/cleat/src/vt/ghostty_ffi.rs`
+
+- [ ] **Step 1: Add `#[repr(C)]` mirror types for Ghostty's enums and structs**
+
+Add these after the existing `GhosttyFormatterOpaque` line (before the `#[link]` block) in `ghostty_ffi.rs`:
+
+```rust
+// --- Render state FFI types ---
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateDirty {
+    False = 0,
+    Partial = 1,
+    Full = 2,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateCursorVisualStyle {
+    Bar = 0,
+    Block = 1,
+    Underline = 2,
+    BlockHollow = 3,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateData {
+    Invalid = 0,
+    Cols = 1,
+    Rows = 2,
+    Dirty = 3,
+    RowIterator = 4,
+    ColorBackground = 5,
+    ColorForeground = 6,
+    ColorCursor = 7,
+    ColorCursorHasValue = 8,
+    ColorPalette = 9,
+    CursorVisualStyle = 10,
+    CursorVisible = 11,
+    CursorBlinking = 12,
+    CursorPasswordInput = 13,
+    CursorViewportHasValue = 14,
+    CursorViewportX = 15,
+    CursorViewportY = 16,
+    CursorViewportWideTail = 17,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateOption {
+    Dirty = 0,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateRowData {
+    Invalid = 0,
+    Dirty = 1,
+    Raw = 2,
+    Cells = 3,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateRowOption {
+    Dirty = 0,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GhosttyRenderStateRowCellsData {
+    Invalid = 0,
+    Raw = 1,
+    Style = 2,
+    GraphemesLen = 3,
+    GraphemesBuf = 4,
+    BgColor = 5,
+    FgColor = 6,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GhosttyColorRgb {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub enum GhosttyStyleColorTag {
+    None = 0,
+    Palette = 1,
+    Rgb = 2,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union GhosttyStyleColorValue {
+    pub palette: u8,
+    pub rgb: GhosttyColorRgb,
+    pub _padding: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyStyleColor {
+    pub tag: GhosttyStyleColorTag,
+    pub value: GhosttyStyleColorValue,
+}
+
+/// Sized struct — `size` must be set to `size_of::<Self>()` before use.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyStyle {
+    pub size: usize,
+    pub fg_color: GhosttyStyleColor,
+    pub bg_color: GhosttyStyleColor,
+    pub underline_color: GhosttyStyleColor,
+    pub bold: bool,
+    pub italic: bool,
+    pub faint: bool,
+    pub blink: bool,
+    pub inverse: bool,
+    pub invisible: bool,
+    pub strikethrough: bool,
+    pub overline: bool,
+    pub underline: i32,
+}
+
+impl GhosttyStyle {
+    pub fn init() -> Self {
+        // Safety: zero-init is valid for this repr(C) struct;
+        // we then set the size field for the sized-struct ABI.
+        let mut s: Self = unsafe { std::mem::zeroed() };
+        s.size = std::mem::size_of::<Self>();
+        s
+    }
+}
+
+/// Sized struct for bulk color retrieval.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyRenderStateColors {
+    pub size: usize,
+    pub background: GhosttyColorRgb,
+    pub foreground: GhosttyColorRgb,
+    pub cursor: GhosttyColorRgb,
+    pub cursor_has_value: bool,
+    pub palette: [GhosttyColorRgb; 256],
+}
+
+impl GhosttyRenderStateColors {
+    pub fn init() -> Self {
+        let mut s: Self = unsafe { std::mem::zeroed() };
+        s.size = std::mem::size_of::<Self>();
+        s
+    }
+}
+
+pub enum GhosttyRenderStateOpaque {}
+pub enum GhosttyRowIteratorOpaque {}
+pub enum GhosttyRowCellsOpaque {}
+
+pub type GhosttyRenderState = *mut GhosttyRenderStateOpaque;
+pub type GhosttyRenderStateRowIterator = *mut GhosttyRowIteratorOpaque;
+pub type GhosttyRenderStateRowCells = *mut GhosttyRowCellsOpaque;
+```
+
+- [ ] **Step 2: Add `extern "C"` function declarations**
+
+Add these inside the existing `#[link(name = "ghostty-vt")] unsafe extern "C"` block, after the formatter declarations:
+
+```rust
+    // --- Render state ---
+    fn ghostty_render_state_new(allocator: *const c_void, state: *mut GhosttyRenderState) -> GhosttyResult;
+    fn ghostty_render_state_free(state: GhosttyRenderState);
+    fn ghostty_render_state_update(state: GhosttyRenderState, terminal: GhosttyTerminal) -> GhosttyResult;
+    fn ghostty_render_state_get(state: GhosttyRenderState, data: GhosttyRenderStateData, out: *mut c_void) -> GhosttyResult;
+    fn ghostty_render_state_set(state: GhosttyRenderState, option: GhosttyRenderStateOption, value: *const c_void) -> GhosttyResult;
+    fn ghostty_render_state_colors_get(state: GhosttyRenderState, out_colors: *mut GhosttyRenderStateColors) -> GhosttyResult;
+
+    // --- Row iterator ---
+    fn ghostty_render_state_row_iterator_new(allocator: *const c_void, out_iterator: *mut GhosttyRenderStateRowIterator) -> GhosttyResult;
+    fn ghostty_render_state_row_iterator_free(iterator: GhosttyRenderStateRowIterator);
+    fn ghostty_render_state_row_iterator_next(iterator: GhosttyRenderStateRowIterator) -> bool;
+    fn ghostty_render_state_row_get(iterator: GhosttyRenderStateRowIterator, data: GhosttyRenderStateRowData, out: *mut c_void) -> GhosttyResult;
+    fn ghostty_render_state_row_set(iterator: GhosttyRenderStateRowIterator, option: GhosttyRenderStateRowOption, value: *const c_void) -> GhosttyResult;
+
+    // --- Row cells ---
+    fn ghostty_render_state_row_cells_new(allocator: *const c_void, out_cells: *mut GhosttyRenderStateRowCells) -> GhosttyResult;
+    fn ghostty_render_state_row_cells_free(cells: GhosttyRenderStateRowCells);
+    fn ghostty_render_state_row_cells_next(cells: GhosttyRenderStateRowCells) -> bool;
+    fn ghostty_render_state_row_cells_select(cells: GhosttyRenderStateRowCells, x: u16) -> GhosttyResult;
+    fn ghostty_render_state_row_cells_get(cells: GhosttyRenderStateRowCells, data: GhosttyRenderStateRowCellsData, out: *mut c_void) -> GhosttyResult;
+```
+
+- [ ] **Step 3: Add RAII wrapper — `RenderStateHandle`**
+
+Add after the existing `TerminalHandle` impl in `ghostty_ffi.rs`:
+
+```rust
+pub struct RenderStateHandle {
+    raw: GhosttyRenderState,
+}
+
+impl RenderStateHandle {
+    pub fn new() -> Result<Self, String> {
+        let mut raw = ptr::null_mut();
+        let result = unsafe { ghostty_render_state_new(ptr::null(), &mut raw) };
+        check_result(result, "ghostty_render_state_new")?;
+        Ok(Self { raw })
+    }
+
+    pub fn update(&mut self, terminal: &TerminalHandle) -> Result<(), String> {
+        let result = unsafe { ghostty_render_state_update(self.raw, terminal.raw()) };
+        check_result(result, "ghostty_render_state_update")
+    }
+
+    pub fn get_cols(&self) -> Result<u16, String> {
+        let mut cols: u16 = 0;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::Cols, &mut cols as *mut u16 as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(Cols)")?;
+        Ok(cols)
+    }
+
+    pub fn get_rows(&self) -> Result<u16, String> {
+        let mut rows: u16 = 0;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::Rows, &mut rows as *mut u16 as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(Rows)")?;
+        Ok(rows)
+    }
+
+    pub fn get_dirty(&self) -> Result<GhosttyRenderStateDirty, String> {
+        let mut dirty = GhosttyRenderStateDirty::False;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::Dirty, &mut dirty as *mut GhosttyRenderStateDirty as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(Dirty)")?;
+        Ok(dirty)
+    }
+
+    pub fn set_dirty(&mut self, dirty: GhosttyRenderStateDirty) -> Result<(), String> {
+        let result = unsafe { ghostty_render_state_set(self.raw, GhosttyRenderStateOption::Dirty, &dirty as *const GhosttyRenderStateDirty as *const c_void) };
+        check_result(result, "ghostty_render_state_set(Dirty)")
+    }
+
+    pub fn get_colors(&self) -> Result<GhosttyRenderStateColors, String> {
+        let mut colors = GhosttyRenderStateColors::init();
+        let result = unsafe { ghostty_render_state_colors_get(self.raw, &mut colors) };
+        check_result(result, "ghostty_render_state_colors_get")?;
+        Ok(colors)
+    }
+
+    pub fn get_cursor_visible(&self) -> Result<bool, String> {
+        let mut visible = false;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorVisible, &mut visible as *mut bool as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(CursorVisible)")?;
+        Ok(visible)
+    }
+
+    pub fn get_cursor_viewport_has_value(&self) -> Result<bool, String> {
+        let mut has_value = false;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorViewportHasValue, &mut has_value as *mut bool as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(CursorViewportHasValue)")?;
+        Ok(has_value)
+    }
+
+    pub fn get_cursor_viewport_x(&self) -> Result<u16, String> {
+        let mut x: u16 = 0;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorViewportX, &mut x as *mut u16 as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(CursorViewportX)")?;
+        Ok(x)
+    }
+
+    pub fn get_cursor_viewport_y(&self) -> Result<u16, String> {
+        let mut y: u16 = 0;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorViewportY, &mut y as *mut u16 as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(CursorViewportY)")?;
+        Ok(y)
+    }
+
+    pub fn get_cursor_visual_style(&self) -> Result<GhosttyRenderStateCursorVisualStyle, String> {
+        let mut style = GhosttyRenderStateCursorVisualStyle::Block;
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::CursorVisualStyle, &mut style as *mut GhosttyRenderStateCursorVisualStyle as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(CursorVisualStyle)")?;
+        Ok(style)
+    }
+
+    pub fn populate_row_iterator(&self, iterator: &mut RowIteratorHandle) -> Result<(), String> {
+        let result = unsafe { ghostty_render_state_get(self.raw, GhosttyRenderStateData::RowIterator, &mut iterator.raw as *mut GhosttyRenderStateRowIterator as *mut c_void) };
+        check_result(result, "ghostty_render_state_get(RowIterator)")
+    }
+}
+
+impl Drop for RenderStateHandle {
+    fn drop(&mut self) {
+        unsafe { ghostty_render_state_free(self.raw) };
+    }
+}
+```
+
+- [ ] **Step 4: Add RAII wrapper — `RowIteratorHandle`**
+
+```rust
+pub struct RowIteratorHandle {
+    raw: GhosttyRenderStateRowIterator,
+}
+
+impl RowIteratorHandle {
+    pub fn new() -> Result<Self, String> {
+        let mut raw = ptr::null_mut();
+        let result = unsafe { ghostty_render_state_row_iterator_new(ptr::null(), &mut raw) };
+        check_result(result, "ghostty_render_state_row_iterator_new")?;
+        Ok(Self { raw })
+    }
+
+    pub fn next(&mut self) -> bool {
+        unsafe { ghostty_render_state_row_iterator_next(self.raw) }
+    }
+
+    pub fn get_dirty(&self) -> Result<bool, String> {
+        let mut dirty = false;
+        let result = unsafe { ghostty_render_state_row_get(self.raw, GhosttyRenderStateRowData::Dirty, &mut dirty as *mut bool as *mut c_void) };
+        check_result(result, "ghostty_render_state_row_get(Dirty)")?;
+        Ok(dirty)
+    }
+
+    pub fn populate_cells(&self, cells: &mut RowCellsHandle) -> Result<(), String> {
+        let result = unsafe { ghostty_render_state_row_get(self.raw, GhosttyRenderStateRowData::Cells, &mut cells.raw as *mut GhosttyRenderStateRowCells as *mut c_void) };
+        check_result(result, "ghostty_render_state_row_get(Cells)")
+    }
+
+    pub fn set_dirty(&mut self, dirty: bool) -> Result<(), String> {
+        let result = unsafe { ghostty_render_state_row_set(self.raw, GhosttyRenderStateRowOption::Dirty, &dirty as *const bool as *const c_void) };
+        check_result(result, "ghostty_render_state_row_set(Dirty)")
+    }
+}
+
+impl Drop for RowIteratorHandle {
+    fn drop(&mut self) {
+        unsafe { ghostty_render_state_row_iterator_free(self.raw) };
+    }
+}
+```
+
+- [ ] **Step 5: Add RAII wrapper — `RowCellsHandle`**
+
+```rust
+pub struct RowCellsHandle {
+    raw: GhosttyRenderStateRowCells,
+}
+
+impl RowCellsHandle {
+    pub fn new() -> Result<Self, String> {
+        let mut raw = ptr::null_mut();
+        let result = unsafe { ghostty_render_state_row_cells_new(ptr::null(), &mut raw) };
+        check_result(result, "ghostty_render_state_row_cells_new")?;
+        Ok(Self { raw })
+    }
+
+    pub fn next(&mut self) -> bool {
+        unsafe { ghostty_render_state_row_cells_next(self.raw) }
+    }
+
+    pub fn get_graphemes_len(&self) -> Result<u32, String> {
+        let mut len: u32 = 0;
+        let result = unsafe { ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::GraphemesLen, &mut len as *mut u32 as *mut c_void) };
+        check_result(result, "ghostty_render_state_row_cells_get(GraphemesLen)")?;
+        Ok(len)
+    }
+
+    pub fn get_graphemes_buf(&self, buf: &mut [u32]) -> Result<(), String> {
+        let result = unsafe { ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::GraphemesBuf, buf.as_mut_ptr() as *mut c_void) };
+        check_result(result, "ghostty_render_state_row_cells_get(GraphemesBuf)")
+    }
+
+    pub fn get_style(&self) -> Result<GhosttyStyle, String> {
+        let mut style = GhosttyStyle::init();
+        let result = unsafe { ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::Style, &mut style as *mut GhosttyStyle as *mut c_void) };
+        check_result(result, "ghostty_render_state_row_cells_get(Style)")?;
+        Ok(style)
+    }
+
+    pub fn get_bg_color(&self) -> Result<Option<GhosttyColorRgb>, String> {
+        let mut color = GhosttyColorRgb::default();
+        let result = unsafe { ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::BgColor, &mut color as *mut GhosttyColorRgb as *mut c_void) };
+        match result {
+            GhosttyResult::Success => Ok(Some(color)),
+            GhosttyResult::InvalidValue => Ok(None),
+            other => check_result(other, "ghostty_render_state_row_cells_get(BgColor)").map(|_| None),
+        }
+    }
+
+    pub fn get_fg_color(&self) -> Result<Option<GhosttyColorRgb>, String> {
+        let mut color = GhosttyColorRgb::default();
+        let result = unsafe { ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::FgColor, &mut color as *mut GhosttyColorRgb as *mut c_void) };
+        match result {
+            GhosttyResult::Success => Ok(Some(color)),
+            GhosttyResult::InvalidValue => Ok(None),
+            other => check_result(other, "ghostty_render_state_row_cells_get(FgColor)").map(|_| None),
+        }
+    }
+}
+
+impl Drop for RowCellsHandle {
+    fn drop(&mut self) {
+        unsafe { ghostty_render_state_row_cells_free(self.raw) };
+    }
+}
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cargo build --workspace --locked --features ghostty-vt`
+Expected: BUILD SUCCESS (no tests yet — just verifying FFI declarations link)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cleat/src/vt/ghostty_ffi.rs
+git commit -m "ffi: add render state API declarations and RAII wrappers"
+```
+
+---
+
+### Task 3: Implement `GhosttyVtEngine::screen_grid()`
+
+Wire the FFI wrappers into the engine to populate `ScreenGrid` from the render state.
+
+**Files:**
+- Modify: `crates/cleat/src/vt/ghostty.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/cleat/tests/vt.rs`:
+
+```rust
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_returns_correct_dimensions() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    engine.feed(b"hello grid").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    assert_eq!(grid.cols, 40);
+    assert_eq!(grid.rows, 5);
+    assert_eq!(grid.cells.len(), 40 * 5);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --locked --features ghostty-vt -p cleat --test vt vt_ghostty_screen_grid_returns_correct_dimensions`
+Expected: FAIL — `screen_grid` not implemented yet.
+
+- [ ] **Step 3: Implement `screen_grid()` on `GhosttyVtEngine`**
+
+In `crates/cleat/src/vt/ghostty.rs`, update the imports and add render state field + implementation:
+
+```rust
+use super::{
+    ghostty_ffi::{
+        self, GhosttyFormatterFormat, GhosttyFormatterTerminalOptions, GhosttyRenderStateCursorVisualStyle,
+        GhosttyRenderStateDirty, GhosttyStyle, GhosttyStyleColorTag, RenderStateHandle, RowCellsHandle,
+        RowIteratorHandle, TerminalHandle,
+    },
+    CellFlags, ClientCapabilities, ColorLevel, CursorState, CursorStyle, ResolvedCell, Rgb, ScreenGrid, VtEngine,
+};
+
+const DEFAULT_MAX_SCROLLBACK: usize = 10_000;
+
+pub struct GhosttyVtEngine {
+    terminal: TerminalHandle,
+    render_state: RenderStateHandle,
+    cols: u16,
+    rows: u16,
+    saw_output: bool,
+}
+
+impl GhosttyVtEngine {
+    pub fn new(cols: u16, rows: u16) -> Self {
+        let terminal = TerminalHandle::new(cols, rows, DEFAULT_MAX_SCROLLBACK).expect("create ghostty terminal");
+        let render_state = RenderStateHandle::new().expect("create ghostty render state");
+        Self { terminal, render_state, cols, rows, saw_output: false }
+    }
+}
+```
+
+Then add `screen_grid()` to the `VtEngine` impl:
+
+```rust
+    fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
+        self.render_state.update(&self.terminal)?;
+        let cols = self.render_state.get_cols()?;
+        let rows = self.render_state.get_rows()?;
+        let colors = self.render_state.get_colors()?;
+
+        let default_fg = Rgb { r: colors.foreground.r, g: colors.foreground.g, b: colors.foreground.b };
+        let default_bg = Rgb { r: colors.background.r, g: colors.background.g, b: colors.background.b };
+
+        let mut cells = Vec::with_capacity((cols as usize) * (rows as usize));
+
+        let mut row_iter = RowIteratorHandle::new()?;
+        self.render_state.populate_row_iterator(&mut row_iter)?;
+
+        let mut row_cells = RowCellsHandle::new()?;
+        while row_iter.next() {
+            row_iter.populate_cells(&mut row_cells)?;
+            while row_cells.next() {
+                let graphemes_len = row_cells.get_graphemes_len()?;
+                let graphemes = if graphemes_len > 0 {
+                    let mut buf = vec![0u32; graphemes_len as usize];
+                    row_cells.get_graphemes_buf(&mut buf)?;
+                    buf
+                } else {
+                    Vec::new()
+                };
+
+                let fg = match row_cells.get_fg_color()? {
+                    Some(c) => Rgb { r: c.r, g: c.g, b: c.b },
+                    None => default_fg,
+                };
+                let bg = match row_cells.get_bg_color()? {
+                    Some(c) => Rgb { r: c.r, g: c.g, b: c.b },
+                    None => default_bg,
+                };
+
+                let style = row_cells.get_style()?;
+                let flags = flags_from_ghostty_style(&style);
+
+                cells.push(ResolvedCell { graphemes, fg, bg, flags });
+            }
+        }
+
+        let cursor = self.read_cursor_state()?;
+
+        // Clear dirty state — cleat is the renderer.
+        self.render_state.set_dirty(GhosttyRenderStateDirty::False)?;
+
+        Ok(ScreenGrid { cells, cols, rows, cursor })
+    }
+```
+
+Add the helper methods (outside the trait impl, as inherent methods):
+
+```rust
+impl GhosttyVtEngine {
+    // ... existing new() ...
+
+    fn read_cursor_state(&self) -> Result<CursorState, String> {
+        let visible = self.render_state.get_cursor_visible()?;
+        let in_viewport = self.render_state.get_cursor_viewport_has_value()?;
+
+        if !visible || !in_viewport {
+            return Ok(CursorState { visible, ..CursorState::default() });
+        }
+
+        let col = self.render_state.get_cursor_viewport_x()?;
+        let row = self.render_state.get_cursor_viewport_y()?;
+        let style = match self.render_state.get_cursor_visual_style()? {
+            GhosttyRenderStateCursorVisualStyle::Bar => CursorStyle::Bar,
+            GhosttyRenderStateCursorVisualStyle::Block => CursorStyle::Block,
+            GhosttyRenderStateCursorVisualStyle::Underline => CursorStyle::Underline,
+            GhosttyRenderStateCursorVisualStyle::BlockHollow => CursorStyle::BlockHollow,
+        };
+
+        Ok(CursorState { col, row, visible, style })
+    }
+}
+
+fn flags_from_ghostty_style(style: &GhosttyStyle) -> CellFlags {
+    let mut flags = CellFlags::empty();
+    if style.bold { flags |= CellFlags::BOLD; }
+    if style.italic { flags |= CellFlags::ITALIC; }
+    if style.faint { flags |= CellFlags::FAINT; }
+    if style.blink { flags |= CellFlags::BLINK; }
+    if style.inverse { flags |= CellFlags::INVERSE; }
+    if style.invisible { flags |= CellFlags::INVISIBLE; }
+    if style.strikethrough { flags |= CellFlags::STRIKETHROUGH; }
+    if style.overline { flags |= CellFlags::OVERLINE; }
+    if style.underline != 0 { flags |= CellFlags::UNDERLINE; }
+    flags
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --locked --features ghostty-vt -p cleat --test vt vt_ghostty_screen_grid_returns_correct_dimensions`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cleat/src/vt/ghostty.rs crates/cleat/tests/vt.rs
+git commit -m "vt: implement screen_grid() on GhosttyVtEngine via render state FFI"
+```
+
+---
+
+### Task 4: Add integration tests for cell content, styles, and cursor
+
+Verify the full round-trip: feed VT sequences, read back resolved cells.
+
+**Files:**
+- Modify: `crates/cleat/tests/vt.rs`
+
+- [ ] **Step 1: Write test for cell text content**
+
+```rust
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_captures_cell_text() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    engine.feed(b"Hello").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    let text: String = (0..5)
+        .map(|col| {
+            let cell = grid.cell(col, 0).unwrap();
+            if cell.graphemes.is_empty() {
+                ' '
+            } else {
+                char::from_u32(cell.graphemes[0]).unwrap_or('?')
+            }
+        })
+        .collect();
+    assert_eq!(text, "Hello");
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cargo test --locked --features ghostty-vt -p cleat --test vt vt_ghostty_screen_grid_captures_cell_text`
+Expected: PASS
+
+- [ ] **Step 3: Write test for bold style flag**
+
+```rust
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_captures_bold_style() {
+    use cleat::vt::CellFlags;
+
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    engine.feed(b"\x1b[1mbold\x1b[0m plain").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    // 'b' at col 0 should be bold
+    assert!(grid.cell(0, 0).unwrap().flags.contains(CellFlags::BOLD));
+    // 'p' at col 5 (after "bold ") should not be bold
+    assert!(!grid.cell(5, 0).unwrap().flags.contains(CellFlags::BOLD));
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cargo test --locked --features ghostty-vt -p cleat --test vt vt_ghostty_screen_grid_captures_bold_style`
+Expected: PASS
+
+- [ ] **Step 5: Write test for cursor position**
+
+```rust
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_captures_cursor_position() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    engine.feed(b"Hello").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    assert!(grid.cursor.visible);
+    assert_eq!(grid.cursor.col, 5);
+    assert_eq!(grid.cursor.row, 0);
+}
+```
+
+- [ ] **Step 6: Run test**
+
+Run: `cargo test --locked --features ghostty-vt -p cleat --test vt vt_ghostty_screen_grid_captures_cursor_position`
+Expected: PASS
+
+- [ ] **Step 7: Write test for `row_text()` helper**
+
+```rust
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_row_text_returns_row_content() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(10, 3);
+
+    engine.feed(b"line one\r\nline two").expect("feed bytes");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    assert_eq!(grid.row_text(0).trim_end(), "line one");
+    assert_eq!(grid.row_text(1).trim_end(), "line two");
+    assert_eq!(grid.row_text(2).trim_end(), "");
+}
+```
+
+- [ ] **Step 8: Run test**
+
+Run: `cargo test --locked --features ghostty-vt -p cleat --test vt vt_ghostty_screen_grid_row_text`
+Expected: PASS
+
+- [ ] **Step 9: Write test for passthrough engine error**
+
+```rust
+#[test]
+fn vt_passthrough_screen_grid_returns_error() {
+    let mut engine = cleat::vt::passthrough::PassthroughVtEngine::new(80, 24);
+    let err = engine.screen_grid().expect_err("passthrough should fail");
+    assert!(err.contains("placeholder/test-only"));
+}
+```
+
+- [ ] **Step 10: Run test**
+
+Run: `cargo test --locked -p cleat --test vt vt_passthrough_screen_grid_returns_error`
+Expected: PASS
+
+- [ ] **Step 11: Run full test suite**
+
+Run: `cargo test --workspace --locked --features ghostty-vt`
+Expected: ALL PASS
+
+- [ ] **Step 12: Run clippy and fmt**
+
+Run: `cargo +nightly-2026-03-12 fmt --check && cargo clippy --workspace --all-targets --locked --features ghostty-vt -- -D warnings`
+Expected: CLEAN
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add crates/cleat/tests/vt.rs
+git commit -m "test: add screen_grid integration tests for text, styles, cursor, and row_text"
+```
+
+---
+
+### Task 5: Commit spec update and finalize
+
+**Files:**
+- Modified earlier: `docs/specs/2026-03-23-terminal-screen-introspection.md`
+
+- [ ] **Step 1: Run full build + test + lint**
+
+Run: `cargo build --workspace --locked --features ghostty-vt && cargo test --workspace --locked --features ghostty-vt && cargo +nightly-2026-03-12 fmt --check && cargo clippy --workspace --all-targets --locked --features ghostty-vt -- -D warnings`
+Expected: ALL PASS
+
+- [ ] **Step 2: Commit spec update**
+
+```bash
+git add docs/specs/2026-03-23-terminal-screen-introspection.md
+git commit -m "docs: update screen introspection spec for actual Ghostty render state API"
+```


### PR DESCRIPTION
## Summary

- Add `ScreenGrid`, `ResolvedCell`, `CellFlags`, `CursorState` types and `VtEngine::screen_grid()` trait method
- Add `#[repr(C)]` FFI declarations and RAII wrappers (`RenderStateHandle`, `RowIteratorHandle`, `RowCellsHandle`) for all 16 render state C API functions in `libghostty-vt`
- Implement `GhosttyVtEngine::screen_grid()` — iterates render state to populate cleat-native types with resolved graphemes, colors, styles, and cursor state
- Fix macOS rpath so test binaries find `libghostty-vt.dylib`
- Update screen introspection spec to document actual upstream API (was written before it existed)

Closes #22

## Context

Ghostty's upstream C API already exposes a full Render State API (`include/ghostty/vt/render.h`) with iterator-based cell access, dirty tracking, resolved colors, and grapheme clusters. All symbols are present in the `libghostty-vt.dylib` that cleat already links. This PR adds the Rust side.

First consumer will be VT transcoding (#29) for `capture --since-marker`.

## Test plan

- [x] `cargo test --workspace --locked --features ghostty-vt` — 202 tests pass
- [x] `cargo clippy --workspace --all-targets --locked --features ghostty-vt -- -D warnings` — clean
- [x] `cargo +nightly-2026-03-12 fmt --check` — clean
- [x] Integration tests verify text content, bold style, cursor position, row_text(), passthrough error