### PR TITLE
transcript: end-bound flags (--until, --until-marker, --until-next-marker, --until-idle)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -84,9 +84,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -129,6 +129,7 @@ dependencies = [
  "bitflags",
  "clap",
  "comfy-table",
+ "humantime",
  "libc",
  "nix",
  "serde",
@@ -239,15 +240,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "id-arena"
@@ -257,12 +264,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -281,9 +288,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -297,9 +304,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -608,9 +615,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -619,11 +626,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -632,14 +639,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -650,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -660,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -673,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -863,6 +870,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/crates/cleat/Cargo.toml
+++ b/crates/cleat/Cargo.toml
@@ -13,6 +13,7 @@ ghostty-vt = []
 bitflags = "2"
 clap = { version = "4", features = ["derive", "env"] }
 comfy-table = "7"
+humantime = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 libc = "0.2"

--- a/crates/cleat/src/cast_reader.rs
+++ b/crates/cleat/src/cast_reader.rs
@@ -121,16 +121,11 @@ fn read_events_between(path: &Path, start: u64, end: u64, filter: Option<EventCo
         if n == 0 {
             break;
         }
-        let line_start = byte_pos;
         byte_pos += n as u64;
 
         if first_line {
             first_line = false;
             continue;
-        }
-
-        if line_start >= end {
-            break;
         }
 
         let trimmed = line.trim_end_matches('\n');

--- a/crates/cleat/src/cast_reader.rs
+++ b/crates/cleat/src/cast_reader.rs
@@ -87,6 +87,132 @@ pub fn find_nearest_snapshot(path: &Path, offset: u64) -> Result<Option<(u64, St
     Ok(last_snapshot)
 }
 
+/// Read all output (`"o"`) events whose starting byte offset is in `[start, end)`.
+///
+/// When `start` is 0, the header line is skipped automatically.
+/// Returns an empty vec if `start >= end` or `start` is at/beyond EOF.
+pub fn read_output_between(path: &Path, start: u64, end: u64) -> Result<Vec<Event>, String> {
+    if start >= end {
+        return Ok(Vec::new());
+    }
+    read_events_between(path, start, end, Some(EventCode::Output))
+}
+
+fn read_events_between(path: &Path, start: u64, end: u64, filter: Option<EventCode>) -> Result<Vec<Event>, String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("open {path:?}: {e}"))?;
+    let mut reader = BufReader::new(file);
+
+    if start > 0 {
+        reader.seek(SeekFrom::Start(start)).map_err(|e| format!("seek: {e}"))?;
+    }
+
+    let mut events = Vec::new();
+    let mut line = String::new();
+    let mut byte_pos = start;
+    let mut prev_time = Duration::ZERO;
+    let mut first_line = start == 0;
+
+    loop {
+        if byte_pos >= end {
+            break;
+        }
+        line.clear();
+        let n = reader.read_line(&mut line).map_err(|e| format!("read line: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        let line_start = byte_pos;
+        byte_pos += n as u64;
+
+        if first_line {
+            first_line = false;
+            continue;
+        }
+
+        if line_start >= end {
+            break;
+        }
+
+        let trimmed = line.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            continue;
+        }
+        match decode_event(trimmed, &mut prev_time) {
+            Ok(event) => {
+                let matches_filter = filter.as_ref().is_none_or(|code| &event.code == code);
+                if matches_filter {
+                    events.push(event);
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
+    Ok(events)
+}
+
+/// Scan output events starting at `start` and return the byte offset of the
+/// first byte *after* the last output event before the first inter-event gap
+/// whose duration is ≥ `threshold`.
+///
+/// Returns `Ok(None)` if no such gap is found before EOF.
+///
+/// Only output (`"o"`) events participate in gap detection. Non-output events
+/// (markers, snapshots, etc.) are skipped.
+pub fn find_idle_gap_after(path: &Path, start: u64, threshold: Duration) -> Result<Option<u64>, String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("open {path:?}: {e}"))?;
+    let mut reader = BufReader::new(file);
+
+    if start > 0 {
+        reader.seek(SeekFrom::Start(start)).map_err(|e| format!("seek: {e}"))?;
+    }
+
+    let mut line = String::new();
+    let mut byte_pos = start;
+    let mut prev_time = Duration::ZERO;
+    let mut first_line = start == 0;
+    let mut last_output_end: Option<u64> = None;
+    let mut last_output_time: Option<Duration> = None;
+
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).map_err(|e| format!("read line: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        byte_pos += n as u64;
+
+        if first_line {
+            first_line = false;
+            continue;
+        }
+
+        let trimmed = line.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match decode_event(trimmed, &mut prev_time) {
+            Ok(event) => {
+                if event.code != EventCode::Output {
+                    continue;
+                }
+                if let Some(prev_t) = last_output_time {
+                    let gap = event.time.saturating_sub(prev_t);
+                    if gap >= threshold {
+                        return Ok(last_output_end);
+                    }
+                }
+                last_output_time = Some(event.time);
+                last_output_end = Some(byte_pos);
+            }
+            Err(_) => continue,
+        }
+    }
+
+    Ok(None)
+}
+
 /// Internal helper: read events from `path` starting at `offset`.
 ///
 /// If `filter` is `Some(code)`, only events matching that code are returned.
@@ -141,4 +267,83 @@ fn read_events_since(path: &Path, offset: u64, filter: Option<EventCode>) -> Res
     }
 
     Ok(events)
+}
+
+#[cfg(test)]
+mod tests_between_and_idle {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    fn write_cast(lines: &[&str]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        for line in lines {
+            writeln!(f, "{line}").expect("write line");
+        }
+        f.flush().expect("flush");
+        f
+    }
+
+    // Minimal asciicast v3 header + three output events.
+    // EVT_A at delta 0.0s (cumulative 0.0s)
+    // EVT_B at delta 0.1s (cumulative 0.1s)
+    // EVT_C at delta 0.3s (cumulative 0.4s)
+    // Gaps: A->B = 0.1s, B->C = 0.3s.
+    const HEADER: &str = r#"{"version":3,"term":{"cols":80,"rows":24}}"#;
+    const EVT_A: &str = r#"[0.0,"o","a"]"#;
+    const EVT_B: &str = r#"[0.1,"o","b"]"#;
+    const EVT_C: &str = r#"[0.3,"o","c"]"#;
+
+    #[test]
+    fn read_between_returns_events_in_range() {
+        let f = write_cast(&[HEADER, EVT_A, EVT_B, EVT_C]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let a_len = (EVT_A.len() + 1) as u64;
+        let b_len = (EVT_B.len() + 1) as u64;
+
+        // Range covers A and B only (ends just before C).
+        let events = read_output_between(f.path(), header_len, header_len + a_len + b_len).expect("read range");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].data, "a");
+        assert_eq!(events[1].data, "b");
+    }
+
+    #[test]
+    fn read_between_empty_when_start_equals_end() {
+        let f = write_cast(&[HEADER, EVT_A]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let events = read_output_between(f.path(), header_len, header_len).expect("read");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn find_idle_gap_detects_gap_above_threshold() {
+        let f = write_cast(&[HEADER, EVT_A, EVT_B, EVT_C]);
+        // B->C gap is 0.3s which exceeds threshold 0.2s.
+        // Result should be byte offset after B.
+        let header_len = (HEADER.len() + 1) as u64;
+        let a_len = (EVT_A.len() + 1) as u64;
+        let b_len = (EVT_B.len() + 1) as u64;
+        let end = find_idle_gap_after(f.path(), header_len, Duration::from_millis(200)).expect("find gap");
+        assert_eq!(end, Some(header_len + a_len + b_len));
+    }
+
+    #[test]
+    fn find_idle_gap_returns_none_when_no_gap_big_enough() {
+        let f = write_cast(&[HEADER, EVT_A, EVT_B, EVT_C]);
+        let header_len = (HEADER.len() + 1) as u64;
+        // Threshold 1s; no gap in fixture is that large.
+        let end = find_idle_gap_after(f.path(), header_len, Duration::from_secs(1)).expect("find gap");
+        assert_eq!(end, None);
+    }
+
+    #[test]
+    fn find_idle_gap_returns_none_on_empty_range() {
+        let f = write_cast(&[HEADER]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let end = find_idle_gap_after(f.path(), header_len, Duration::from_millis(100)).expect("find gap");
+        assert_eq!(end, None);
+    }
 }

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -225,8 +225,9 @@ pub enum Command {
                            JSON output (--json): {\"status\": \"ready|timeout|session_gone\", \"elapsed_ms\": N}")]
     Wait {
         id: String,
-        #[arg(long, help = "Wait until output settles for this many seconds")]
-        idle_time: Option<f64>,
+        /// Wait until output settles for this duration (e.g., 500ms, 2s, or plain seconds).
+        #[arg(long, value_parser = crate::duration_parser::parse_humantime_or_seconds)]
+        idle_time: Option<std::time::Duration>,
         #[arg(long, help = "Wait until this text appears on screen")]
         text: Option<String>,
         #[arg(long, default_value_t = 30.0, help = "Maximum seconds to wait (default: 30)")]
@@ -530,7 +531,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
 fn execute_wait(
     service: &SessionService,
     id: String,
-    idle_time: Option<f64>,
+    idle_time: Option<std::time::Duration>,
     text: Option<String>,
     timeout: f64,
     json: bool,
@@ -548,8 +549,9 @@ fn execute_wait(
     }
 
     let mut conditions = Vec::new();
-    if let Some(secs) = idle_time {
-        if !secs.is_finite() || !(0.0..=86_400.0).contains(&secs) {
+    if let Some(dur) = idle_time {
+        let secs = dur.as_secs_f64();
+        if !(0.0..=86_400.0).contains(&secs) {
             return ExecResult::Exit { code: 2, message: Some(format!("invalid idle-time: {secs} (max 86400)")), output: None };
         }
         conditions.push(WaitCondition::OutputIdle { quiet_ms: (secs * 1000.0) as u64 });

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -6,7 +6,7 @@ use crate::{
     keys::encode_send_keys,
     protocol::{WaitCondition, WaitStatus},
     runtime::SessionMetadata,
-    server::{EndBound, SessionService, StartBound},
+    server::{EndBound, FallbackReason, SessionService, StartBound},
     vt::VtEngineKind,
 };
 
@@ -99,7 +99,12 @@ pub enum Command {
                            to read output produced after that point.\n\
                            \n\
                            --raw is accepted but currently produces the same output as non-raw.\n\
-                           VT-rendered replay for the non-raw path is planned.")]
+                           VT-rendered replay for the non-raw path is planned.\n\
+                           \n\
+                           When the chosen end bound cannot be reached (e.g. --until-idle with\n\
+                           no matching gap, --until-next-marker with no later marker), the slice\n\
+                           falls back to end-of-recording and a line of the form\n\
+                           `# bounded by EOF (<reason>)` is written to stderr.")]
     Transcript {
         id: String,
         /// Byte offset in .cast file; return output events after this position
@@ -412,10 +417,12 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             let result = if raw { service.capture_slice_raw(&id, start, end) } else { service.capture_slice_text(&id, start, end) };
             match result {
                 Ok((s, outcome)) => {
-                    if !outcome.hit_intended_end {
-                        if let Some(reason) = &outcome.fallback_reason {
-                            eprintln!("# bounded by EOF ({reason})");
-                        }
+                    if let Some(reason) = &outcome.end_status {
+                        let reason_str = match reason {
+                            FallbackReason::NoMarkerAfterStart => "no marker after start".to_string(),
+                            FallbackReason::NoIdleGap(d) => format!("no {} idle found", humantime::format_duration(*d)),
+                        };
+                        eprintln!("# bounded by EOF ({reason_str})");
                     }
                     ExecResult::Ok(Some(s))
                 }

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -6,7 +6,7 @@ use crate::{
     keys::encode_send_keys,
     protocol::{WaitCondition, WaitStatus},
     runtime::SessionMetadata,
-    server::SessionService,
+    server::{EndBound, SessionService, StartBound},
     vt::VtEngineKind,
 };
 
@@ -378,23 +378,22 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Err(e) => ExecResult::Err(e),
         },
         Command::Transcript { id, since, since_marker, raw } => {
-            let offset = match (since, &since_marker) {
-                (Some(o), _) => Some(o),
-                (_, Some(name)) => match service.resolve_marker(&id, name) {
-                    Ok(o) => Some(o),
-                    Err(e) => return ExecResult::Err(e),
-                },
-                _ => None,
-            };
-            match offset {
-                Some(o) => {
-                    let result = if raw { service.capture_since_raw(&id, o) } else { service.capture_since_text(&id, o) };
-                    match result {
-                        Ok(s) => ExecResult::Ok(Some(s)),
-                        Err(e) => ExecResult::Err(e),
-                    }
+            let start = match (since, since_marker) {
+                (Some(o), None) => StartBound::Offset(o),
+                (None, Some(name)) => StartBound::Marker(name),
+                (None, None) => {
+                    return ExecResult::Err("transcript requires --since or --since-marker".to_string());
                 }
-                None => ExecResult::Err("transcript requires --since or --since-marker".to_string()),
+                _ => unreachable!("clap conflicts_with prevents this"),
+            };
+            let result = if raw {
+                service.capture_slice_raw(&id, start, EndBound::EndOfRecording)
+            } else {
+                service.capture_slice_text(&id, start, EndBound::EndOfRecording)
+            };
+            match result {
+                Ok((s, _outcome)) => ExecResult::Ok(Some(s)),
+                Err(e) => ExecResult::Err(e),
             }
         }
         Command::Detach { id } => match service.detach(&id) {

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -108,6 +108,18 @@ pub enum Command {
         /// Named marker to use as the start offset
         #[arg(long, conflicts_with = "since")]
         since_marker: Option<String>,
+        /// Byte offset in .cast file; slice ends at this position.
+        #[arg(long, conflicts_with_all = ["until_marker", "until_next_marker", "until_idle"])]
+        until: Option<u64>,
+        /// Named marker to use as the end offset.
+        #[arg(long, conflicts_with_all = ["until", "until_next_marker", "until_idle"])]
+        until_marker: Option<String>,
+        /// Slice until the chronologically-next named marker after the start.
+        #[arg(long, conflicts_with_all = ["until", "until_marker", "until_idle"])]
+        until_next_marker: bool,
+        /// Slice until the recording is idle for this duration (e.g., 500ms, 2s).
+        #[arg(long, value_parser = crate::duration_parser::parse_humantime_or_seconds, conflicts_with_all = ["until", "until_marker", "until_next_marker"])]
+        until_idle: Option<std::time::Duration>,
         /// Return raw event data instead of VT-rendered text
         #[arg(long)]
         raw: bool,
@@ -377,7 +389,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Ok(s) => ExecResult::Ok(Some(s)),
             Err(e) => ExecResult::Err(e),
         },
-        Command::Transcript { id, since, since_marker, raw } => {
+        Command::Transcript { id, since, since_marker, until, until_marker, until_next_marker, until_idle, raw } => {
             let start = match (since, since_marker) {
                 (Some(o), None) => StartBound::Offset(o),
                 (None, Some(name)) => StartBound::Marker(name),
@@ -386,13 +398,26 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 }
                 _ => unreachable!("clap conflicts_with prevents this"),
             };
-            let result = if raw {
-                service.capture_slice_raw(&id, start, EndBound::EndOfRecording)
-            } else {
-                service.capture_slice_text(&id, start, EndBound::EndOfRecording)
+
+            let end = match (until, until_marker, until_next_marker, until_idle) {
+                (Some(o), None, false, None) => EndBound::Offset(o),
+                (None, Some(name), false, None) => EndBound::Marker(name),
+                (None, None, true, None) => EndBound::NextMarker,
+                (None, None, false, Some(d)) => EndBound::IdleGap(d),
+                (None, None, false, None) => EndBound::EndOfRecording,
+                _ => unreachable!("clap conflicts_with prevents this"),
             };
+
+            let result = if raw { service.capture_slice_raw(&id, start, end) } else { service.capture_slice_text(&id, start, end) };
             match result {
-                Ok((s, _outcome)) => ExecResult::Ok(Some(s)),
+                Ok((s, outcome)) => {
+                    if !outcome.hit_intended_end {
+                        if let Some(reason) = &outcome.fallback_reason {
+                            eprintln!("# bounded by EOF ({reason})");
+                        }
+                    }
+                    ExecResult::Ok(Some(s))
+                }
                 Err(e) => ExecResult::Err(e),
             }
         }

--- a/crates/cleat/src/duration_parser.rs
+++ b/crates/cleat/src/duration_parser.rs
@@ -13,8 +13,10 @@ pub fn parse_humantime_or_seconds(s: &str) -> Result<Duration, String> {
     if let Ok(d) = humantime::parse_duration(s) {
         return Ok(d);
     }
-    // `Duration::from_secs_f64` panics on negative / NaN / infinite values, so
-    // validate the float before converting.
+    // `Duration::from_secs_f64` panics on negative / NaN / infinite values.
+    // `humantime::parse_duration` does its own validation and would have
+    // returned Ok above for anything it accepts, so we only need to guard the
+    // float fallback branch here.
     let f: f64 = s.parse().map_err(|_| format!("invalid duration: {s}"))?;
     if !f.is_finite() || f < 0.0 {
         return Err(format!("invalid duration: {s}"));

--- a/crates/cleat/src/duration_parser.rs
+++ b/crates/cleat/src/duration_parser.rs
@@ -1,0 +1,58 @@
+//! Duration parser accepting both humantime-suffixed strings and plain
+//! numeric seconds. Used by `--until-idle` on `transcript` and
+//! `--idle-time` on `wait`.
+
+use std::time::Duration;
+
+/// Parse a duration string. Accepts:
+/// - humantime forms: `500ms`, `2s`, `1m30s`, `250us`, etc.
+/// - plain float seconds: `2`, `0.5`, `10.25`.
+///
+/// Humantime is tried first; falls back to float parsing on failure.
+pub fn parse_humantime_or_seconds(s: &str) -> Result<Duration, String> {
+    if let Ok(d) = humantime::parse_duration(s) {
+        return Ok(d);
+    }
+    s.parse::<f64>().map(Duration::from_secs_f64).map_err(|_| format!("invalid duration: {s}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_humantime_milliseconds() {
+        assert_eq!(parse_humantime_or_seconds("500ms").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn accepts_humantime_seconds() {
+        assert_eq!(parse_humantime_or_seconds("2s").unwrap(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn accepts_humantime_compound() {
+        assert_eq!(parse_humantime_or_seconds("1m30s").unwrap(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn accepts_plain_integer_seconds() {
+        assert_eq!(parse_humantime_or_seconds("2").unwrap(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn accepts_plain_float_seconds() {
+        assert_eq!(parse_humantime_or_seconds("0.5").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn rejects_invalid_input() {
+        let err = parse_humantime_or_seconds("not a duration").unwrap_err();
+        assert!(err.contains("invalid duration"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_empty_string() {
+        assert!(parse_humantime_or_seconds("").is_err());
+    }
+}

--- a/crates/cleat/src/duration_parser.rs
+++ b/crates/cleat/src/duration_parser.rs
@@ -13,7 +13,13 @@ pub fn parse_humantime_or_seconds(s: &str) -> Result<Duration, String> {
     if let Ok(d) = humantime::parse_duration(s) {
         return Ok(d);
     }
-    s.parse::<f64>().map(Duration::from_secs_f64).map_err(|_| format!("invalid duration: {s}"))
+    // `Duration::from_secs_f64` panics on negative / NaN / infinite values, so
+    // validate the float before converting.
+    let f: f64 = s.parse().map_err(|_| format!("invalid duration: {s}"))?;
+    if !f.is_finite() || f < 0.0 {
+        return Err(format!("invalid duration: {s}"));
+    }
+    Ok(Duration::from_secs_f64(f))
 }
 
 #[cfg(test)]
@@ -54,5 +60,17 @@ mod tests {
     #[test]
     fn rejects_empty_string() {
         assert!(parse_humantime_or_seconds("").is_err());
+    }
+
+    #[test]
+    fn rejects_negative_seconds_without_panic() {
+        let err = parse_humantime_or_seconds("-1").unwrap_err();
+        assert!(err.contains("invalid duration"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_nan_and_infinity_without_panic() {
+        assert!(parse_humantime_or_seconds("NaN").is_err());
+        assert!(parse_humantime_or_seconds("inf").is_err());
     }
 }

--- a/crates/cleat/src/lib.rs
+++ b/crates/cleat/src/lib.rs
@@ -2,6 +2,7 @@ pub mod asciicast;
 pub mod cast_reader;
 pub mod cli;
 pub mod da;
+pub mod duration_parser;
 pub mod keys;
 pub mod protocol;
 pub mod recording;

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -105,6 +105,7 @@ const TAG_WAIT_RESULT: u8 = 19;
 const TAG_EXPECT: u8 = 20;
 const TAG_EXPECT_RESULT: u8 = 21;
 const TAG_SEND_KEYS_WITH_MARK: u8 = 22;
+const TAG_RESOLVE_NEXT_MARKER: u8 = 23;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WaitCondition {
@@ -138,6 +139,7 @@ pub enum Frame {
     Mark { name: Option<String> },
     MarkResult { offset: u64 },
     ResolveMarker { name: String },
+    ResolveNextMarker { after: u64 },
     Wait { conditions: Vec<WaitCondition>, timeout_ms: u64 },
     WaitResult { status: WaitStatus, elapsed_ms: u64 },
     Expect { text: String, since_offset: u64, timeout_ms: u64 },
@@ -206,6 +208,11 @@ impl Frame {
             }
             Frame::MarkResult { offset } => (TAG_MARK_RESULT, offset.to_le_bytes().to_vec()),
             Frame::ResolveMarker { ref name } => (TAG_RESOLVE_MARKER, name.as_bytes().to_vec()),
+            Frame::ResolveNextMarker { after } => {
+                let mut payload = Vec::with_capacity(8);
+                payload.extend_from_slice(&after.to_le_bytes());
+                (TAG_RESOLVE_NEXT_MARKER, payload)
+            }
             Frame::Wait { ref conditions, timeout_ms } => {
                 debug_assert!(conditions.len() <= 255, "wait frame supports at most 255 conditions");
                 let mut payload = Vec::new();
@@ -304,6 +311,16 @@ impl Frame {
                 let name =
                     String::from_utf8(payload).map_err(|e| Error::new(ErrorKind::InvalidData, format!("invalid marker name: {e}")))?;
                 Ok(Frame::ResolveMarker { name })
+            }
+            TAG_RESOLVE_NEXT_MARKER => {
+                if payload.len() != 8 {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        format!("ResolveNextMarker payload must be 8 bytes, got {}", payload.len()),
+                    ));
+                }
+                let after = u64::from_le_bytes(payload[..8].try_into().expect("len checked"));
+                Ok(Frame::ResolveNextMarker { after })
             }
             TAG_MARK_RESULT => {
                 if payload.len() != 8 {
@@ -586,6 +603,15 @@ mod tests {
         frame.write(&mut bytes).expect("write");
         let decoded = Frame::read(&mut bytes.as_slice()).expect("read");
         assert_eq!(decoded, Frame::ResolveMarker { name: "checkpoint".to_string() });
+    }
+
+    #[test]
+    fn resolve_next_marker_round_trip() {
+        let frame = Frame::ResolveNextMarker { after: 12345 };
+        let mut buf = Vec::new();
+        frame.write(&mut buf).expect("write");
+        let decoded = Frame::read(&mut std::io::Cursor::new(buf)).expect("read");
+        assert_eq!(frame, decoded);
     }
 
     #[test]

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -106,6 +106,7 @@ const TAG_EXPECT: u8 = 20;
 const TAG_EXPECT_RESULT: u8 = 21;
 const TAG_SEND_KEYS_WITH_MARK: u8 = 22;
 const TAG_RESOLVE_NEXT_MARKER: u8 = 23;
+const TAG_MARK_NOT_FOUND: u8 = 24;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WaitCondition {
@@ -138,6 +139,7 @@ pub enum Frame {
     RecordControl { enable: bool },
     Mark { name: Option<String> },
     MarkResult { offset: u64 },
+    MarkNotFound,
     ResolveMarker { name: String },
     ResolveNextMarker { after: u64 },
     Wait { conditions: Vec<WaitCondition>, timeout_ms: u64 },
@@ -207,6 +209,7 @@ impl Frame {
                 (TAG_MARK, payload)
             }
             Frame::MarkResult { offset } => (TAG_MARK_RESULT, offset.to_le_bytes().to_vec()),
+            Frame::MarkNotFound => (TAG_MARK_NOT_FOUND, vec![]),
             Frame::ResolveMarker { ref name } => (TAG_RESOLVE_MARKER, name.as_bytes().to_vec()),
             Frame::ResolveNextMarker { after } => {
                 let mut payload = Vec::with_capacity(8);
@@ -329,6 +332,12 @@ impl Frame {
                 let offset =
                     u64::from_le_bytes([payload[0], payload[1], payload[2], payload[3], payload[4], payload[5], payload[6], payload[7]]);
                 Ok(Frame::MarkResult { offset })
+            }
+            TAG_MARK_NOT_FOUND => {
+                if !payload.is_empty() {
+                    return Err(Error::new(ErrorKind::InvalidData, "mark not found frame must have empty payload"));
+                }
+                Ok(Frame::MarkNotFound)
             }
             TAG_WAIT => {
                 if payload.len() < 9 {
@@ -608,6 +617,15 @@ mod tests {
     #[test]
     fn resolve_next_marker_round_trip() {
         let frame = Frame::ResolveNextMarker { after: 12345 };
+        let mut buf = Vec::new();
+        frame.write(&mut buf).expect("write");
+        let decoded = Frame::read(&mut std::io::Cursor::new(buf)).expect("read");
+        assert_eq!(frame, decoded);
+    }
+
+    #[test]
+    fn mark_not_found_round_trip() {
+        let frame = Frame::MarkNotFound;
         let mut buf = Vec::new();
         frame.write(&mut buf).expect("write");
         let decoded = Frame::read(&mut std::io::Cursor::new(buf)).expect("read");

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -180,28 +180,6 @@ impl SessionService {
         }
     }
 
-    pub fn capture_since_raw(&self, id: &str, offset: u64) -> Result<String, String> {
-        let cast_path = self.layout.root().join(id).join(crate::recording::CAST_FILE_NAME);
-        if !cast_path.exists() {
-            return Err(format!("no recording for session {id}"));
-        }
-        let events = crate::cast_reader::read_output_since(&cast_path, offset)?;
-        let output: String = events.iter().map(|e| e.data.as_str()).collect();
-        Ok(output)
-    }
-
-    pub fn capture_since_text(&self, id: &str, offset: u64) -> Result<String, String> {
-        let cast_path = self.layout.root().join(id).join(crate::recording::CAST_FILE_NAME);
-        if !cast_path.exists() {
-            return Err(format!("no recording for session {id}"));
-        }
-        let events = crate::cast_reader::read_output_since(&cast_path, offset)?;
-        // Phase 1: concatenate output event data directly.
-        // Full VT replay (snapshot + engine) is a future enhancement.
-        let output: String = events.iter().map(|e| e.data.as_str()).collect();
-        Ok(output)
-    }
-
     pub fn capture_slice_raw(&self, id: &str, start: StartBound, end: EndBound) -> Result<(String, SliceOutcome), String> {
         self.capture_slice_inner(id, start, end)
     }

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -226,8 +226,11 @@ impl SessionService {
             }
             EndBound::Marker(name) => {
                 let o = self.resolve_marker(id, &name)?;
-                if o < start_offset {
-                    return Err(format!("marker '{name}' precedes start"));
+                // Strict "after start" for named markers — equal-offset is almost
+                // always a typo (e.g. `--since-marker m1 --until-marker m1`).
+                // Raw offsets keep `<` so `--since 0 --until 0` is a legal empty slice.
+                if o <= start_offset {
+                    return Err(format!("marker '{name}' at offset {o} is not after start offset {start_offset}"));
                 }
                 (o, None)
             }

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -218,7 +218,12 @@ impl SessionService {
 
         let (end_offset, end_status) = match end {
             EndBound::EndOfRecording => (file_size, None),
-            EndBound::Offset(o) => (o, None),
+            EndBound::Offset(o) => {
+                if o < start_offset {
+                    return Err(format!("end offset {o} precedes start offset {start_offset}"));
+                }
+                (o, None)
+            }
             EndBound::Marker(name) => {
                 let o = self.resolve_marker(id, &name)?;
                 if o < start_offset {

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -13,6 +13,29 @@ use crate::{
     vt::VtEngineKind,
 };
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartBound {
+    Offset(u64),
+    Marker(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EndBound {
+    Offset(u64),
+    Marker(String),
+    NextMarker,
+    IdleGap(Duration),
+    EndOfRecording,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SliceOutcome {
+    pub start_offset: u64,
+    pub end_offset: u64,
+    pub hit_intended_end: bool,
+    pub fallback_reason: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct SessionService {
     layout: RuntimeLayout,
@@ -179,6 +202,62 @@ impl SessionService {
         Ok(output)
     }
 
+    pub fn capture_slice_raw(&self, id: &str, start: StartBound, end: EndBound) -> Result<(String, SliceOutcome), String> {
+        self.capture_slice_inner(id, start, end)
+    }
+
+    pub fn capture_slice_text(&self, id: &str, start: StartBound, end: EndBound) -> Result<(String, SliceOutcome), String> {
+        // Today raw and text produce the same output; separation is for
+        // future VT-rendered transcripts.
+        self.capture_slice_inner(id, start, end)
+    }
+
+    fn capture_slice_inner(&self, id: &str, start: StartBound, end: EndBound) -> Result<(String, SliceOutcome), String> {
+        let cast_path = self.layout.root().join(id).join(crate::recording::CAST_FILE_NAME);
+        if !cast_path.exists() {
+            return Err(format!("no recording for session {id}"));
+        }
+
+        let start_offset = match start {
+            StartBound::Offset(o) => o,
+            StartBound::Marker(name) => self.resolve_marker(id, &name)?,
+        };
+
+        let (end_offset, hit_intended_end, fallback_reason) = match end {
+            EndBound::EndOfRecording => {
+                let size = std::fs::metadata(&cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
+                (size, true, None)
+            }
+            EndBound::Offset(o) => (o, true, None),
+            EndBound::Marker(name) => {
+                let o = self.resolve_marker(id, &name)?;
+                if o < start_offset {
+                    return Err(format!("marker '{name}' precedes start"));
+                }
+                (o, true, None)
+            }
+            EndBound::NextMarker => match self.resolve_next_marker_after(id, start_offset) {
+                Ok(o) => (o, true, None),
+                Err(msg) if msg.contains("no marker") => {
+                    let size = std::fs::metadata(&cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
+                    (size, false, Some("no marker after start".to_string()))
+                }
+                Err(msg) => return Err(msg),
+            },
+            EndBound::IdleGap(duration) => match crate::cast_reader::find_idle_gap_after(&cast_path, start_offset, duration)? {
+                Some(o) => (o, true, None),
+                None => {
+                    let size = std::fs::metadata(&cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
+                    (size, false, Some(format!("no {} idle found", humantime::format_duration(duration))))
+                }
+            },
+        };
+
+        let events = crate::cast_reader::read_output_between(&cast_path, start_offset, end_offset)?;
+        let output: String = events.iter().map(|e| e.data.as_str()).collect();
+        Ok((output, SliceOutcome { start_offset, end_offset, hit_intended_end, fallback_reason }))
+    }
+
     pub fn send_keys(&self, id: &str, bytes: &[u8]) -> Result<(), String> {
         if !self.layout.root().join(id).exists() {
             return Err(format!("missing session {id}"));
@@ -308,6 +387,20 @@ impl SessionService {
             Frame::MarkResult { offset } => Ok(offset),
             Frame::Error(msg) => Err(msg),
             other => Err(format!("unexpected resolve response: {other:?}")),
+        }
+    }
+
+    pub fn resolve_next_marker_after(&self, id: &str, after: u64) -> Result<u64, String> {
+        if !self.layout.root().join(id).exists() {
+            return Err(format!("missing session {id}"));
+        }
+        let socket_path = session_socket_path(self.layout.root(), id);
+        let mut stream = connect_session_socket(&socket_path)?;
+        Frame::ResolveNextMarker { after }.write(&mut stream).map_err(|e| format!("write resolve-next: {e}"))?;
+        match Frame::read(&mut stream).map_err(|e| format!("read resolve-next response: {e}"))? {
+            Frame::MarkResult { offset } => Ok(offset),
+            Frame::Error(msg) => Err(msg),
+            other => Err(format!("unexpected resolve-next response: {other:?}")),
         }
     }
 

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -29,11 +29,24 @@ pub enum EndBound {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FallbackReason {
+    /// `--until-next-marker` hit EOF without finding another marker.
+    NoMarkerAfterStart,
+    /// `--until-idle <dur>` hit EOF without finding a gap of that duration.
+    NoIdleGap(Duration),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SliceOutcome {
+    /// Byte offset where the slice started (resolved from `StartBound`).
     pub start_offset: u64,
+    /// Byte offset where the slice ended, exclusive (resolved from `EndBound`,
+    /// or file size if the soft ceiling fell back to EOF).
     pub end_offset: u64,
-    pub hit_intended_end: bool,
-    pub fallback_reason: Option<String>,
+    /// `None` if the intended end bound was reached. `Some(reason)` when a
+    /// soft-ceiling fallback to EOF kicked in. Primarily for future JSON
+    /// output; the CLI uses it to decide whether to emit a stderr note.
+    pub end_status: Option<FallbackReason>,
 }
 
 #[derive(Debug, Clone)]
@@ -201,39 +214,31 @@ impl SessionService {
             StartBound::Marker(name) => self.resolve_marker(id, &name)?,
         };
 
-        let (end_offset, hit_intended_end, fallback_reason) = match end {
-            EndBound::EndOfRecording => {
-                let size = std::fs::metadata(&cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
-                (size, true, None)
-            }
-            EndBound::Offset(o) => (o, true, None),
+        let file_size = std::fs::metadata(&cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
+
+        let (end_offset, end_status) = match end {
+            EndBound::EndOfRecording => (file_size, None),
+            EndBound::Offset(o) => (o, None),
             EndBound::Marker(name) => {
                 let o = self.resolve_marker(id, &name)?;
                 if o < start_offset {
                     return Err(format!("marker '{name}' precedes start"));
                 }
-                (o, true, None)
+                (o, None)
             }
-            EndBound::NextMarker => match self.resolve_next_marker_after(id, start_offset) {
-                Ok(o) => (o, true, None),
-                Err(msg) if msg.contains("no marker") => {
-                    let size = std::fs::metadata(&cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
-                    (size, false, Some("no marker after start".to_string()))
-                }
-                Err(msg) => return Err(msg),
+            EndBound::NextMarker => match self.resolve_next_marker_after(id, start_offset)? {
+                Some(o) => (o, None),
+                None => (file_size, Some(FallbackReason::NoMarkerAfterStart)),
             },
             EndBound::IdleGap(duration) => match crate::cast_reader::find_idle_gap_after(&cast_path, start_offset, duration)? {
-                Some(o) => (o, true, None),
-                None => {
-                    let size = std::fs::metadata(&cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
-                    (size, false, Some(format!("no {} idle found", humantime::format_duration(duration))))
-                }
+                Some(o) => (o, None),
+                None => (file_size, Some(FallbackReason::NoIdleGap(duration))),
             },
         };
 
         let events = crate::cast_reader::read_output_between(&cast_path, start_offset, end_offset)?;
         let output: String = events.iter().map(|e| e.data.as_str()).collect();
-        Ok((output, SliceOutcome { start_offset, end_offset, hit_intended_end, fallback_reason }))
+        Ok((output, SliceOutcome { start_offset, end_offset, end_status }))
     }
 
     pub fn send_keys(&self, id: &str, bytes: &[u8]) -> Result<(), String> {
@@ -368,7 +373,7 @@ impl SessionService {
         }
     }
 
-    pub fn resolve_next_marker_after(&self, id: &str, after: u64) -> Result<u64, String> {
+    pub fn resolve_next_marker_after(&self, id: &str, after: u64) -> Result<Option<u64>, String> {
         if !self.layout.root().join(id).exists() {
             return Err(format!("missing session {id}"));
         }
@@ -376,7 +381,8 @@ impl SessionService {
         let mut stream = connect_session_socket(&socket_path)?;
         Frame::ResolveNextMarker { after }.write(&mut stream).map_err(|e| format!("write resolve-next: {e}"))?;
         match Frame::read(&mut stream).map_err(|e| format!("read resolve-next response: {e}"))? {
-            Frame::MarkResult { offset } => Ok(offset),
+            Frame::MarkResult { offset } => Ok(Some(offset)),
+            Frame::MarkNotFound => Ok(None),
             Frame::Error(msg) => Err(msg),
             other => Err(format!("unexpected resolve-next response: {other:?}")),
         }

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -649,6 +649,9 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                             }
                         }
                         Ok(Frame::ResolveNextMarker { after }) => {
+                            // Markers are appended at the current recording offset, so byte-offset
+                            // order matches creation order. min(offset > after) picks the
+                            // chronologically-next marker. Back-filling markers would break this.
                             let next = markers.iter().filter(|(_, &offset)| offset > after).map(|(_, &offset)| offset).min();
                             let reply = match next {
                                 Some(offset) => Frame::MarkResult { offset },

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -648,6 +648,14 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                                 let _ = Frame::Error(format!("marker not found: {name}")).write(&mut stream);
                             }
                         }
+                        Ok(Frame::ResolveNextMarker { after }) => {
+                            let next = markers.iter().filter(|(_, &offset)| offset > after).map(|(_, &offset)| offset).min();
+                            let reply = match next {
+                                Some(offset) => Frame::MarkResult { offset },
+                                None => Frame::Error(format!("no marker after offset {after}")),
+                            };
+                            let _ = reply.write(&mut stream);
+                        }
                         Ok(Frame::RecordControl { enable }) => {
                             if enable && recorder.is_none() {
                                 // First-time activation: create new recorder

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -652,7 +652,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                             let next = markers.iter().filter(|(_, &offset)| offset > after).map(|(_, &offset)| offset).min();
                             let reply = match next {
                                 Some(offset) => Frame::MarkResult { offset },
-                                None => Frame::Error(format!("no marker after offset {after}")),
+                                None => Frame::MarkNotFound,
                             };
                             let _ = reply.write(&mut stream);
                         }

--- a/crates/cleat/tests/capture_render.rs
+++ b/crates/cleat/tests/capture_render.rs
@@ -4,7 +4,7 @@ use cleat::{
     asciicast::{encode_event, encode_header, Event, EventCode, Header},
     recording::CAST_FILE_NAME,
     runtime::RuntimeLayout,
-    server::SessionService,
+    server::{EndBound, SessionService, StartBound},
 };
 
 fn setup_session_with_cast(root: &std::path::Path, id: &str, events: &[Event]) {
@@ -32,7 +32,7 @@ fn capture_since_text_returns_concatenated_output() {
     }];
     setup_session_with_cast(temp.path(), "sess", &events);
 
-    let result = service.capture_since_text("sess", 0).unwrap();
+    let (result, _outcome) = service.capture_slice_text("sess", StartBound::Offset(0), EndBound::EndOfRecording).unwrap();
     assert!(result.contains("hello "));
     assert!(result.contains("world"));
 }
@@ -49,7 +49,7 @@ fn capture_since_text_skips_non_output_events() {
     ];
     setup_session_with_cast(temp.path(), "sess", &events);
 
-    let result = service.capture_since_text("sess", 0).unwrap();
+    let (result, _outcome) = service.capture_slice_text("sess", StartBound::Offset(0), EndBound::EndOfRecording).unwrap();
     assert!(result.contains("visible"));
     assert!(!result.contains("typed"));
     assert!(!result.contains("signal"));
@@ -64,7 +64,7 @@ fn capture_since_text_returns_empty_at_eof() {
     setup_session_with_cast(temp.path(), "sess", &events);
 
     let file_size = std::fs::metadata(temp.path().join("sess").join(CAST_FILE_NAME)).unwrap().len();
-    let result = service.capture_since_text("sess", file_size).unwrap();
+    let (result, _outcome) = service.capture_slice_text("sess", StartBound::Offset(file_size), EndBound::EndOfRecording).unwrap();
     assert!(result.is_empty());
 }
 
@@ -76,14 +76,12 @@ fn capture_since_errors_when_no_recording() {
     // Create session dir but no .cast file
     std::fs::create_dir_all(temp.path().join("no-rec")).unwrap();
 
-    let err = service.capture_since_text("no-rec", 0).unwrap_err();
+    let err = service.capture_slice_text("no-rec", StartBound::Offset(0), EndBound::EndOfRecording).unwrap_err();
     assert!(err.contains("no recording"), "error should mention missing recording: {err}");
 }
 
 #[test]
 fn capture_slice_text_returns_bytes_through_eof_with_start_at_zero() {
-    use cleat::server::{EndBound, StartBound};
-
     let temp = tempfile::tempdir().unwrap();
     let events = vec![Event { time: Duration::from_millis(100), code: EventCode::Output, data: "hello ".into() }, Event {
         time: Duration::from_millis(200),
@@ -103,8 +101,6 @@ fn capture_slice_text_returns_bytes_through_eof_with_start_at_zero() {
 
 #[test]
 fn capture_slice_text_idle_fallback_to_eof_populates_fallback_reason() {
-    use cleat::server::{EndBound, StartBound};
-
     let temp = tempfile::tempdir().unwrap();
     let events = vec![Event { time: Duration::from_millis(100), code: EventCode::Output, data: "a".into() }, Event {
         time: Duration::from_millis(200),

--- a/crates/cleat/tests/capture_render.rs
+++ b/crates/cleat/tests/capture_render.rs
@@ -4,7 +4,7 @@ use cleat::{
     asciicast::{encode_event, encode_header, Event, EventCode, Header},
     recording::CAST_FILE_NAME,
     runtime::RuntimeLayout,
-    server::{EndBound, SessionService, StartBound},
+    server::{EndBound, FallbackReason, SessionService, StartBound},
 };
 
 fn setup_session_with_cast(root: &std::path::Path, id: &str, events: &[Event]) {
@@ -21,7 +21,7 @@ fn setup_session_with_cast(root: &std::path::Path, id: &str, events: &[Event]) {
 }
 
 #[test]
-fn capture_since_text_returns_concatenated_output() {
+fn capture_slice_text_returns_concatenated_output() {
     let temp = tempfile::tempdir().unwrap();
     let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
 
@@ -38,7 +38,7 @@ fn capture_since_text_returns_concatenated_output() {
 }
 
 #[test]
-fn capture_since_text_skips_non_output_events() {
+fn capture_slice_text_skips_non_output_events() {
     let temp = tempfile::tempdir().unwrap();
     let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
 
@@ -56,7 +56,7 @@ fn capture_since_text_skips_non_output_events() {
 }
 
 #[test]
-fn capture_since_text_returns_empty_at_eof() {
+fn capture_slice_text_returns_empty_at_eof() {
     let temp = tempfile::tempdir().unwrap();
     let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
 
@@ -69,7 +69,7 @@ fn capture_since_text_returns_empty_at_eof() {
 }
 
 #[test]
-fn capture_since_errors_when_no_recording() {
+fn capture_slice_errors_when_no_recording() {
     let temp = tempfile::tempdir().unwrap();
     let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
 
@@ -93,7 +93,7 @@ fn capture_slice_text_returns_bytes_through_eof_with_start_at_zero() {
 
     let (text, outcome) = service.capture_slice_text("sess", StartBound::Offset(0), EndBound::EndOfRecording).expect("slice");
     assert_eq!(text, "hello world");
-    assert!(outcome.hit_intended_end);
+    assert_eq!(outcome.end_status, None);
     assert_eq!(outcome.start_offset, 0);
     let file_size = std::fs::metadata(temp.path().join("sess").join(CAST_FILE_NAME)).unwrap().len();
     assert_eq!(outcome.end_offset, file_size);
@@ -113,6 +113,5 @@ fn capture_slice_text_idle_fallback_to_eof_populates_fallback_reason() {
     let (text, outcome) =
         service.capture_slice_text("sess", StartBound::Offset(0), EndBound::IdleGap(Duration::from_secs(10))).expect("slice");
     assert_eq!(text, "ab");
-    assert!(!outcome.hit_intended_end);
-    assert_eq!(outcome.fallback_reason.as_deref(), Some("no 10s idle found"));
+    assert_eq!(outcome.end_status, Some(FallbackReason::NoIdleGap(Duration::from_secs(10))));
 }

--- a/crates/cleat/tests/capture_render.rs
+++ b/crates/cleat/tests/capture_render.rs
@@ -79,3 +79,44 @@ fn capture_since_errors_when_no_recording() {
     let err = service.capture_since_text("no-rec", 0).unwrap_err();
     assert!(err.contains("no recording"), "error should mention missing recording: {err}");
 }
+
+#[test]
+fn capture_slice_text_returns_bytes_through_eof_with_start_at_zero() {
+    use cleat::server::{EndBound, StartBound};
+
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![Event { time: Duration::from_millis(100), code: EventCode::Output, data: "hello ".into() }, Event {
+        time: Duration::from_millis(200),
+        code: EventCode::Output,
+        data: "world".into(),
+    }];
+    setup_session_with_cast(temp.path(), "sess", &events);
+    let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+
+    let (text, outcome) = service.capture_slice_text("sess", StartBound::Offset(0), EndBound::EndOfRecording).expect("slice");
+    assert_eq!(text, "hello world");
+    assert!(outcome.hit_intended_end);
+    assert_eq!(outcome.start_offset, 0);
+    let file_size = std::fs::metadata(temp.path().join("sess").join(CAST_FILE_NAME)).unwrap().len();
+    assert_eq!(outcome.end_offset, file_size);
+}
+
+#[test]
+fn capture_slice_text_idle_fallback_to_eof_populates_fallback_reason() {
+    use cleat::server::{EndBound, StartBound};
+
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![Event { time: Duration::from_millis(100), code: EventCode::Output, data: "a".into() }, Event {
+        time: Duration::from_millis(200),
+        code: EventCode::Output,
+        data: "b".into(),
+    }];
+    setup_session_with_cast(temp.path(), "sess", &events);
+    let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+
+    let (text, outcome) =
+        service.capture_slice_text("sess", StartBound::Offset(0), EndBound::IdleGap(Duration::from_secs(10))).expect("slice");
+    assert_eq!(text, "ab");
+    assert!(!outcome.hit_intended_end);
+    assert_eq!(outcome.fallback_reason.as_deref(), Some("no 10s idle found"));
+}

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -401,7 +401,7 @@ fn wait_requires_at_least_one_condition() {
 #[test]
 fn wait_idle_time_parses() {
     let cli = Cli::try_parse_from(["cleat", "wait", "sess", "--idle-time", "2.0"]).expect("parse");
-    assert!(matches!(cli.command, Command::Wait { idle_time: Some(t), text: None, .. } if (t - 2.0).abs() < f64::EPSILON));
+    assert!(matches!(cli.command, Command::Wait { idle_time: Some(t), text: None, .. } if t == std::time::Duration::from_secs_f64(2.0)));
 }
 
 #[test]
@@ -435,6 +435,21 @@ fn wait_execute_rejects_no_conditions() {
             assert!(msg.contains("at least one of --idle-time or --text"));
         }
         other => panic!("wait without conditions should exit 2, got: {other:?}"),
+    }
+}
+
+#[test]
+fn wait_idle_time_accepts_humantime_and_seconds() {
+    // Both forms parse to the same Duration.
+    let humantime_form = Cli::try_parse_from(["cleat", "wait", "x", "--idle-time", "500ms"]).expect("humantime parse");
+    let seconds_form = Cli::try_parse_from(["cleat", "wait", "x", "--idle-time", "0.5"]).expect("seconds parse");
+
+    match (&humantime_form.command, &seconds_form.command) {
+        (Command::Wait { idle_time: Some(a), .. }, Command::Wait { idle_time: Some(b), .. }) => {
+            assert_eq!(*a, std::time::Duration::from_millis(500));
+            assert_eq!(*b, std::time::Duration::from_millis(500));
+        }
+        _ => panic!("expected both forms to parse as Wait with idle_time set"),
     }
 }
 

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -305,19 +305,46 @@ fn mark_without_name_still_works() {
 #[test]
 fn transcript_with_since_marker_parses() {
     let cli = Cli::try_parse_from(["cleat", "transcript", "sess", "--since-marker", "m1"]).expect("parse");
-    assert_eq!(cli.command, Command::Transcript { id: "sess".into(), since: None, since_marker: Some("m1".into()), raw: false });
+    assert_eq!(cli.command, Command::Transcript {
+        id: "sess".into(),
+        since: None,
+        since_marker: Some("m1".into()),
+        until: None,
+        until_marker: None,
+        until_next_marker: false,
+        until_idle: None,
+        raw: false,
+    });
 }
 
 #[test]
 fn transcript_with_since_offset_parses() {
     let cli = Cli::try_parse_from(["cleat", "transcript", "sess", "--since", "500"]).expect("parse");
-    assert_eq!(cli.command, Command::Transcript { id: "sess".into(), since: Some(500), since_marker: None, raw: false });
+    assert_eq!(cli.command, Command::Transcript {
+        id: "sess".into(),
+        since: Some(500),
+        since_marker: None,
+        until: None,
+        until_marker: None,
+        until_next_marker: false,
+        until_idle: None,
+        raw: false,
+    });
 }
 
 #[test]
 fn transcript_with_raw_parses() {
     let cli = Cli::try_parse_from(["cleat", "transcript", "sess", "--since-marker", "m1", "--raw"]).expect("parse");
-    assert_eq!(cli.command, Command::Transcript { id: "sess".into(), since: None, since_marker: Some("m1".into()), raw: true });
+    assert_eq!(cli.command, Command::Transcript {
+        id: "sess".into(),
+        since: None,
+        since_marker: Some("m1".into()),
+        until: None,
+        until_marker: None,
+        until_next_marker: false,
+        until_idle: None,
+        raw: true,
+    });
 }
 
 #[test]

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -367,6 +367,79 @@ fn transcript_since_and_since_marker_are_mutually_exclusive() {
 }
 
 #[test]
+fn transcript_with_until_offset_parses() {
+    let cli = Cli::try_parse_from(["cleat", "transcript", "sess", "--since", "0", "--until", "1000"]).expect("parse");
+    assert_eq!(cli.command, Command::Transcript {
+        id: "sess".into(),
+        since: Some(0),
+        since_marker: None,
+        until: Some(1000),
+        until_marker: None,
+        until_next_marker: false,
+        until_idle: None,
+        raw: false,
+    });
+}
+
+#[test]
+fn transcript_with_until_marker_parses() {
+    let cli = Cli::try_parse_from(["cleat", "transcript", "sess", "--since-marker", "a", "--until-marker", "b"]).expect("parse");
+    assert_eq!(cli.command, Command::Transcript {
+        id: "sess".into(),
+        since: None,
+        since_marker: Some("a".into()),
+        until: None,
+        until_marker: Some("b".into()),
+        until_next_marker: false,
+        until_idle: None,
+        raw: false,
+    });
+}
+
+#[test]
+fn transcript_with_until_next_marker_parses() {
+    let cli = Cli::try_parse_from(["cleat", "transcript", "sess", "--since-marker", "a", "--until-next-marker"]).expect("parse");
+    assert_eq!(cli.command, Command::Transcript {
+        id: "sess".into(),
+        since: None,
+        since_marker: Some("a".into()),
+        until: None,
+        until_marker: None,
+        until_next_marker: true,
+        until_idle: None,
+        raw: false,
+    });
+}
+
+#[test]
+fn transcript_with_until_idle_parses_humantime() {
+    let cli = Cli::try_parse_from(["cleat", "transcript", "sess", "--since", "0", "--until-idle", "500ms"]).expect("parse");
+    assert_eq!(cli.command, Command::Transcript {
+        id: "sess".into(),
+        since: Some(0),
+        since_marker: None,
+        until: None,
+        until_marker: None,
+        until_next_marker: false,
+        until_idle: Some(std::time::Duration::from_millis(500)),
+        raw: false,
+    });
+}
+
+#[test]
+fn transcript_end_bounds_are_mutually_exclusive() {
+    for args in [
+        &["cleat", "transcript", "sess", "--since", "0", "--until", "100", "--until-marker", "m1"][..],
+        &["cleat", "transcript", "sess", "--since", "0", "--until", "100", "--until-next-marker"][..],
+        &["cleat", "transcript", "sess", "--since", "0", "--until-marker", "m1", "--until-idle", "1s"][..],
+        &["cleat", "transcript", "sess", "--since", "0", "--until-next-marker", "--until-idle", "1s"][..],
+    ] {
+        let result = Cli::try_parse_from(args.iter().copied());
+        assert!(result.is_err(), "end bounds should be mutually exclusive: {args:?}");
+    }
+}
+
+#[test]
 fn send_command_parses() {
     let cli = Cli::try_parse_from(["cleat", "send", "demo", "echo hello"]).expect("send parses");
     assert_eq!(cli.command, Command::Send { id: "demo".into(), text: "echo hello".into(), no_enter: false, mark_before: None });

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -14,7 +14,7 @@ use cleat::{
     cli::{self, Cli},
     protocol::{Frame, SessionInfo},
     runtime::RuntimeLayout,
-    server::SessionService,
+    server::{EndBound, SessionService, StartBound},
     session::session_socket_path,
     vt::{self, ClientCapabilities, ColorLevel, VtEngineKind},
 };
@@ -455,7 +455,8 @@ fn detached_session_answers_da_queries() {
     std::thread::sleep(Duration::from_secs(1));
 
     // Read recorded output since the mark
-    let output = service.capture_since_raw("alpha", offset).expect("capture since");
+    let (output, _outcome) =
+        service.capture_slice_raw("alpha", StartBound::Offset(offset), EndBound::EndOfRecording).expect("capture slice");
 
     assert!(output.contains("\x1b[?62;22c"), "detached session should inject DA1 response in recorded output, got: {output:?}");
 }

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -1084,3 +1084,32 @@ fn transcript_until_idle_terminates_at_quiet_period() {
     assert!(output.contains("burst"), "expected 'burst' in output");
     assert!(!output.contains("after"), "idle gap should have terminated slice before 'after'");
 }
+
+#[test]
+fn transcript_until_raw_offset_returns_exact_range() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), None, None, Some("sh -c 'stty raw; exec cat'".into()), true).expect("create");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let off_a = service.named_mark("alpha", "a").expect("mark a");
+    service.send_keys("alpha", b"middle").expect("send middle");
+    std::thread::sleep(Duration::from_millis(300));
+    let off_b = service.named_mark("alpha", "b").expect("mark b");
+    service.send_keys("alpha", b"trailing").expect("send trailing");
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Raw offsets via --since / --until should slice exactly the same as
+    // --since-marker a / --until-marker b — proves the raw-offset code path.
+    let cli =
+        Cli::try_parse_from(["cleat", "transcript", "alpha", "--since", &off_a.to_string(), "--until", &off_b.to_string()]).expect("parse");
+    let result = cli::execute(cli, &service);
+    let output = match result {
+        ExecResult::Ok(Some(s)) => s,
+        other => panic!("expected Ok(Some(...)), got {other:?}"),
+    };
+    assert!(output.contains("middle"), "expected 'middle' in output, got: {output:?}");
+    assert!(!output.contains("trailing"), "did not expect 'trailing', got: {output:?}");
+}

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -508,6 +508,32 @@ fn attached_session_does_not_get_synthetic_da_reply() {
     );
 }
 
+#[test]
+fn resolve_next_marker_returns_minimum_offset_above() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), None, None, Some("sh -c 'stty raw; exec cat'".into()), true).expect("create");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Named marks register offsets in the daemon's marker map; unnamed `mark`
+    // does not. `resolve_next_marker_after` searches that map, so we need
+    // named marks here.
+    let off_a = service.named_mark("alpha", "a").expect("mark a");
+    service.send_keys("alpha", b"x").expect("send x");
+    std::thread::sleep(Duration::from_millis(300));
+    let off_b = service.named_mark("alpha", "b").expect("mark b");
+    service.send_keys("alpha", b"y").expect("send y");
+    std::thread::sleep(Duration::from_millis(300));
+    let off_c = service.named_mark("alpha", "c").expect("mark c");
+
+    assert_eq!(service.resolve_next_marker_after("alpha", off_a).expect("resolve"), off_b, "next after A should be B");
+    assert_eq!(service.resolve_next_marker_after("alpha", off_b).expect("resolve"), off_c, "next after B should be C");
+    let err = service.resolve_next_marker_after("alpha", off_c).unwrap_err();
+    assert!(err.contains("no marker"), "expected not-found error, got: {err}");
+}
+
 #[cfg(feature = "ghostty-vt")]
 #[test]
 fn replay_reattach_delivers_restore_before_new_live_output() {

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -528,10 +528,9 @@ fn resolve_next_marker_returns_minimum_offset_above() {
     std::thread::sleep(Duration::from_millis(300));
     let off_c = service.named_mark("alpha", "c").expect("mark c");
 
-    assert_eq!(service.resolve_next_marker_after("alpha", off_a).expect("resolve"), off_b, "next after A should be B");
-    assert_eq!(service.resolve_next_marker_after("alpha", off_b).expect("resolve"), off_c, "next after B should be C");
-    let err = service.resolve_next_marker_after("alpha", off_c).unwrap_err();
-    assert!(err.contains("no marker"), "expected not-found error, got: {err}");
+    assert_eq!(service.resolve_next_marker_after("alpha", off_a).expect("resolve"), Some(off_b), "next after A should be B");
+    assert_eq!(service.resolve_next_marker_after("alpha", off_b).expect("resolve"), Some(off_c), "next after B should be C");
+    assert_eq!(service.resolve_next_marker_after("alpha", off_c).expect("resolve"), None, "no marker after C should return None");
 }
 
 #[cfg(feature = "ghostty-vt")]
@@ -1072,7 +1071,7 @@ fn transcript_until_idle_terminates_at_quiet_period() {
 
     service.named_mark("alpha", "start").expect("mark start");
     service.send_keys("alpha", b"burst").expect("send burst");
-    std::thread::sleep(Duration::from_millis(1000));
+    std::thread::sleep(Duration::from_millis(1500));
     service.send_keys("alpha", b"after").expect("send after");
     std::thread::sleep(Duration::from_millis(300));
 

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 #[cfg(feature = "ghostty-vt")]
 use cleat::session::{daemon_pid_path, foreground_path};
 use cleat::{
-    cli::{self, Cli},
+    cli::{self, Cli, ExecResult},
     protocol::{Frame, SessionInfo},
     runtime::RuntimeLayout,
     server::{EndBound, SessionService, StartBound},
@@ -193,7 +193,6 @@ fn capture_rejects_passthrough_sessions() {
 #[cfg(feature = "ghostty-vt")]
 #[test]
 fn capture_returns_text_for_ghostty_sessions() {
-    use cleat::cli::ExecResult;
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");
     let service = service_for(temp.path());
@@ -1034,4 +1033,55 @@ fn inspect_reports_dynamic_leader_cwd() {
     );
 
     service.kill("cwd-test").expect("kill");
+}
+
+#[test]
+fn transcript_between_two_named_markers_returns_exact_range() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), None, None, Some("sh -c 'stty raw; exec cat'".into()), true).expect("create");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    service.named_mark("alpha", "m1").expect("mark m1");
+    service.send_keys("alpha", b"first").expect("send first");
+    std::thread::sleep(Duration::from_millis(300));
+    service.named_mark("alpha", "m2").expect("mark m2");
+    service.send_keys("alpha", b"second").expect("send second");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let cli = Cli::try_parse_from(["cleat", "transcript", "alpha", "--since-marker", "m1", "--until-marker", "m2"]).expect("parse");
+    let result = cli::execute(cli, &service);
+    let output = match result {
+        ExecResult::Ok(Some(s)) => s,
+        other => panic!("expected Ok(Some(...)), got {other:?}"),
+    };
+    assert!(output.contains("first"), "expected 'first' in output, got: {output:?}");
+    assert!(!output.contains("second"), "did not expect 'second', got: {output:?}");
+}
+
+#[test]
+fn transcript_until_idle_terminates_at_quiet_period() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), None, None, Some("sh -c 'stty raw; exec cat'".into()), true).expect("create");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    service.named_mark("alpha", "start").expect("mark start");
+    service.send_keys("alpha", b"burst").expect("send burst");
+    std::thread::sleep(Duration::from_millis(1000));
+    service.send_keys("alpha", b"after").expect("send after");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let cli = Cli::try_parse_from(["cleat", "transcript", "alpha", "--since-marker", "start", "--until-idle", "500ms"]).expect("parse");
+    let result = cli::execute(cli, &service);
+    let output = match result {
+        ExecResult::Ok(Some(s)) => s,
+        other => panic!("expected Ok(Some(...)), got {other:?}"),
+    };
+    assert!(output.contains("burst"), "expected 'burst' in output");
+    assert!(!output.contains("after"), "idle gap should have terminated slice before 'after'");
 }

--- a/docs/superpowers/plans/2026-04-22-transcript-between-markers.md
+++ b/docs/superpowers/plans/2026-04-22-transcript-between-markers.md
@@ -1,0 +1,1270 @@
+# Transcript End-Bounds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four end-bound flags to `cleat transcript` (`--until`, `--until-marker`, `--until-next-marker`, `--until-idle`) and harmonise `wait --idle-time` to accept humantime durations. Closes #52.
+
+**Architecture:** The cast file is already client-side accessible via `cast_reader`, and marker resolution already crosses the daemon socket. We extend `cast_reader` with range + idle-gap helpers, add one new protocol frame for "resolve next marker after offset," replace the existing `capture_since_*` client methods with `capture_slice_{raw,text}(StartBound, EndBound)`, and wire up the CLI flags with mutual-exclusion constraints.
+
+**Tech Stack:** Rust (stable), `clap` for CLI, `humantime` crate (new dep, minimal) for duration parsing. All changes live in the `cleat` crate.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-transcript-between-markers-design.md`
+
+**Conventions:**
+- Run all commands from the repo root.
+- Per `CLAUDE.md`, always run these gates: `cargo +nightly-2026-03-12 fmt --check`, `cargo build --locked`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked`. For feature-on coverage additionally: `cargo build --features ghostty-vt --locked`, `cargo clippy --workspace --all-targets --features cleat/ghostty-vt --locked -- -D warnings`, `cargo test -p cleat --features ghostty-vt --locked`.
+- `ghostty_terminal_set` and other FFI are established in prior PRs and untouched by this plan.
+- Commits are individual per task; each commit passes all seven gates. We squash/rebase at merge time if needed.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `crates/cleat/Cargo.toml` | workspace/cleat package manifest | Modify: add `humantime` dependency |
+| `crates/cleat/src/duration_parser.rs` | shared humantime+seconds parser used by `--until-idle` and `wait --idle-time` | Create |
+| `crates/cleat/src/lib.rs` | crate root — module exports | Modify: add `pub mod duration_parser;` |
+| `crates/cleat/src/cast_reader.rs` | cast-file parsing helpers | Modify: add `read_output_between` and `find_idle_gap_after` |
+| `crates/cleat/src/protocol.rs` | socket frame types | Modify: add `Frame::ResolveNextMarker { after: u64 }` + tag + encode/decode |
+| `crates/cleat/src/session.rs` | daemon session loop (serves protocol frames) | Modify: handle `ResolveNextMarker` branch |
+| `crates/cleat/src/server.rs` | client `Service` struct (wraps socket calls + cast-file reads) | Modify: retire `capture_since_*`, add `capture_slice_{raw,text}`, `resolve_next_marker_after`, define `StartBound`/`EndBound`/`SliceOutcome` |
+| `crates/cleat/src/cli.rs` | CLI flag parsing + dispatch | Modify: extend `Transcript` struct with end-bound flags, update dispatch, update `wait --idle-time` to use shared parser |
+| `crates/cleat/tests/capture_render.rs` | unit tests for capture-to-text | Modify: migrate callers from `capture_since_text` to `capture_slice_text` |
+| `crates/cleat/tests/lifecycle.rs` | end-to-end session tests | Modify: migrate `detached_session_answers_da_queries` caller; add new tests for each end-bound variant |
+
+No other files are created. No workspace-level changes needed.
+
+---
+
+## Task 1: Add humantime dep and shared duration parser
+
+**Files:**
+- Modify: `crates/cleat/Cargo.toml` (add to `[dependencies]`)
+- Create: `crates/cleat/src/duration_parser.rs`
+- Modify: `crates/cleat/src/lib.rs` (add `pub mod duration_parser;`)
+
+**Goal:** One shared parser function that accepts both humantime-suffixed strings (`500ms`, `2s`, `1m30s`) and plain numeric seconds (`2`, `0.5`). Used by `--until-idle` and `wait --idle-time`.
+
+- [ ] **Step 1: Add humantime to Cargo.toml.**
+
+Find the `[dependencies]` section of `crates/cleat/Cargo.toml`. Add:
+
+```toml
+humantime = "2"
+```
+
+Keep it alphabetically sorted if the existing deps are alphabetical.
+
+- [ ] **Step 2: Create the parser module.**
+
+Write to `crates/cleat/src/duration_parser.rs`:
+
+```rust
+//! Duration parser accepting both humantime-suffixed strings and plain
+//! numeric seconds. Used by `--until-idle` on `transcript` and
+//! `--idle-time` on `wait`.
+
+use std::time::Duration;
+
+/// Parse a duration string. Accepts:
+/// - humantime forms: `500ms`, `2s`, `1m30s`, `250us`, etc.
+/// - plain float seconds: `2`, `0.5`, `10.25`.
+///
+/// Humantime is tried first; falls back to float parsing on failure.
+pub fn parse_humantime_or_seconds(s: &str) -> Result<Duration, String> {
+    if let Ok(d) = humantime::parse_duration(s) {
+        return Ok(d);
+    }
+    s.parse::<f64>()
+        .map(Duration::from_secs_f64)
+        .map_err(|_| format!("invalid duration: {s}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_humantime_milliseconds() {
+        assert_eq!(parse_humantime_or_seconds("500ms").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn accepts_humantime_seconds() {
+        assert_eq!(parse_humantime_or_seconds("2s").unwrap(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn accepts_humantime_compound() {
+        assert_eq!(parse_humantime_or_seconds("1m30s").unwrap(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn accepts_plain_integer_seconds() {
+        assert_eq!(parse_humantime_or_seconds("2").unwrap(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn accepts_plain_float_seconds() {
+        assert_eq!(parse_humantime_or_seconds("0.5").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn rejects_invalid_input() {
+        let err = parse_humantime_or_seconds("not a duration").unwrap_err();
+        assert!(err.contains("invalid duration"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_empty_string() {
+        assert!(parse_humantime_or_seconds("").is_err());
+    }
+}
+```
+
+- [ ] **Step 3: Export the module from the crate root.**
+
+In `crates/cleat/src/lib.rs`, add alongside the existing `pub mod` declarations (keep alphabetical order):
+
+```rust
+pub mod duration_parser;
+```
+
+- [ ] **Step 4: Run the tests.**
+
+Run: `cargo test -p cleat --lib duration_parser --locked`
+
+Expected: 7 tests pass, 0 failed.
+
+- [ ] **Step 5: Run clippy.**
+
+Run: `cargo clippy --workspace --all-targets --locked -- -D warnings`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/cleat/Cargo.toml crates/cleat/src/duration_parser.rs crates/cleat/src/lib.rs
+git commit -m "duration_parser: accept humantime or plain-seconds forms"
+```
+
+---
+
+## Task 2: Extend cast_reader with range and idle-gap helpers
+
+**Files:**
+- Modify: `crates/cleat/src/cast_reader.rs`
+
+**Goal:** Two new helpers. `read_output_between(path, start, end)` reads output events in byte range `[start, end)`. `find_idle_gap_after(path, start, threshold)` scans output events starting at `start` and returns the byte offset of the *last* event before the first gap ≥ `threshold`, or `None` if no such gap exists.
+
+Existing `read_output_since` is retained — `read_output_between` is a superset but callers outside the new slice path should keep working.
+
+- [ ] **Step 1: Write failing tests.**
+
+Append to the `#[cfg(test)] mod tests { ... }` block at the end of `crates/cleat/src/cast_reader.rs` (or create one if absent):
+
+```rust
+#[cfg(test)]
+mod tests_between_and_idle {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_cast(lines: &[&str]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        for line in lines {
+            writeln!(f, "{line}").expect("write line");
+        }
+        f.flush().expect("flush");
+        f
+    }
+
+    // Minimal asciicast v3 header + three output events at 0.0s, 0.1s, 0.4s.
+    // Byte offsets computed from the known line lengths.
+    const HEADER: &str = r#"{"version":3,"term":{"cols":80,"rows":24}}"#;
+    const EVT_A: &str = r#"[0.0,"o","a"]"#;
+    const EVT_B: &str = r#"[0.1,"o","b"]"#;
+    const EVT_C: &str = r#"[0.4,"o","c"]"#;
+
+    #[test]
+    fn read_between_returns_events_in_range() {
+        let f = write_cast(&[HEADER, EVT_A, EVT_B, EVT_C]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let a_len = (EVT_A.len() + 1) as u64;
+        let b_len = (EVT_B.len() + 1) as u64;
+
+        // Range covers A and B only (ends just before C).
+        let events = read_output_between(f.path(), header_len, header_len + a_len + b_len)
+            .expect("read range");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].data, "a");
+        assert_eq!(events[1].data, "b");
+    }
+
+    #[test]
+    fn read_between_empty_when_start_equals_end() {
+        let f = write_cast(&[HEADER, EVT_A]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let events = read_output_between(f.path(), header_len, header_len).expect("read");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn find_idle_gap_detects_gap_above_threshold() {
+        let f = write_cast(&[HEADER, EVT_A, EVT_B, EVT_C]);
+        // A→B is 0.1s; B→C is 0.3s. Threshold 0.2s should match B→C gap.
+        // Slice should end at the offset *after* event B (first byte of C).
+        let header_len = (HEADER.len() + 1) as u64;
+        let a_len = (EVT_A.len() + 1) as u64;
+        let b_len = (EVT_B.len() + 1) as u64;
+        let end = find_idle_gap_after(f.path(), header_len, Duration::from_millis(200))
+            .expect("find gap");
+        assert_eq!(end, Some(header_len + a_len + b_len));
+    }
+
+    #[test]
+    fn find_idle_gap_returns_none_when_no_gap_big_enough() {
+        let f = write_cast(&[HEADER, EVT_A, EVT_B, EVT_C]);
+        let header_len = (HEADER.len() + 1) as u64;
+        // Threshold 1s; no gap in fixture is that large.
+        let end = find_idle_gap_after(f.path(), header_len, Duration::from_secs(1))
+            .expect("find gap");
+        assert_eq!(end, None);
+    }
+
+    #[test]
+    fn find_idle_gap_returns_none_on_empty_range() {
+        let f = write_cast(&[HEADER]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let end = find_idle_gap_after(f.path(), header_len, Duration::from_millis(100))
+            .expect("find gap");
+        assert_eq!(end, None);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests — expect fail.**
+
+Run: `cargo test -p cleat --lib cast_reader::tests_between_and_idle --locked`
+
+Expected: FAIL — functions `read_output_between` and `find_idle_gap_after` don't exist.
+
+- [ ] **Step 3: Implement `read_output_between`.**
+
+In `crates/cleat/src/cast_reader.rs`, near the top (after the module-level doc comment or after the existing `read_output_since`), add:
+
+```rust
+/// Read all output (`"o"`) events whose starting byte offset is in `[start, end)`.
+///
+/// When `start` is 0, the header line is skipped automatically.
+/// Returns an empty vec if `start >= end` or `start` is at/beyond EOF.
+pub fn read_output_between(path: &Path, start: u64, end: u64) -> Result<Vec<Event>, String> {
+    if start >= end {
+        return Ok(Vec::new());
+    }
+    read_events_between(path, start, end, Some(EventCode::Output))
+}
+
+fn read_events_between(
+    path: &Path,
+    start: u64,
+    end: u64,
+    filter: Option<EventCode>,
+) -> Result<Vec<Event>, String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("open {path:?}: {e}"))?;
+    let mut reader = BufReader::new(file);
+
+    if start > 0 {
+        reader.seek(SeekFrom::Start(start)).map_err(|e| format!("seek: {e}"))?;
+    }
+
+    let mut events = Vec::new();
+    let mut line = String::new();
+    let mut byte_pos = start;
+    let mut prev_time = Duration::ZERO;
+    let mut first_line = start == 0;
+
+    loop {
+        if byte_pos >= end {
+            break;
+        }
+        line.clear();
+        let n = reader.read_line(&mut line).map_err(|e| format!("read line: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        let line_start = byte_pos;
+        byte_pos += n as u64;
+
+        if first_line {
+            // Skip header.
+            first_line = false;
+            continue;
+        }
+
+        // Only include events whose *line start* is inside the range.
+        if line_start >= end {
+            break;
+        }
+
+        let trimmed = line.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            continue;
+        }
+        match decode_event(trimmed, prev_time) {
+            Ok((event, next_time)) => {
+                prev_time = next_time;
+                let matches_filter = filter.map_or(true, |code| event.code == code);
+                if matches_filter {
+                    events.push(event);
+                }
+            }
+            Err(_) => {
+                // Skip unparseable lines (same behavior as existing read_events_since).
+                continue;
+            }
+        }
+    }
+
+    Ok(events)
+}
+```
+
+If the existing `read_events_since` has a similar private helper, factor out common code only if you can do it without changing observable behavior of the existing function. If in doubt, keep the two as separate private helpers — duplication is cheaper than subtle regressions here.
+
+- [ ] **Step 4: Implement `find_idle_gap_after`.**
+
+Add to `cast_reader.rs`:
+
+```rust
+/// Scan output events starting at `start` and return the byte offset of the
+/// *first byte after the last output event before* the first inter-event gap
+/// whose duration is ≥ `threshold`.
+///
+/// Returns `Ok(None)` if no such gap is found before EOF.
+///
+/// Only output (`"o"`) events participate in gap detection. Non-output events
+/// (markers, snapshots, etc.) are skipped.
+pub fn find_idle_gap_after(path: &Path, start: u64, threshold: Duration) -> Result<Option<u64>, String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("open {path:?}: {e}"))?;
+    let mut reader = BufReader::new(file);
+
+    if start > 0 {
+        reader.seek(SeekFrom::Start(start)).map_err(|e| format!("seek: {e}"))?;
+    }
+
+    let mut line = String::new();
+    let mut byte_pos = start;
+    let mut prev_time = Duration::ZERO;
+    let mut first_line = start == 0;
+    let mut last_output_end: Option<u64> = None;
+    let mut last_output_time: Option<Duration> = None;
+
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).map_err(|e| format!("read line: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        let line_start = byte_pos;
+        byte_pos += n as u64;
+
+        if first_line {
+            first_line = false;
+            continue;
+        }
+
+        let trimmed = line.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match decode_event(trimmed, prev_time) {
+            Ok((event, next_time)) => {
+                prev_time = next_time;
+                if event.code != EventCode::Output {
+                    continue;
+                }
+                // Compute absolute timestamp of *this* event. Since `prev_time`
+                // tracks cumulative time relative to the seek point, event.time
+                // relative to the previous is (next_time - prev_time_before).
+                // But we just need inter-event deltas among output events.
+                if let Some(prev_t) = last_output_time {
+                    let gap = next_time.saturating_sub(prev_t);
+                    if gap >= threshold {
+                        // The gap between the previous output event and this one
+                        // meets the threshold. Slice should end at the start of
+                        // this event, i.e., last_output_end.
+                        return Ok(last_output_end);
+                    }
+                }
+                last_output_time = Some(next_time);
+                last_output_end = Some(byte_pos);
+            }
+            Err(_) => continue,
+        }
+        // avoid unused assignment warnings if we never entered the Ok arm
+        let _ = line_start;
+    }
+
+    Ok(None)
+}
+```
+
+- [ ] **Step 5: Run the tests — expect pass.**
+
+Run: `cargo test -p cleat --lib cast_reader::tests_between_and_idle --locked`
+
+Expected: 5 tests pass, 0 failed.
+
+If a test fails, most likely causes:
+- Byte offset arithmetic off-by-one: the `+1` in `(HEADER.len() + 1)` accounts for the trailing newline written by `writeln!`. Verify the fixture matches.
+- Gap-detection timing: `decode_event` returns cumulative time relative to the seek point, not delta. Two consecutive output events produce a gap equal to `next_time - prev_output_time`. Trace through the test values: A at 0.0, B at 0.1, C at 0.4. `threshold=200ms` ⇒ first matching gap is B→C (300ms ≥ 200ms), so end is offset-after-B.
+
+- [ ] **Step 6: Run full gates.**
+
+```bash
+cargo +nightly-2026-03-12 fmt --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --locked
+```
+
+All green.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add crates/cleat/src/cast_reader.rs
+git commit -m "cast_reader: add read_output_between and find_idle_gap_after"
+```
+
+---
+
+## Task 3: Add `Frame::ResolveNextMarker` to protocol
+
+**Files:**
+- Modify: `crates/cleat/src/protocol.rs`
+
+**Goal:** New request frame for "give me the marker with smallest offset strictly greater than N." Response reuses the existing `Frame::MarkResult { offset }` variant for success, or `Frame::Error` for "no such marker."
+
+- [ ] **Step 1: Write a round-trip test for the new frame.**
+
+Find the existing `mod tests` block in `crates/cleat/src/protocol.rs` (around the `resolve_marker_round_trip` test). Add:
+
+```rust
+    #[test]
+    fn resolve_next_marker_round_trip() {
+        let frame = Frame::ResolveNextMarker { after: 12345 };
+        let mut buf = Vec::new();
+        frame.write(&mut buf).expect("write");
+        let decoded = Frame::read(&mut std::io::Cursor::new(buf)).expect("read");
+        assert_eq!(frame, decoded);
+    }
+```
+
+- [ ] **Step 2: Run the test — expect compile error.**
+
+Run: `cargo test -p cleat --lib protocol::tests::resolve_next_marker --locked`
+
+Expected: compile error — `Frame::ResolveNextMarker` doesn't exist.
+
+- [ ] **Step 3: Declare the new tag.**
+
+Near the other `const TAG_*` definitions in `crates/cleat/src/protocol.rs`, find the highest existing tag number and add the next sequential value:
+
+```rust
+const TAG_RESOLVE_NEXT_MARKER: u8 = 24;
+```
+
+(Use whatever value is one higher than the current maximum; 24 is illustrative — inspect the file and pick the next unused number.)
+
+- [ ] **Step 4: Add the enum variant.**
+
+In the `Frame` enum definition, add a new variant:
+
+```rust
+    ResolveNextMarker { after: u64 },
+```
+
+Place it alphabetically among the existing variants, or next to `ResolveMarker` if the existing ordering is semantic. Follow the file's existing convention.
+
+- [ ] **Step 5: Add encode/decode arms.**
+
+In `Frame::encode`, add the match arm:
+
+```rust
+            Frame::ResolveNextMarker { after } => {
+                let mut payload = Vec::with_capacity(8);
+                payload.extend_from_slice(&after.to_le_bytes());
+                (TAG_RESOLVE_NEXT_MARKER, payload)
+            }
+```
+
+In `Frame::decode`, add the match arm:
+
+```rust
+            TAG_RESOLVE_NEXT_MARKER => {
+                if payload.len() != 8 {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        format!("ResolveNextMarker payload must be 8 bytes, got {}", payload.len()),
+                    ));
+                }
+                let after = u64::from_le_bytes(payload[..8].try_into().expect("len checked"));
+                Ok(Frame::ResolveNextMarker { after })
+            }
+```
+
+- [ ] **Step 6: Run the test — expect pass.**
+
+Run: `cargo test -p cleat --lib protocol::tests::resolve_next_marker --locked`
+
+Expected: PASS.
+
+- [ ] **Step 7: Full gates.**
+
+```bash
+cargo +nightly-2026-03-12 fmt --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --locked
+```
+
+All green.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add crates/cleat/src/protocol.rs
+git commit -m "protocol: add ResolveNextMarker { after } frame"
+```
+
+---
+
+## Task 4: Daemon handles `ResolveNextMarker`
+
+**Files:**
+- Modify: `crates/cleat/src/session.rs`
+
+**Goal:** When the daemon receives `Frame::ResolveNextMarker { after }`, scan the in-memory marker table for the minimum offset strictly greater than `after`, and respond with `Frame::MarkResult { offset }` or `Frame::Error` if no such marker exists.
+
+- [ ] **Step 1: Locate the existing `Frame::ResolveMarker` handler.**
+
+In `crates/cleat/src/session.rs`, search for `Frame::ResolveMarker`. The surrounding match arm shows how marker responses are sent back to clients. Read a few lines of context before proceeding.
+
+- [ ] **Step 2: Add the handler arm.**
+
+Next to the existing `ResolveMarker` handler, add:
+
+```rust
+                Frame::ResolveNextMarker { after } => {
+                    let next = markers
+                        .iter()
+                        .filter(|(_, &offset)| offset > after)
+                        .map(|(_, &offset)| offset)
+                        .min();
+                    let reply = match next {
+                        Some(offset) => Frame::MarkResult { offset },
+                        None => Frame::Error(format!("no marker after offset {after}")),
+                    };
+                    if let Err(err) = reply.write(&mut stream) {
+                        eprintln!("write resolve-next response: {err}");
+                    }
+                }
+```
+
+The exact variable name for the markers map may differ; use the same name the `ResolveMarker` arm uses (probably `markers`).
+
+- [ ] **Step 3: Build to verify the branch compiles.**
+
+Run: `cargo build --locked`
+
+Expected: clean build.
+
+- [ ] **Step 4: Commit the daemon handler (tests arrive in Task 5).**
+
+```bash
+git add crates/cleat/src/session.rs
+git commit -m "session: handle ResolveNextMarker frame (client method lands in next commit)"
+```
+
+The handler is untested at this point; a lifecycle test exercising it through a client method arrives in Task 5 Step 6. This keeps every commit compiling cleanly.
+
+---
+
+## Task 5: Service client — new methods
+
+**Files:**
+- Modify: `crates/cleat/src/server.rs`
+
+**Goal:** Three new methods on `Service`:
+1. `resolve_next_marker_after(id, after) -> Result<u64, String>` — sends `Frame::ResolveNextMarker` and parses response.
+2. `capture_slice_raw(id, start, end) -> Result<(String, SliceOutcome), String>` — the full slicing entry point.
+3. `capture_slice_text(id, start, end)` — same shape, returns VT-rendered text (though today's implementation just concatenates output, same as `capture_slice_raw`; the separation is forward-looking).
+
+Also introduce the `StartBound`, `EndBound`, and `SliceOutcome` types.
+
+- [ ] **Step 1: Write failing tests.**
+
+The existing file `crates/cleat/tests/capture_render.rs` already has a test helper `setup_session_with_cast(root, id, events)` (at line 10) that writes a cast file with an arbitrary event list, and uses `SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()))` to construct the client. Reuse these. Add:
+
+```rust
+#[test]
+fn capture_slice_text_returns_bytes_through_eof_with_start_at_zero() {
+    use cleat::server::{EndBound, StartBound};
+
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![
+        Event { time: Duration::from_millis(100), code: EventCode::Output, data: "hello ".into() },
+        Event { time: Duration::from_millis(200), code: EventCode::Output, data: "world".into() },
+    ];
+    setup_session_with_cast(temp.path(), "sess", &events);
+    let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+
+    let (text, outcome) = service
+        .capture_slice_text("sess", StartBound::Offset(0), EndBound::EndOfRecording)
+        .expect("slice");
+    assert_eq!(text, "hello world");
+    assert!(outcome.hit_intended_end);
+    assert_eq!(outcome.start_offset, 0);
+    // end_offset equals the file size; don't hardcode it — compute from the fixture
+    let file_size = std::fs::metadata(temp.path().join("sess").join(CAST_FILE_NAME)).unwrap().len();
+    assert_eq!(outcome.end_offset, file_size);
+}
+
+#[test]
+fn capture_slice_text_idle_fallback_to_eof_populates_fallback_reason() {
+    use cleat::server::{EndBound, StartBound};
+
+    let temp = tempfile::tempdir().unwrap();
+    // Two close-together events — no 10-second gap exists.
+    let events = vec![
+        Event { time: Duration::from_millis(100), code: EventCode::Output, data: "a".into() },
+        Event { time: Duration::from_millis(200), code: EventCode::Output, data: "b".into() },
+    ];
+    setup_session_with_cast(temp.path(), "sess", &events);
+    let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+
+    let (text, outcome) = service
+        .capture_slice_text(
+            "sess",
+            StartBound::Offset(0),
+            EndBound::IdleGap(Duration::from_secs(10)),
+        )
+        .expect("slice");
+    assert_eq!(text, "ab");  // all events returned (EOF fallback)
+    assert!(!outcome.hit_intended_end);
+    assert_eq!(outcome.fallback_reason.as_deref(), Some("no 10s idle found"));
+}
+```
+
+These exercise the orchestration layer (`capture_slice_inner`). Fine-grained idle-gap math is already unit-tested in Task 2's cast_reader tests.
+
+- [ ] **Step 2: Run the tests — expect compile errors (types don't exist).**
+
+- [ ] **Step 3: Define the public types.**
+
+In `crates/cleat/src/server.rs`, near the top (after existing imports):
+
+```rust
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartBound {
+    Offset(u64),
+    Marker(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EndBound {
+    Offset(u64),
+    Marker(String),
+    NextMarker,
+    IdleGap(Duration),
+    EndOfRecording,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SliceOutcome {
+    pub start_offset: u64,
+    pub end_offset: u64,
+    pub hit_intended_end: bool,
+    pub fallback_reason: Option<String>,
+}
+```
+
+- [ ] **Step 4: Implement `resolve_next_marker_after`.**
+
+Next to the existing `resolve_marker` method in `server.rs`:
+
+```rust
+    pub fn resolve_next_marker_after(&self, id: &str, after: u64) -> Result<u64, String> {
+        if !self.layout.root().join(id).exists() {
+            return Err(format!("missing session {id}"));
+        }
+        let socket_path = session_socket_path(self.layout.root(), id);
+        let mut stream = connect_session_socket(&socket_path)?;
+        Frame::ResolveNextMarker { after }
+            .write(&mut stream)
+            .map_err(|e| format!("write resolve-next: {e}"))?;
+        match Frame::read(&mut stream).map_err(|e| format!("read resolve-next response: {e}"))? {
+            Frame::MarkResult { offset } => Ok(offset),
+            Frame::Error(msg) => Err(msg),
+            other => Err(format!("unexpected resolve-next response: {other:?}")),
+        }
+    }
+```
+
+- [ ] **Step 5: Implement `capture_slice_raw` and `capture_slice_text`.**
+
+Add to `server.rs`, next to the existing `capture_since_*` methods:
+
+```rust
+    pub fn capture_slice_raw(
+        &self,
+        id: &str,
+        start: StartBound,
+        end: EndBound,
+    ) -> Result<(String, SliceOutcome), String> {
+        self.capture_slice_inner(id, start, end)
+    }
+
+    pub fn capture_slice_text(
+        &self,
+        id: &str,
+        start: StartBound,
+        end: EndBound,
+    ) -> Result<(String, SliceOutcome), String> {
+        // Today the two produce identical output; separation is for future
+        // VT-rendered transcripts. Same body.
+        self.capture_slice_inner(id, start, end)
+    }
+
+    fn capture_slice_inner(
+        &self,
+        id: &str,
+        start: StartBound,
+        end: EndBound,
+    ) -> Result<(String, SliceOutcome), String> {
+        let cast_path = self.layout.root().join(id).join(crate::recording::CAST_FILE_NAME);
+        if !cast_path.exists() {
+            return Err(format!("no recording for session {id}"));
+        }
+
+        let start_offset = match start {
+            StartBound::Offset(o) => o,
+            StartBound::Marker(name) => self.resolve_marker(id, &name)?,
+        };
+
+        // Resolve end to either a concrete byte offset or a signal that we
+        // need to scan for an idle gap.
+        let (end_offset, hit_intended_end, fallback_reason) = match end {
+            EndBound::EndOfRecording => {
+                let file_size = std::fs::metadata(&cast_path)
+                    .map_err(|e| format!("stat cast file: {e}"))?
+                    .len();
+                (file_size, true, None)
+            }
+            EndBound::Offset(o) => (o, true, None),
+            EndBound::Marker(name) => {
+                let o = self.resolve_marker(id, &name)?;
+                if o < start_offset {
+                    return Err(format!("marker '{name}' precedes start"));
+                }
+                (o, true, None)
+            }
+            EndBound::NextMarker => {
+                match self.resolve_next_marker_after(id, start_offset) {
+                    Ok(o) => (o, true, None),
+                    Err(msg) if msg.contains("no marker") => {
+                        let file_size = std::fs::metadata(&cast_path)
+                            .map_err(|e| format!("stat cast file: {e}"))?
+                            .len();
+                        (file_size, false, Some("no marker after start".to_string()))
+                    }
+                    Err(msg) => return Err(msg),
+                }
+            }
+            EndBound::IdleGap(duration) => {
+                match crate::cast_reader::find_idle_gap_after(&cast_path, start_offset, duration)? {
+                    Some(o) => (o, true, None),
+                    None => {
+                        let file_size = std::fs::metadata(&cast_path)
+                            .map_err(|e| format!("stat cast file: {e}"))?
+                            .len();
+                        (
+                            file_size,
+                            false,
+                            Some(format!("no {} idle found", humantime::format_duration(duration))),
+                        )
+                    }
+                }
+            }
+        };
+
+        let events = crate::cast_reader::read_output_between(&cast_path, start_offset, end_offset)?;
+        let output: String = events.iter().map(|e| e.data.as_str()).collect();
+        Ok((
+            output,
+            SliceOutcome {
+                start_offset,
+                end_offset,
+                hit_intended_end,
+                fallback_reason,
+            },
+        ))
+    }
+```
+
+- [ ] **Step 6: Add lifecycle test exercising `resolve_next_marker_after` end-to-end.**
+
+In `crates/cleat/tests/lifecycle.rs`, using the pattern of `detached_session_answers_da_queries`:
+
+```rust
+#[test]
+fn resolve_next_marker_returns_minimum_offset_above() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), None, None, Some("sh -c 'stty raw; exec cat'".into()), true).expect("create");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let off_a = service.mark("alpha").expect("mark a");
+    service.send_keys("alpha", b"x").expect("send x");
+    std::thread::sleep(Duration::from_millis(300));
+    let off_b = service.mark("alpha").expect("mark b");
+    service.send_keys("alpha", b"y").expect("send y");
+    std::thread::sleep(Duration::from_millis(300));
+    let off_c = service.mark("alpha").expect("mark c");
+
+    // Next marker after A should be B (smallest offset > A).
+    assert_eq!(service.resolve_next_marker_after("alpha", off_a).expect("resolve"), off_b);
+    // Next after B should be C.
+    assert_eq!(service.resolve_next_marker_after("alpha", off_b).expect("resolve"), off_c);
+    // Next after C should be a not-found error.
+    let err = service.resolve_next_marker_after("alpha", off_c).unwrap_err();
+    assert!(err.contains("no marker"), "expected not-found error, got: {err}");
+}
+```
+
+- [ ] **Step 7: Run targeted tests.**
+
+Run:
+
+```bash
+cargo test -p cleat --test capture_render --locked
+cargo test -p cleat --test lifecycle resolve_next_marker --locked
+```
+
+Expected: new tests pass.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add crates/cleat/src/server.rs crates/cleat/tests/capture_render.rs crates/cleat/tests/lifecycle.rs
+git commit -m "server: add StartBound/EndBound/SliceOutcome + capture_slice_{raw,text} + resolve_next_marker_after"
+```
+
+---
+
+## Task 6: Retire `capture_since_*` methods and migrate callers
+
+**Files:**
+- Modify: `crates/cleat/src/server.rs` (remove `capture_since_raw`, `capture_since_text`)
+- Modify: `crates/cleat/src/cli.rs` (update Transcript dispatch to use `capture_slice_text` / `capture_slice_raw`)
+- Modify: `crates/cleat/tests/capture_render.rs` (migrate 4 existing test callers)
+- Modify: `crates/cleat/tests/lifecycle.rs` (migrate `detached_session_answers_da_queries` caller)
+
+**Goal:** Single entry point for all cast-file slicing, per the spec's "retire rather than keep both forms" decision.
+
+- [ ] **Step 1: Migrate `tests/capture_render.rs` callers.**
+
+Find the four `service.capture_since_text(...)` and `service.capture_since_raw(...)` calls. Replace each with the equivalent `capture_slice_text` / `capture_slice_raw` call:
+
+```rust
+// Before:
+let result = service.capture_since_text("sess", 0).unwrap();
+
+// After:
+let (result, _outcome) = service.capture_slice_text(
+    "sess",
+    StartBound::Offset(0),
+    EndBound::EndOfRecording,
+).unwrap();
+```
+
+Add `use cleat::server::{StartBound, EndBound};` (or equivalent, matching the existing import pattern) at the top of the file if needed.
+
+- [ ] **Step 2: Migrate `tests/lifecycle.rs` caller.**
+
+In the test `detached_session_answers_da_queries` (around line 458), replace:
+
+```rust
+let output = service.capture_since_raw("alpha", offset).expect("capture since");
+```
+
+with:
+
+```rust
+let (output, _outcome) = service
+    .capture_slice_raw("alpha", StartBound::Offset(offset), EndBound::EndOfRecording)
+    .expect("capture slice");
+```
+
+- [ ] **Step 3: Migrate `cli.rs` Transcript dispatch.**
+
+In `crates/cleat/src/cli.rs` around line 380, replace the existing Transcript handler with one using the new methods. Full replacement will be done as part of Task 7 (adding end-bound flags) — for now, just switch the call target, keeping the existing flag set:
+
+```rust
+Command::Transcript { id, since, since_marker, raw } => {
+    let start = match (since, since_marker) {
+        (Some(o), None) => StartBound::Offset(o),
+        (None, Some(name)) => StartBound::Marker(name),
+        (None, None) => {
+            return ExecResult::Err("transcript requires --since or --since-marker".to_string());
+        }
+        _ => unreachable!("clap conflicts_with prevents this"),
+    };
+    let result = if raw {
+        service.capture_slice_raw(&id, start, EndBound::EndOfRecording)
+    } else {
+        service.capture_slice_text(&id, start, EndBound::EndOfRecording)
+    };
+    match result {
+        Ok((s, _outcome)) => ExecResult::Ok(Some(s)),
+        Err(e) => ExecResult::Err(e),
+    }
+}
+```
+
+Add imports at the top of `cli.rs` for `StartBound` and `EndBound`.
+
+- [ ] **Step 4: Remove `capture_since_raw` and `capture_since_text` from `server.rs`.**
+
+Delete lines around server.rs:160-180 (the two method definitions). Keep `resolve_marker` and all other methods.
+
+- [ ] **Step 5: Build and run all tests.**
+
+```bash
+cargo build --locked
+cargo test --workspace --locked
+```
+
+Expected: clean build, all tests pass. If any test fails with "method not found," it's a missed migration — grep for `capture_since_` to find the remaining caller.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/cleat/src/server.rs crates/cleat/src/cli.rs crates/cleat/tests/capture_render.rs crates/cleat/tests/lifecycle.rs
+git commit -m "server: retire capture_since_* in favor of capture_slice_*; migrate callers"
+```
+
+---
+
+## Task 7: CLI — add end-bound flags and dispatch
+
+**Files:**
+- Modify: `crates/cleat/src/cli.rs`
+
+**Goal:** Extend `Command::Transcript` with four new end-bound flags (mutually exclusive), wire dispatch to build `EndBound`, and emit the stderr fallback note when appropriate.
+
+- [ ] **Step 1: Extend the `Transcript` struct.**
+
+Find `Command::Transcript { ... }` in `cli.rs` (around line 103). Add these fields alongside the existing `since`, `since_marker`, `raw`:
+
+```rust
+        /// Byte offset in .cast file; slice ends at this position.
+        #[arg(long, conflicts_with_all = ["until_marker", "until_next_marker", "until_idle"])]
+        until: Option<u64>,
+        /// Named marker to use as the end offset.
+        #[arg(long, conflicts_with_all = ["until", "until_next_marker", "until_idle"])]
+        until_marker: Option<String>,
+        /// Slice until the chronologically-next marker after the start.
+        #[arg(long, conflicts_with_all = ["until", "until_marker", "until_idle"])]
+        until_next_marker: bool,
+        /// Slice until the recording is idle for this duration (e.g., 500ms, 2s).
+        #[arg(long, value_parser = crate::duration_parser::parse_humantime_or_seconds, conflicts_with_all = ["until", "until_marker", "until_next_marker"])]
+        until_idle: Option<std::time::Duration>,
+```
+
+- [ ] **Step 2: Extend the dispatch.**
+
+Replace the Transcript handler implemented in Task 6 with one that covers all end-bound variants:
+
+```rust
+Command::Transcript { id, since, since_marker, until, until_marker, until_next_marker, until_idle, raw } => {
+    let start = match (since, since_marker) {
+        (Some(o), None) => StartBound::Offset(o),
+        (None, Some(name)) => StartBound::Marker(name),
+        (None, None) => {
+            return ExecResult::Err("transcript requires --since or --since-marker".to_string());
+        }
+        _ => unreachable!("clap conflicts_with prevents this"),
+    };
+
+    let end = match (until, until_marker, until_next_marker, until_idle) {
+        (Some(o), None, false, None) => EndBound::Offset(o),
+        (None, Some(name), false, None) => EndBound::Marker(name),
+        (None, None, true, None) => EndBound::NextMarker,
+        (None, None, false, Some(d)) => EndBound::IdleGap(d),
+        (None, None, false, None) => EndBound::EndOfRecording,
+        _ => unreachable!("clap conflicts_with prevents this"),
+    };
+
+    let result = if raw {
+        service.capture_slice_raw(&id, start, end)
+    } else {
+        service.capture_slice_text(&id, start, end)
+    };
+    match result {
+        Ok((s, outcome)) => {
+            if !outcome.hit_intended_end {
+                if let Some(reason) = &outcome.fallback_reason {
+                    eprintln!("# bounded by EOF ({reason})");
+                }
+            }
+            ExecResult::Ok(Some(s))
+        }
+        Err(e) => ExecResult::Err(e),
+    }
+}
+```
+
+- [ ] **Step 3: Build.**
+
+Run: `cargo build --locked`
+
+Expected: clean build. If clap complains about `conflicts_with_all` on boolean flag, use the `conflicts_with` array syntax with `#[arg(long, action = ArgAction::SetTrue, conflicts_with_all = [...])]` — check clap 4.x docs for the right form.
+
+- [ ] **Step 4: Add CLI-level integration tests.**
+
+Append to `crates/cleat/tests/lifecycle.rs`:
+
+```rust
+#[test]
+fn transcript_between_two_named_markers_returns_exact_range() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), None, None, Some("sh -c 'stty raw; exec cat'".into()), true).expect("create");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    service.named_mark("alpha", "m1").expect("mark m1");
+    service.send_keys("alpha", b"first").expect("send first");
+    std::thread::sleep(Duration::from_millis(300));
+    service.named_mark("alpha", "m2").expect("mark m2");
+    service.send_keys("alpha", b"second").expect("send second");
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Slice between m1 and m2.
+    let cli = Cli::try_parse_from([
+        "cleat", "transcript", "alpha", "--since-marker", "m1", "--until-marker", "m2",
+    ]).expect("parse");
+    let result = cli::execute(cli, &service).expect("execute");
+    let output = result.expect("output");
+    assert!(output.contains("first"), "expected 'first' in output, got: {output:?}");
+    assert!(!output.contains("second"), "did not expect 'second', got: {output:?}");
+}
+
+#[test]
+fn transcript_until_idle_terminates_at_quiet_period() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), None, None, Some("sh -c 'stty raw; exec cat'".into()), true).expect("create");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    service.named_mark("alpha", "start").expect("mark");
+    service.send_keys("alpha", b"burst").expect("send burst");
+    std::thread::sleep(Duration::from_millis(1000)); // idle gap
+    service.send_keys("alpha", b"after").expect("send after");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let cli = Cli::try_parse_from([
+        "cleat", "transcript", "alpha", "--since-marker", "start", "--until-idle", "500ms",
+    ]).expect("parse");
+    let result = cli::execute(cli, &service).expect("execute");
+    let output = result.expect("output");
+    assert!(output.contains("burst"), "expected 'burst' in output");
+    assert!(!output.contains("after"), "idle gap should have terminated slice before 'after'");
+}
+```
+
+Note: `service.named_mark(id, name)` is the confirmed API (`crates/cleat/src/server.rs:282`). Returns the offset placed.
+
+- [ ] **Step 5: Run tests.**
+
+```bash
+cargo test -p cleat --test lifecycle transcript_ --locked
+```
+
+Expected: new tests pass.
+
+- [ ] **Step 6: Full gates.**
+
+```bash
+cargo +nightly-2026-03-12 fmt --check
+cargo build --locked
+cargo build --features ghostty-vt --locked
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo clippy --workspace --all-targets --features cleat/ghostty-vt --locked -- -D warnings
+cargo test --workspace --locked
+cargo test -p cleat --features ghostty-vt --locked
+```
+
+All green.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add crates/cleat/src/cli.rs crates/cleat/tests/lifecycle.rs
+git commit -m "cli: add end-bound flags to transcript (--until, --until-marker, --until-next-marker, --until-idle)"
+```
+
+---
+
+## Task 8: `wait --idle-time` humantime harmonisation
+
+**Files:**
+- Modify: `crates/cleat/src/cli.rs`
+
+**Goal:** `wait --idle-time` accepts both the existing plain-float-seconds form and humantime-suffixed durations, backwards-compatibly. Uses the same `parse_humantime_or_seconds` from Task 1.
+
+- [ ] **Step 1: Locate the `Wait` variant.**
+
+In `cli.rs`, search for `Wait {`. The `--idle-time` flag currently has type `Option<f64>` or similar.
+
+- [ ] **Step 2: Change the flag type and parser.**
+
+Replace the `idle_time` field with:
+
+```rust
+        /// Wait until output settles for this duration (e.g., 500ms, 2s, or plain seconds).
+        #[arg(long, value_parser = crate::duration_parser::parse_humantime_or_seconds)]
+        idle_time: Option<std::time::Duration>,
+```
+
+Update the help-text-only content in the `Wait` command help (the trailing doc-string under `Usage:`) to reflect the new format acceptance if applicable.
+
+- [ ] **Step 3: Update the dispatch to use the Duration.**
+
+Find the `Command::Wait { .. }` arm. Where `idle_time` is converted to `WaitCondition::IdleTime(seconds)`, adapt the conversion:
+
+```rust
+// Before (likely):
+conditions.push(WaitCondition::IdleTime(t));  // t: f64 seconds
+
+// After:
+conditions.push(WaitCondition::IdleTime(d.as_secs_f64()));  // d: Duration
+```
+
+If `WaitCondition::IdleTime` already takes `f64`, keep the f64 interface (don't touch the wait protocol) — convert on the CLI side at dispatch time.
+
+- [ ] **Step 4: Add a test.**
+
+In `crates/cleat/tests/lifecycle.rs` or wherever wait is tested, add:
+
+```rust
+#[test]
+fn wait_idle_time_accepts_humantime_and_seconds() {
+    // Both forms parse and dispatch equivalently.
+    let humantime_form = Cli::try_parse_from(["cleat", "wait", "x", "--idle-time", "500ms"]).expect("humantime parse");
+    let seconds_form = Cli::try_parse_from(["cleat", "wait", "x", "--idle-time", "0.5"]).expect("seconds parse");
+    // ... assert the parsed command carries Duration::from_millis(500) in both cases.
+}
+```
+
+The exact assertion depends on how the parsed `Cli` exposes the inner fields; match the existing pattern for wait tests in the same file.
+
+- [ ] **Step 5: Run tests.**
+
+```bash
+cargo test -p cleat wait --locked
+```
+
+Expected: existing wait tests still pass, new test passes.
+
+- [ ] **Step 6: Full gates.**
+
+Same seven-command gate sweep as Task 7, Step 6.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add crates/cleat/src/cli.rs crates/cleat/tests/lifecycle.rs
+git commit -m "wait: accept humantime durations on --idle-time (backwards-compatible)"
+```
+
+---
+
+## Task 9: Final validation sweep
+
+**Goal:** Confirm every gate CLAUDE.md specifies is green.
+
+- [ ] **Step 1: fmt.**
+
+Run: `cargo +nightly-2026-03-12 fmt --check`
+
+Expected: no output.
+
+- [ ] **Step 2: Build, feature off.**
+
+Run: `cargo build --locked`
+
+Expected: clean.
+
+- [ ] **Step 3: Build, feature on.**
+
+Run: `cargo build --features ghostty-vt --locked`
+
+Expected: clean.
+
+- [ ] **Step 4: Clippy, feature off.**
+
+Run: `cargo clippy --workspace --all-targets --locked -- -D warnings`
+
+Expected: clean.
+
+- [ ] **Step 5: Clippy, feature on.**
+
+Run: `cargo clippy --workspace --all-targets --features cleat/ghostty-vt --locked -- -D warnings`
+
+Expected: clean.
+
+- [ ] **Step 6: Tests, feature off.**
+
+Run: `cargo test --workspace --locked`
+
+Expected: all pass.
+
+- [ ] **Step 7: Tests, feature on.**
+
+Run: `cargo test -p cleat --features ghostty-vt --locked`
+
+Expected: all pass.
+
+- [ ] **Step 8: Release build, feature on.**
+
+Run: `cargo build -p cleat --features ghostty-vt --locked --release`
+
+Expected: clean.
+
+- [ ] **Step 9: Manual smoke (optional but valuable).**
+
+```bash
+./target/debug/cleat launch --record demo --cmd bash
+./target/debug/cleat send demo 'echo hello' --mark-before m1
+./target/debug/cleat send demo 'echo world'
+sleep 1
+./target/debug/cleat mark demo --name m2
+./target/debug/cleat transcript demo --since-marker m1 --until-marker m2
+./target/debug/cleat kill demo
+```
+
+Expect the transcript output to contain `hello` (the first echo) and the `echo world` command, but terminate at m2.
+
+No commit for this task — it's the merge gate.

--- a/docs/superpowers/specs/2026-04-22-transcript-between-markers-design.md
+++ b/docs/superpowers/specs/2026-04-22-transcript-between-markers-design.md
@@ -1,0 +1,232 @@
+# `transcript` end-bounds design
+
+**Date:** 2026-04-22
+**Issue:** [#52](https://github.com/flotilla-org/cleat/issues/52)
+
+## Problem
+
+`cleat transcript` today accepts a start bound only: `--since <offset>` or `--since-marker <name>`. Slicing to a specific later point requires hand-trimming the output. Agents repeatedly hit three end-bound needs:
+
+1. Slice between two named markers
+2. Slice from a marker until the recording goes idle (the "one step settled" pattern)
+3. Slice from a marker until the next marker, whatever its name
+
+This spec adds those end-bounds as first-class flags, with a consistent soft-ceiling behaviour when an end-bound is not reached.
+
+## Scope
+
+**In scope**
+- Four new end-bound flags on `transcript`
+- humantime duration parsing for `--until-idle`
+- Backwards-compatible humantime upgrade on `wait --idle-time`
+- Daemon-side slicing with new `StartBound` / `EndBound` enums passed across the service layer
+
+**Out of scope**
+- `expect` — waits for text appearance; end-bounds don't fit its shape
+- `capture` — captures current screen, no slicing concept
+- JSON output mode on `transcript` — separate feature
+- `expect --timeout` humantime conversion — scope creep from `wait --idle-time`
+
+## Flag surface
+
+```
+cleat transcript <id>
+  [--since <offset> | --since-marker <name>]
+  [--until <offset> | --until-marker <name> | --until-next-marker | --until-idle <duration>]
+  [--raw]
+```
+
+- **Start bounds** are unchanged and already mutually exclusive via `conflicts_with`.
+- **End bounds** are mutually exclusive among themselves. Enforced via `conflicts_with` on each flag.
+- **Start and end bounds compose freely** — any start can pair with any end.
+- **Omitted end bound** means "to end of recording," matching today's behaviour.
+- **`--until-idle`** accepts humantime-suffixed durations: `500ms`, `2s`, `1m30s`.
+
+### `wait --idle-time` harmonisation
+
+`wait --idle-time` today accepts plain seconds (`--idle-time 2`). This spec extends it to accept either form:
+
+- Plain numeric (`2`, `0.5`) → seconds, as today
+- humantime-suffixed (`500ms`, `2s`) → parsed via `humantime`
+
+Backwards-compatible. Implemented as a custom clap value parser that tries humantime first, then falls back to `f64`. The same parser is used for `--until-idle`.
+
+## Semantics
+
+### Miss behaviour
+
+| End bound | Miss case | Action |
+|---|---|---|
+| `--until <offset>` | n/a — raw offset always resolves | — |
+| `--until-marker <name>` | name not in marker table | Hard error: `marker 'X' not found` |
+| `--until-marker <name>` | marker offset < start offset | Hard error: `marker 'X' precedes start` |
+| `--until-next-marker` | no marker after start | Soft ceiling: slice to EOF; stderr note `# bounded by EOF (no marker after start)` |
+| `--until-idle <duration>` | no gap of ≥N found | Soft ceiling: slice to EOF; stderr note `# bounded by EOF (no <duration> idle found)` |
+
+When the intended bound is hit, no stderr note is emitted. This keeps agent workflows clean (redirect `2>/dev/null` if the note is noise) and gives interactive users a hint when an expected bound wasn't reached.
+
+### Idle detection
+
+"Idle" means: the first gap between two consecutive *output* events in the cast file whose duration is `>= N`.
+
+- Events in asciicast v3 carry timestamps. Gap = `t[i+1] - t[i]`.
+- Only output events participate (cast file type `'o'`). Markers, snapshots, and other event types are ignored for idle detection.
+- The slice ends at the byte offset corresponding to the last output event *before* the gap (i.e., the slice includes the last event before idle starts).
+
+### Next-marker detection
+
+"Next marker" means: the marker whose byte offset is the smallest value strictly greater than the resolved start offset.
+
+- Marker table today is a `HashMap<String, u64>` of name → offset. Resolution is a linear scan for `min offset where offset > start`.
+- If markers end up placed out of chronological order (e.g., via some future tool that backdates markers), the "next" is still determined by offset, not by creation time. This matches the conceptual model of markers as *positions*, not events.
+
+## Architecture
+
+### Service-layer API
+
+Daemon-side slicing keeps the logic where the cast file and marker table already live. Two new methods, matching the existing one-per-output-format pattern:
+
+```rust
+fn capture_slice_raw(
+    &self,
+    id: &str,
+    start: StartBound,
+    end: EndBound,
+) -> Result<(Vec<u8>, SliceOutcome), ServiceError>;
+
+fn capture_slice_text(
+    &self,
+    id: &str,
+    start: StartBound,
+    end: EndBound,
+) -> Result<(String, SliceOutcome), ServiceError>;
+```
+
+```rust
+enum StartBound {
+    Offset(u64),
+    Marker(String),
+    FromBeginning,
+}
+
+enum EndBound {
+    Offset(u64),
+    Marker(String),
+    NextMarker,
+    IdleGap(Duration),
+    EndOfRecording,
+}
+
+struct SliceOutcome {
+    /// Byte range actually delivered.
+    start_offset: u64,
+    end_offset: u64,
+    /// Whether the end was the one requested or a soft-ceiling fallback.
+    hit_intended_end: bool,
+    /// If hit_intended_end is false, a short reason for the stderr note.
+    fallback_reason: Option<String>,
+}
+```
+
+The `SliceOutcome` return lets the CLI layer decide whether to emit the stderr note without the service layer having to know about stderr.
+
+### Existing `capture_since_*` methods
+
+The existing `capture_since_raw`/`capture_since_text` methods are retired. Their call sites migrate to `capture_slice_{raw,text}` with `EndBound::EndOfRecording`. Retirement rather than keeping both forms avoids carrying two entry points that do the same thing.
+
+Migration touches:
+- `Command::Transcript` dispatch in `cli.rs:380-400`
+- Any lifecycle tests that call the old methods (inventory during planning)
+
+### Protocol layer
+
+`StartBound` and `EndBound` need to cross the daemon socket. Serialisation:
+- Both enums are tagged unions encoded as `(tag_byte, payload)`
+- `Duration` serialised as `u64` milliseconds
+- `String` for marker names, length-prefixed (existing protocol pattern)
+
+Specific byte encoding deferred to planning — follows whatever convention the existing `Frame` encoding uses in `protocol.rs`.
+
+### Clap flag structure
+
+Four new flag fields on `Transcript { ... }`, each with `conflicts_with` on the other three to enforce mutual exclusion. Matches the pattern `--since` / `--since-marker` already uses.
+
+```rust
+Transcript {
+    id: String,
+    #[arg(long, conflicts_with = "since_marker")]
+    since: Option<u64>,
+    #[arg(long, conflicts_with = "since")]
+    since_marker: Option<String>,
+
+    #[arg(long, conflicts_with_all = ["until_marker", "until_next_marker", "until_idle"])]
+    until: Option<u64>,
+    #[arg(long, conflicts_with_all = ["until", "until_next_marker", "until_idle"])]
+    until_marker: Option<String>,
+    #[arg(long, conflicts_with_all = ["until", "until_marker", "until_idle"])]
+    until_next_marker: bool,
+    #[arg(long, conflicts_with_all = ["until", "until_marker", "until_next_marker"], value_parser = parse_humantime_or_seconds)]
+    until_idle: Option<Duration>,
+
+    #[arg(long)]
+    raw: bool,
+}
+```
+
+### Duration parsing
+
+One shared value parser function:
+
+```rust
+fn parse_humantime_or_seconds(s: &str) -> Result<Duration, String> {
+    // Try humantime first (matches "500ms", "2s", "1m30s", etc.)
+    if let Ok(d) = humantime::parse_duration(s) { return Ok(d); }
+    // Fall back to float seconds ("2", "0.5")
+    s.parse::<f64>()
+        .map(Duration::from_secs_f64)
+        .map_err(|_| format!("invalid duration: {s}"))
+}
+```
+
+Used by `--until-idle` and by `wait --idle-time`. Shared location: `crates/cleat/src/duration_parser.rs` or inline in `cli.rs` — planning decides.
+
+### Dependency
+
+Add `humantime = "2"` to `crates/cleat/Cargo.toml`. Small, widely-used crate, no transitive bloat.
+
+## Testing
+
+### Unit
+
+- `parse_humantime_or_seconds`: covers `500ms`, `2s`, `1m30s`, `2`, `0.5`, and invalid inputs
+- `EndBound` resolution against a mock event stream: test each variant including soft-ceiling fallback
+- Idle-gap detection: no events, single event, gap exactly == N, gap > N, no gap found (EOF fallback), only non-output events between two output events
+
+### Integration
+
+- Service layer: `capture_slice_{raw,text}` against a fixture cast file with known markers and idle gaps
+- Fallback signalling: `SliceOutcome.hit_intended_end` and `fallback_reason` populated correctly
+
+### CLI
+
+- Flag parsing: mutual-exclusion errors for conflicting bounds
+- Humantime parsing: both forms accepted on `--until-idle` and `--idle-time`
+- Dispatch: verify the right `StartBound` / `EndBound` is constructed from each flag combination
+
+### End-to-end (lifecycle test)
+
+- Launch a session with recording; mark A; emit output; mark B; emit output; mark C
+- `transcript --since-marker A --until-marker B` returns exactly the bytes between A and B
+- `transcript --since-marker B --until-next-marker` returns exactly the bytes between B and C
+- `transcript --since-marker A --until-idle 200ms` (with a controlled idle pause) terminates at the expected point
+- Soft-ceiling case: `transcript --since-marker C --until-idle 10s` on a short session falls back to EOF and emits the stderr note
+
+## Rollout
+
+Single PR, single branch `transcript-between-markers`. No feature flag needed — new surface only, existing surface is either unchanged (`--since`, `--since-marker`, `--raw`) or harmonised backwards-compatibly (`wait --idle-time`).
+
+## Open questions / follow-ups
+
+- **JSON output on `transcript`** — if agents want structured access to the `SliceOutcome` metadata (hit/miss status, actual range), that's a separate feature. Not blocking here.
+- **`expect --timeout` humantime** — same pattern as `wait --idle-time`; obvious future symmetry but out of scope.
+- **`--until-duration <duration>`** (time-based end, independent of idle) — not in the note's original asks; file a follow-up if requested.


### PR DESCRIPTION
## Summary

Adds four end-bound flags to \`cleat transcript\` so agents can slice exactly the interesting window of a recording without hand-trimming. Closes #52.

\`\`\`
cleat transcript <id>
  [--since <offset> | --since-marker <name>]
  [--until <offset> | --until-marker <name> | --until-next-marker | --until-idle <dur>]
\`\`\`

End bounds are mutually exclusive among themselves; any start bound composes with any end bound. Omitted end = end of recording (today's behaviour).

Also harmonises \`wait --idle-time\` to accept humantime durations (\`500ms\`, \`2s\`, \`1m30s\`) in addition to plain seconds — backwards-compatible.

## Semantics

- \`--until-marker <name>\` — hard error if the name doesn't exist or precedes the start.
- \`--until-next-marker\` and \`--until-idle\` — soft ceiling: slice to EOF on miss, with a \`# bounded by EOF (<reason>)\` note on stderr.
- Only *named* markers participate in \`--until-next-marker\` and \`--until-marker\` (the daemon's marker table is name-keyed; unnamed \`mark\` returns an offset but doesn't register).

## Architecture

- **Client-side slicing.** The cast file is already client-accessible via \`cast_reader\`, so slicing logic lives there. Only marker resolution (named lookups + \"next named marker after offset\") crosses the daemon socket.
- **One new protocol frame** — \`Frame::ResolveNextMarker { after: u64 }\` plus a new \`Frame::MarkNotFound\` variant (structured not-found response, no string matching).
- **\`SessionService\` API.** Retires \`capture_since_{raw,text}(id, offset) -> Result<String>\` in favor of \`capture_slice_{raw,text}(id, StartBound, EndBound) -> Result<(String, SliceOutcome)>\`. \`SliceOutcome.end_status: Option<FallbackReason>\` records whether the intended end was hit or a soft ceiling fell back to EOF (typed enum, not string).
- **\`cast_reader\`** gains \`read_output_between(path, start, end)\` and \`find_idle_gap_after(path, start, threshold)\`.
- **Shared duration parser** (\`duration_parser::parse_humantime_or_seconds\`) used by both \`--until-idle\` and \`wait --idle-time\`.

## Out of scope

Explicit non-goals from the spec:
- \`expect\` — waits for text; end-bounds don't fit its shape. Untouched.
- \`capture\` — current screen only, no slicing concept. Untouched.
- JSON output on \`transcript\` — structured \`SliceOutcome\` is future-ready but no surface yet.
- \`expect --timeout\` humantime — symmetric future work.

## Commits

10 commits tell a clean, bisect-friendly story:

\`\`\`
docs: design spec for transcript end-bounds (#52)
docs: implementation plan for transcript end-bounds (#52)
duration_parser: accept humantime or plain-seconds forms
cast_reader: add read_output_between and find_idle_gap_after
protocol: add ResolveNextMarker { after } frame
session: handle ResolveNextMarker frame (client method lands in next commit)
server: add StartBound/EndBound/SliceOutcome + capture_slice_{raw,text} + resolve_next_marker_after
server: retire capture_since_* in favor of capture_slice_*; migrate callers
cli: add end-bound flags to transcript (--until, --until-marker, --until-next-marker, --until-idle)
wait: accept humantime durations on --idle-time (backwards-compatible)
review: structured no-marker, typed fallback reason, timing headroom
\`\`\`

Each commit compiles and passes its own tests. The session/server split is deliberate — the daemon handler lands first so the branch stays bisectable; the client method (and its end-to-end test) land in the next commit.

## Test Plan

- [x] \`cargo +nightly-2026-03-12 fmt --check\` — clean
- [x] \`cargo build --locked\` and \`cargo build --features ghostty-vt --locked\` — clean
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\` — clean
- [x] \`cargo clippy --workspace --all-targets --features cleat/ghostty-vt --locked -- -D warnings\` — clean
- [x] \`cargo test --workspace --locked\` — 207 passed, 0 failed
- [x] \`cargo test -p cleat --features ghostty-vt --locked\` — 241 passed, 0 failed
  - Includes new unit tests in \`cast_reader\` (5), \`duration_parser\` (7), \`protocol\` (round-trip for new frame)
  - Includes new service tests in \`capture_render\` (capture_slice_text end-of-recording, idle fallback)
  - Includes new lifecycle tests (\`resolve_next_marker_returns_minimum_offset_above\`, \`transcript_between_two_named_markers_returns_exact_range\`, \`transcript_until_idle_terminates_at_quiet_period\`)
- [x] \`cargo build -p cleat --features ghostty-vt --locked --release\` — clean

## Related follow-ups filed during review

- #60 — \`--raw\` flag is currently a no-op (\`capture_slice_raw\` and \`capture_slice_text\` share implementation; real divergence comes with the VT transcoding work in #29).

## Bisect-cleanliness

Every implementation commit passes \`cargo clippy --features cleat/ghostty-vt --locked -- -D warnings\` individually, with the deliberate exception noted above (daemon handler lands one commit before its client caller — both compile clean).