### PR TITLE
screen_grid: dirty-state fast-path and FFI test coverage

### DIFF
--- a/crates/cleat/src/vt/ghostty.rs
+++ b/crates/cleat/src/vt/ghostty.rs
@@ -117,13 +117,14 @@ impl VtEngine for GhosttyVtEngine {
         let default_fg = Rgb { r: colors.foreground.r, g: colors.foreground.g, b: colors.foreground.b };
         let default_bg = Rgb { r: colors.background.r, g: colors.background.g, b: colors.background.b };
 
-        let partial = dirty == GhosttyRenderStateDirty::Partial;
+        let mut partial = dirty == GhosttyRenderStateDirty::Partial;
         let row_stride = cols as usize;
 
         // Reuse the cached cell vec when doing a partial update.
         let mut cells = if partial { self.cached_grid.take().map(|g| g.cells).unwrap_or_default() } else { Vec::new() };
         if cells.len() != row_stride * (rows as usize) {
-            // Dimensions changed or no cache — full rebuild.
+            // Dimensions changed or no cache — force a full rebuild.
+            partial = false;
             cells.clear();
             cells.reserve(row_stride * (rows as usize));
         }

--- a/crates/cleat/src/vt/ghostty.rs
+++ b/crates/cleat/src/vt/ghostty.rs
@@ -16,6 +16,7 @@ pub struct GhosttyVtEngine {
     cols: u16,
     rows: u16,
     saw_output: bool,
+    cached_grid: Option<ScreenGrid>,
 }
 
 impl GhosttyVtEngine {
@@ -24,7 +25,7 @@ impl GhosttyVtEngine {
         let render_state = RenderStateHandle::new().expect("create ghostty render state");
         let row_iter = RowIteratorHandle::new().expect("create ghostty row iterator");
         let row_cells = RowCellsHandle::new().expect("create ghostty row cells");
-        Self { terminal, render_state, row_iter, row_cells, cols, rows, saw_output: false }
+        Self { terminal, render_state, row_iter, row_cells, cols, rows, saw_output: false, cached_grid: None }
     }
 
     fn read_cursor_state(&self) -> Result<CursorState, String> {
@@ -101,6 +102,14 @@ impl VtEngine for GhosttyVtEngine {
 
     fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
         self.render_state.update(&self.terminal)?;
+
+        let dirty = self.render_state.get_dirty()?;
+        if dirty == GhosttyRenderStateDirty::False {
+            if let Some(ref cached) = self.cached_grid {
+                return Ok(cached.clone());
+            }
+        }
+
         let cols = self.render_state.get_cols()?;
         let rows = self.render_state.get_rows()?;
         let colors = self.render_state.get_colors()?;
@@ -108,12 +117,30 @@ impl VtEngine for GhosttyVtEngine {
         let default_fg = Rgb { r: colors.foreground.r, g: colors.foreground.g, b: colors.foreground.b };
         let default_bg = Rgb { r: colors.background.r, g: colors.background.g, b: colors.background.b };
 
-        let mut cells = Vec::with_capacity((cols as usize) * (rows as usize));
+        let partial = dirty == GhosttyRenderStateDirty::Partial;
+        let row_stride = cols as usize;
+
+        // Reuse the cached cell vec when doing a partial update.
+        let mut cells = if partial { self.cached_grid.take().map(|g| g.cells).unwrap_or_default() } else { Vec::new() };
+        if cells.len() != row_stride * (rows as usize) {
+            // Dimensions changed or no cache — full rebuild.
+            cells.clear();
+            cells.reserve(row_stride * (rows as usize));
+        }
 
         self.render_state.populate_row_iterator(&mut self.row_iter)?;
 
+        let mut row_idx: usize = 0;
         while self.row_iter.next() {
+            let skip = partial && !self.row_iter.get_dirty().unwrap_or(true);
+            if skip {
+                row_idx += 1;
+                continue;
+            }
+
             self.row_iter.populate_cells(&mut self.row_cells)?;
+            let row_start = row_idx * row_stride;
+            let mut col_idx: usize = 0;
             while self.row_cells.next() {
                 let graphemes_len = self.row_cells.get_graphemes_len()?;
                 let graphemes = if graphemes_len > 0 {
@@ -143,16 +170,25 @@ impl VtEngine for GhosttyVtEngine {
                     GhosttyCellWide::SpacerHead => CellWidth::SpacerHead,
                 };
 
-                cells.push(ResolvedCell { graphemes, fg, bg, flags, width });
+                let cell = ResolvedCell { graphemes, fg, bg, flags, width };
+                let idx = row_start + col_idx;
+                if idx < cells.len() {
+                    cells[idx] = cell;
+                } else {
+                    cells.push(cell);
+                }
+                col_idx += 1;
             }
+            row_idx += 1;
         }
 
         let cursor = self.read_cursor_state()?;
 
-        // Clear dirty state — cleat is the renderer.
         self.render_state.set_dirty(GhosttyRenderStateDirty::False)?;
 
-        Ok(ScreenGrid { cells, cols, rows, cursor })
+        let grid = ScreenGrid { cells, cols, rows, cursor };
+        self.cached_grid = Some(grid.clone());
+        Ok(grid)
     }
 
     fn size(&self) -> (u16, u16) {

--- a/crates/cleat/src/vt/ghostty_ffi.rs
+++ b/crates/cleat/src/vt/ghostty_ffi.rs
@@ -475,7 +475,6 @@ impl RenderStateHandle {
         Ok(rows)
     }
 
-    #[allow(dead_code)]
     pub fn get_dirty(&self) -> Result<GhosttyRenderStateDirty, String> {
         let mut dirty = GhosttyRenderStateDirty::False;
         let result = unsafe {
@@ -588,7 +587,6 @@ impl RowIteratorHandle {
         unsafe { ghostty_render_state_row_iterator_next(self.raw) }
     }
 
-    #[allow(dead_code)]
     pub fn get_dirty(&self) -> Result<bool, String> {
         let mut dirty = false;
         let result =

--- a/crates/cleat/tests/vt.rs
+++ b/crates/cleat/tests/vt.rs
@@ -206,6 +206,87 @@ fn vt_ghostty_screen_grid_wide_chars_not_doubled_in_row_text() {
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
+fn vt_ghostty_screen_grid_returns_cached_when_clean() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(20, 3);
+
+    engine.feed(b"hello").expect("feed bytes");
+
+    let grid1 = engine.screen_grid().expect("first screen_grid");
+    assert_eq!(grid1.row_text(0).trim_end(), "hello");
+
+    // Second call with no new input should return cached result
+    let grid2 = engine.screen_grid().expect("second screen_grid (cached)");
+    assert_eq!(grid1, grid2);
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_updates_after_new_input() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(20, 3);
+
+    engine.feed(b"aaa").expect("feed bytes");
+    let grid1 = engine.screen_grid().expect("first screen_grid");
+    assert_eq!(grid1.row_text(0).trim_end(), "aaa");
+
+    engine.feed(b"bbb").expect("feed more bytes");
+    let grid2 = engine.screen_grid().expect("second screen_grid after new input");
+    assert_eq!(grid2.row_text(0).trim_end(), "aaabbb");
+    assert_ne!(grid1, grid2);
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_resolves_explicit_fg_and_bg_colors() {
+    use cleat::vt::Rgb;
+
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    // True-color SGR: red fg on green bg for "R", then blue fg for "B", then reset
+    engine.feed(b"\x1b[38;2;255;0;0m\x1b[48;2;0;255;0mR\x1b[38;2;0;0;255mB\x1b[0m").expect("feed SGR color sequence");
+
+    let grid = engine.screen_grid().expect("screen grid");
+
+    let r_cell = grid.cell(0, 0).unwrap();
+    assert_eq!(r_cell.fg, Rgb { r: 255, g: 0, b: 0 }, "R cell foreground should be red");
+    assert_eq!(r_cell.bg, Rgb { r: 0, g: 255, b: 0 }, "R cell background should be green");
+
+    let b_cell = grid.cell(1, 0).unwrap();
+    assert_eq!(b_cell.fg, Rgb { r: 0, g: 0, b: 255 }, "B cell foreground should be blue");
+    assert_eq!(b_cell.bg, Rgb { r: 0, g: 255, b: 0 }, "B cell background should still be green");
+
+    // A cell after reset should have default colors (not the explicit ones)
+    let default_cell = grid.cell(2, 0).unwrap();
+    assert_ne!(default_cell.fg, Rgb { r: 255, g: 0, b: 0 }, "post-reset cell should not have red fg");
+    assert_ne!(default_cell.bg, Rgb { r: 0, g: 255, b: 0 }, "post-reset cell should not have green bg");
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_screen_grid_multi_codepoint_grapheme() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+
+    // e + combining acute accent (U+0065 U+0301) → single grapheme cluster "é"
+    engine.feed("e\u{0301}AB".as_bytes()).expect("feed combining character sequence");
+
+    let grid = engine.screen_grid().expect("screen grid");
+
+    // The combined grapheme should occupy col 0 with two codepoints
+    let combined_cell = grid.cell(0, 0).unwrap();
+    assert!(combined_cell.graphemes.len() > 1, "combined é should have multiple codepoints, got {:?}", combined_cell.graphemes);
+    assert_eq!(combined_cell.graphemes[0], 'e' as u32);
+    assert_eq!(combined_cell.graphemes[1], 0x0301, "second codepoint should be combining acute accent");
+
+    // 'A' should follow at col 1
+    let a_cell = grid.cell(1, 0).unwrap();
+    assert_eq!(a_cell.graphemes, vec!['A' as u32]);
+
+    // row_text should reconstruct the full grapheme cluster
+    let text = grid.row_text(0);
+    assert!(text.starts_with("e\u{0301}AB"), "row_text should contain the full grapheme cluster, got: {text:?}");
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
 fn vt_ghostty_links_against_shared_library() {
     let prefix = PathBuf::from(env!("CLEAT_GHOSTTY_PREFIX"));
     let lib_name = shared_library_filename();

--- a/crates/cleat/tests/vt.rs
+++ b/crates/cleat/tests/vt.rs
@@ -254,10 +254,11 @@ fn vt_ghostty_screen_grid_resolves_explicit_fg_and_bg_colors() {
     assert_eq!(b_cell.fg, Rgb { r: 0, g: 0, b: 255 }, "B cell foreground should be blue");
     assert_eq!(b_cell.bg, Rgb { r: 0, g: 255, b: 0 }, "B cell background should still be green");
 
-    // A cell after reset should have default colors (not the explicit ones)
+    // A cell after reset should have default colors, matching an untouched cell
     let default_cell = grid.cell(2, 0).unwrap();
-    assert_ne!(default_cell.fg, Rgb { r: 255, g: 0, b: 0 }, "post-reset cell should not have red fg");
-    assert_ne!(default_cell.bg, Rgb { r: 0, g: 255, b: 0 }, "post-reset cell should not have green bg");
+    let untouched_cell = grid.cell(39, 4).unwrap();
+    assert_eq!(default_cell.fg, untouched_cell.fg, "post-reset fg should match untouched cell default");
+    assert_eq!(default_cell.bg, untouched_cell.bg, "post-reset bg should match untouched cell default");
 }
 
 #[cfg(feature = "ghostty-vt")]


### PR DESCRIPTION
## Summary

- **Dirty-state fast-path (#43):** `screen_grid()` now checks the render state dirty flag after `update()`. Returns cached grid immediately when clean (`False`). On partial dirty, reuses the cached cell vec and skips clean rows via per-row dirty flags. Falls back to full rebuild on `Full` dirty or dimension changes.
- **Color and grapheme tests (#44):** Two new integration tests verify the FFI binding paths that were untested: true-color SGR foreground/background resolution on `ResolvedCell`, and multi-codepoint grapheme clusters (combining characters) through the grapheme buffer fetch path.

Closes #43, closes #44

## Test plan

- [x] `cargo test --workspace --locked` — 187 tests pass (default build)
- [x] `cargo test --workspace --locked --features ghostty-vt` — 218 tests pass
- [x] `cargo clippy --workspace --all-targets --locked --features ghostty-vt -- -D warnings` — clean
- [x] `cargo +nightly-2026-03-12 fmt --check` — clean
- [x] New: `vt_ghostty_screen_grid_resolves_explicit_fg_and_bg_colors`
- [x] New: `vt_ghostty_screen_grid_multi_codepoint_grapheme`
- [x] New: `vt_ghostty_screen_grid_returns_cached_when_clean`
- [x] New: `vt_ghostty_screen_grid_updates_after_new_input`