### PR TITLE
cleat replay: play cast files at controlled speed

### DIFF
--- a/crates/cleat/src/cast_reader.rs
+++ b/crates/cleat/src/cast_reader.rs
@@ -230,6 +230,10 @@ pub struct OutputEventIter<R: std::io::Read> {
     byte_pos: u64,
     end: u64,
     prev_time: Duration,
+    /// True iff iteration started at byte 0 of the file. The first read in
+    /// that case is the asciicast header, which is skipped exactly once.
+    /// When the iterator is constructed mid-file (post-seek), this is false
+    /// and the first read is treated as a regular event line.
     first_line: bool,
     exhausted: bool,
 }

--- a/crates/cleat/src/cast_reader.rs
+++ b/crates/cleat/src/cast_reader.rs
@@ -208,6 +208,73 @@ pub fn find_idle_gap_after(path: &Path, start: u64, threshold: Duration) -> Resu
     Ok(None)
 }
 
+/// Streaming counterpart to [`read_output_between`]. Yields Output-coded
+/// events whose line starts in `[start, end)` without loading them all into
+/// memory. Malformed lines and non-Output events are silently skipped to
+/// match `read_output_between`.
+///
+/// Returns `Err` only on file-open or seek failures; mid-stream read or
+/// decode errors are folded into the iterator (decode errors skipped, read
+/// errors surface as `Err` items).
+pub fn iter_output_between(path: &Path, start: u64, end: u64) -> Result<OutputEventIter<std::fs::File>, String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("open {path:?}: {e}"))?;
+    let mut reader = BufReader::new(file);
+    if start > 0 {
+        reader.seek(SeekFrom::Start(start)).map_err(|e| format!("seek: {e}"))?;
+    }
+    Ok(OutputEventIter { reader, byte_pos: start, end, prev_time: Duration::ZERO, first_line: start == 0, exhausted: start >= end })
+}
+
+pub struct OutputEventIter<R: std::io::Read> {
+    reader: BufReader<R>,
+    byte_pos: u64,
+    end: u64,
+    prev_time: Duration,
+    first_line: bool,
+    exhausted: bool,
+}
+
+impl<R: std::io::Read> Iterator for OutputEventIter<R> {
+    type Item = Result<Event, String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.exhausted || self.byte_pos >= self.end {
+                return None;
+            }
+            let mut line = String::new();
+            let n = match self.reader.read_line(&mut line) {
+                Ok(0) => {
+                    self.exhausted = true;
+                    return None;
+                }
+                Ok(n) => n,
+                Err(e) => {
+                    self.exhausted = true;
+                    return Some(Err(format!("read line: {e}")));
+                }
+            };
+            self.byte_pos += n as u64;
+
+            if self.first_line {
+                self.first_line = false;
+                continue;
+            }
+
+            let trimmed = line.trim_end_matches('\n');
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            match decode_event(trimmed, &mut self.prev_time) {
+                Ok(event) if event.code == EventCode::Output => return Some(Ok(event)),
+                Ok(_) => continue,
+                Err(_) => continue,
+            }
+        }
+    }
+}
+
 /// Internal helper: read events from `path` starting at `offset`.
 ///
 /// If `filter` is `Some(code)`, only events matching that code are returned.
@@ -340,5 +407,46 @@ mod tests_between_and_idle {
         let header_len = (HEADER.len() + 1) as u64;
         let end = find_idle_gap_after(f.path(), header_len, Duration::from_millis(100)).expect("find gap");
         assert_eq!(end, None);
+    }
+
+    #[test]
+    fn iter_output_between_yields_same_events_as_read_output_between() {
+        let f = write_cast(&[HEADER, EVT_A, EVT_B, EVT_C]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let file_size = std::fs::metadata(f.path()).unwrap().len();
+
+        let vec_events = read_output_between(f.path(), header_len, file_size).expect("vec read");
+        let iter_events: Vec<Event> =
+            iter_output_between(f.path(), header_len, file_size).expect("iter open").collect::<Result<Vec<_>, _>>().expect("iter items");
+
+        assert_eq!(vec_events.len(), iter_events.len());
+        for (a, b) in vec_events.iter().zip(iter_events.iter()) {
+            assert_eq!(a.data, b.data, "data mismatch");
+            assert_eq!(a.code, b.code, "code mismatch");
+            assert_eq!(a.time, b.time, "time mismatch");
+        }
+    }
+
+    #[test]
+    fn iter_output_between_skips_non_output_events() {
+        let f = write_cast(&[HEADER, r#"[0.1,"o","a"]"#, r#"[0.05,"m","mark-1"]"#, r#"[0.05,"o","b"]"#]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let file_size = std::fs::metadata(f.path()).unwrap().len();
+
+        let events: Vec<Event> =
+            iter_output_between(f.path(), header_len, file_size).expect("iter open").collect::<Result<Vec<_>, _>>().expect("iter items");
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].data, "a");
+        assert_eq!(events[1].data, "b");
+    }
+
+    #[test]
+    fn iter_output_between_empty_when_start_equals_end() {
+        let f = write_cast(&[HEADER, EVT_A]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let events: Vec<Event> =
+            iter_output_between(f.path(), header_len, header_len).expect("iter").collect::<Result<Vec<_>, _>>().unwrap();
+        assert!(events.is_empty());
     }
 }

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -129,6 +129,52 @@ pub enum Command {
         #[arg(long)]
         raw: bool,
     },
+    /// Play back a recorded cast file (or slice) at controlled speed.
+    #[command(long_about = "\
+Play a cast file to stdout at controlled speed. The positional argument is a \
+path to a .cast file; alternatively use --session <id> to replay a running \
+session's recording. \n\
+\n\
+Slice bounds (--since, --since-marker, --until, --until-marker, \
+--until-next-marker, --until-idle) match the `transcript` command's \
+semantics. Marker-based flags require --session because markers are \
+resolved through the live daemon socket. \n\
+")]
+    Replay {
+        /// Path to the .cast file. Mutually exclusive with --session.
+        #[arg(conflicts_with = "session", required_unless_present = "session")]
+        path: Option<std::path::PathBuf>,
+        /// Session ID whose recording should be replayed.
+        #[arg(long, conflicts_with = "path", required_unless_present = "path")]
+        session: Option<String>,
+
+        /// Byte offset in the cast file; slice starts at this position.
+        #[arg(long, conflicts_with = "since_marker")]
+        since: Option<u64>,
+        /// Named marker to use as the start offset (requires --session).
+        #[arg(long, conflicts_with_all = ["since", "path"])]
+        since_marker: Option<String>,
+
+        /// Byte offset in the cast file; slice ends at this position.
+        #[arg(long, conflicts_with_all = ["until_marker", "until_next_marker", "until_idle"])]
+        until: Option<u64>,
+        /// Named marker to use as the end offset (requires --session).
+        #[arg(long, conflicts_with_all = ["until", "until_next_marker", "until_idle", "path"])]
+        until_marker: Option<String>,
+        /// Slice until the chronologically-next named marker after the start (requires --session).
+        #[arg(long, conflicts_with_all = ["until", "until_marker", "until_idle", "path"])]
+        until_next_marker: bool,
+        /// Slice until the recording is idle for this duration (e.g., 500ms, 2s).
+        #[arg(long, value_parser = crate::duration_parser::parse_humantime_or_seconds, conflicts_with_all = ["until", "until_marker", "until_next_marker"])]
+        until_idle: Option<std::time::Duration>,
+
+        /// Gap multiplier; >1 faster, <1 slower (default: 1.0).
+        #[arg(long, value_parser = crate::replay::parse_speed, default_value = "1.0")]
+        speed: f64,
+        /// Clamp any inter-event gap to this maximum after speed scaling.
+        #[arg(long, value_parser = crate::duration_parser::parse_humantime_or_seconds)]
+        max_idle: Option<std::time::Duration>,
+    },
     /// Detach from a session
     Detach { id: String },
     /// Terminate a session
@@ -426,6 +472,91 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                     }
                     ExecResult::Ok(Some(s))
                 }
+                Err(e) => ExecResult::Err(e),
+            }
+        }
+        Command::Replay { path, session, since, since_marker, until, until_marker, until_next_marker, until_idle, speed, max_idle } => {
+            let start = match (since, since_marker) {
+                (Some(o), None) => crate::server::StartBound::Offset(o),
+                (None, Some(name)) => crate::server::StartBound::Marker(name),
+                (None, None) => crate::server::StartBound::Offset(0),
+                _ => unreachable!("clap conflicts_with prevents this"),
+            };
+
+            let end = match (until, until_marker, until_next_marker, until_idle) {
+                (Some(o), None, false, None) => crate::server::EndBound::Offset(o),
+                (None, Some(name), false, None) => crate::server::EndBound::Marker(name),
+                (None, None, true, None) => crate::server::EndBound::NextMarker,
+                (None, None, false, Some(d)) => crate::server::EndBound::IdleGap(d),
+                (None, None, false, None) => crate::server::EndBound::EndOfRecording,
+                _ => unreachable!("clap conflicts_with prevents this"),
+            };
+
+            let (cast_path, start_offset, end_offset, end_status) = match (&path, &session) {
+                (Some(p), None) => {
+                    if !p.exists() {
+                        return ExecResult::Err(format!("replay: no such file: {}", p.display()));
+                    }
+                    let file_size = match std::fs::metadata(p) {
+                        Ok(m) => m.len(),
+                        Err(e) => return ExecResult::Err(format!("replay: stat {}: {e}", p.display())),
+                    };
+                    let so = match start {
+                        crate::server::StartBound::Offset(o) => o,
+                        crate::server::StartBound::Marker(_) => {
+                            unreachable!("clap `conflicts_with = path` prevents marker with path")
+                        }
+                    };
+                    let (eo, status): (u64, Option<crate::server::FallbackReason>) = match end {
+                        crate::server::EndBound::EndOfRecording => (file_size, None),
+                        crate::server::EndBound::Offset(o) => {
+                            if o < so {
+                                return ExecResult::Err(format!("end offset {o} precedes start offset {so}"));
+                            }
+                            (o, None)
+                        }
+                        crate::server::EndBound::IdleGap(duration) => match crate::cast_reader::find_idle_gap_after(p, so, duration) {
+                            Ok(Some(o)) => (o, None),
+                            Ok(None) => (file_size, Some(crate::server::FallbackReason::NoIdleGap(duration))),
+                            Err(e) => return ExecResult::Err(e),
+                        },
+                        crate::server::EndBound::Marker(_) | crate::server::EndBound::NextMarker => {
+                            unreachable!("clap `conflicts_with = path` prevents marker with path")
+                        }
+                    };
+                    (p.clone(), so, eo, status)
+                }
+                (None, Some(id)) => {
+                    let cast_path = service.layout_root().join(id).join(crate::recording::CAST_FILE_NAME);
+                    if !cast_path.exists() {
+                        return ExecResult::Err(format!("replay: no recording for session {id}"));
+                    }
+                    match service.resolve_slice_range(id, start, end, &cast_path) {
+                        Ok((so, eo, status)) => (cast_path, so, eo, status),
+                        Err(e) => return ExecResult::Err(e),
+                    }
+                }
+                _ => unreachable!("clap enforces exactly one of --path or --session"),
+            };
+
+            if let Some(reason) = &end_status {
+                let reason_str = match reason {
+                    crate::server::FallbackReason::NoMarkerAfterStart => "no marker after start".to_string(),
+                    crate::server::FallbackReason::NoIdleGap(d) => {
+                        format!("no {} idle found", humantime::format_duration(*d))
+                    }
+                };
+                eprintln!("# bounded by EOF ({reason_str})");
+            }
+
+            let iter = match crate::cast_reader::iter_output_between(&cast_path, start_offset, end_offset) {
+                Ok(it) => it,
+                Err(e) => return ExecResult::Err(e),
+            };
+            let opts = crate::replay::ReplayOptions { speed, max_idle };
+            let mut stdout = std::io::stdout().lock();
+            match crate::replay::play(iter, &opts, &mut stdout, std::thread::sleep) {
+                Ok(()) => ExecResult::Ok(None),
                 Err(e) => ExecResult::Err(e),
             }
         }

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -492,51 +492,27 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 _ => unreachable!("clap conflicts_with prevents this"),
             };
 
-            let (cast_path, start_offset, end_offset, end_status) = match (&path, &session) {
+            let (cast_path, start_offset, end_offset, end_status) = match (path, session) {
                 (Some(p), None) => {
                     if !p.exists() {
                         return ExecResult::Err(format!("replay: no such file: {}", p.display()));
                     }
-                    let file_size = match std::fs::metadata(p) {
-                        Ok(m) => m.len(),
-                        Err(e) => return ExecResult::Err(format!("replay: stat {}: {e}", p.display())),
-                    };
-                    let so = match start {
-                        crate::server::StartBound::Offset(o) => o,
-                        crate::server::StartBound::Marker(_) => {
-                            unreachable!("clap `conflicts_with = path` prevents marker with path")
-                        }
-                    };
-                    let (eo, status): (u64, Option<crate::server::FallbackReason>) = match end {
-                        crate::server::EndBound::EndOfRecording => (file_size, None),
-                        crate::server::EndBound::Offset(o) => {
-                            if o < so {
-                                return ExecResult::Err(format!("end offset {o} precedes start offset {so}"));
-                            }
-                            (o, None)
-                        }
-                        crate::server::EndBound::IdleGap(duration) => match crate::cast_reader::find_idle_gap_after(p, so, duration) {
-                            Ok(Some(o)) => (o, None),
-                            Ok(None) => (file_size, Some(crate::server::FallbackReason::NoIdleGap(duration))),
-                            Err(e) => return ExecResult::Err(e),
-                        },
-                        crate::server::EndBound::Marker(_) | crate::server::EndBound::NextMarker => {
-                            unreachable!("clap `conflicts_with = path` prevents marker with path")
-                        }
-                    };
-                    (p.clone(), so, eo, status)
+                    match crate::server::resolve_range_for_path(&p, start, end) {
+                        Ok((so, eo, status)) => (p, so, eo, status),
+                        Err(e) => return ExecResult::Err(e),
+                    }
                 }
                 (None, Some(id)) => {
-                    let cast_path = service.layout_root().join(id).join(crate::recording::CAST_FILE_NAME);
+                    let cast_path = service.layout_root().join(&id).join(crate::recording::CAST_FILE_NAME);
                     if !cast_path.exists() {
                         return ExecResult::Err(format!("replay: no recording for session {id}"));
                     }
-                    match service.resolve_slice_range(id, start, end, &cast_path) {
+                    match service.resolve_slice_range(&id, start, end, &cast_path) {
                         Ok((so, eo, status)) => (cast_path, so, eo, status),
                         Err(e) => return ExecResult::Err(e),
                     }
                 }
-                _ => unreachable!("clap enforces exactly one of --path or --session"),
+                _ => unreachable!("clap enforces exactly one of path or --session"),
             };
 
             if let Some(reason) = &end_status {
@@ -549,13 +525,9 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 eprintln!("# bounded by EOF ({reason_str})");
             }
 
-            let iter = match crate::cast_reader::iter_output_between(&cast_path, start_offset, end_offset) {
-                Ok(it) => it,
-                Err(e) => return ExecResult::Err(e),
-            };
             let opts = crate::replay::ReplayOptions { speed, max_idle };
             let mut stdout = std::io::stdout().lock();
-            match crate::replay::play(iter, &opts, &mut stdout, std::thread::sleep) {
+            match crate::replay::run_replay(&cast_path, start_offset, end_offset, &opts, &mut stdout, std::thread::sleep) {
                 Ok(()) => ExecResult::Ok(None),
                 Err(e) => ExecResult::Err(e),
             }

--- a/crates/cleat/src/lib.rs
+++ b/crates/cleat/src/lib.rs
@@ -6,6 +6,7 @@ pub mod duration_parser;
 pub mod keys;
 pub mod protocol;
 pub mod recording;
+pub mod replay;
 pub mod runtime;
 pub mod server;
 pub mod session;

--- a/crates/cleat/src/replay.rs
+++ b/crates/cleat/src/replay.rs
@@ -24,8 +24,18 @@ impl Default for ReplayOptions {
 
 /// Compute the sleep duration before the next event given the raw inter-event
 /// gap and the replay options.
+///
+/// Saturates at `Duration::MAX` if the scaled gap would overflow (e.g. an
+/// extreme speed value combined with a large gap).
 pub fn sleep_for_gap(gap: Duration, opts: &ReplayOptions) -> Duration {
-    let scaled = Duration::from_secs_f64(gap.as_secs_f64() / opts.speed);
+    let scaled_secs = gap.as_secs_f64() / opts.speed;
+    let scaled = if !scaled_secs.is_finite() || scaled_secs < 0.0 {
+        Duration::ZERO
+    } else if scaled_secs >= u64::MAX as f64 {
+        Duration::MAX
+    } else {
+        Duration::from_secs_f64(scaled_secs)
+    };
     match opts.max_idle {
         Some(clamp) => scaled.min(clamp),
         None => scaled,
@@ -62,6 +72,29 @@ where
         prev_time = event.time;
     }
     Ok(())
+}
+
+/// Play the resolved byte range of a cast file through to `writer`, honoring
+/// `opts`. `sleeper` is injected so tests can pass a no-op.
+///
+/// This is the testable core of the `replay` subcommand. The CLI dispatch
+/// resolves the range (via [`crate::server::SessionService::resolve_slice_range`]
+/// for session form or [`crate::server::resolve_range_for_path`] for path form)
+/// and then calls this function.
+pub fn run_replay<W, S>(
+    cast_path: &std::path::Path,
+    start_offset: u64,
+    end_offset: u64,
+    opts: &ReplayOptions,
+    writer: &mut W,
+    sleeper: S,
+) -> Result<(), String>
+where
+    W: Write,
+    S: FnMut(Duration),
+{
+    let iter = crate::cast_reader::iter_output_between(cast_path, start_offset, end_offset)?;
+    play(iter, opts, writer, sleeper)
 }
 
 /// Validate the speed value from clap. Called by the CLI value parser.
@@ -106,6 +139,20 @@ mod tests {
     fn sleep_for_gap_max_idle_does_not_expand_below_clamp() {
         let opts = ReplayOptions { speed: 1.0, max_idle: Some(Duration::from_millis(100)) };
         assert_eq!(sleep_for_gap(Duration::from_millis(50), &opts), Duration::from_millis(50));
+    }
+
+    #[test]
+    fn sleep_for_gap_saturates_instead_of_panicking_on_extreme_speed() {
+        let opts = ReplayOptions { speed: 1e-20, max_idle: None };
+        let result = sleep_for_gap(Duration::from_secs(1), &opts);
+        assert_eq!(result, Duration::MAX);
+    }
+
+    #[test]
+    fn sleep_for_gap_max_idle_still_clamps_saturated_value() {
+        let opts = ReplayOptions { speed: 1e-20, max_idle: Some(Duration::from_millis(100)) };
+        let result = sleep_for_gap(Duration::from_secs(1), &opts);
+        assert_eq!(result, Duration::from_millis(100));
     }
 
     #[test]

--- a/crates/cleat/src/replay.rs
+++ b/crates/cleat/src/replay.rs
@@ -1,0 +1,172 @@
+//! `cleat replay`: play back cast files (or slices) at controlled speed.
+//!
+//! Pure timing logic and the playback loop live here. The CLI dispatch and
+//! bound resolution are in [`crate::cli`] and [`crate::server`] respectively.
+
+use std::{io::Write, time::Duration};
+
+use crate::asciicast::Event;
+
+/// Options that shape playback pacing and output.
+#[derive(Debug, Clone)]
+pub struct ReplayOptions {
+    /// Event-gap multiplier. Must be positive and finite.
+    pub speed: f64,
+    /// If set, clamp any inter-event gap to this maximum after speed scaling.
+    pub max_idle: Option<Duration>,
+}
+
+impl Default for ReplayOptions {
+    fn default() -> Self {
+        Self { speed: 1.0, max_idle: None }
+    }
+}
+
+/// Compute the sleep duration before the next event given the raw inter-event
+/// gap and the replay options.
+pub fn sleep_for_gap(gap: Duration, opts: &ReplayOptions) -> Duration {
+    let scaled = Duration::from_secs_f64(gap.as_secs_f64() / opts.speed);
+    match opts.max_idle {
+        Some(clamp) => scaled.min(clamp),
+        None => scaled,
+    }
+}
+
+/// Play an iterator of Output events to `writer`, sleeping by the scaled,
+/// optionally-clamped gap between events.
+///
+/// `sleeper` is injected so unit tests can assert the requested sleep
+/// durations without actually blocking.
+pub fn play<W, S, I>(events: I, opts: &ReplayOptions, writer: &mut W, mut sleeper: S) -> Result<(), String>
+where
+    W: Write,
+    S: FnMut(Duration),
+    I: Iterator<Item = Result<Event, String>>,
+{
+    let mut prev_time = Duration::ZERO;
+    for event in events {
+        let event = event?;
+        let gap = event.time.saturating_sub(prev_time);
+        let sleep = sleep_for_gap(gap, opts);
+        sleeper(sleep);
+        match writer.write_all(event.data.as_bytes()) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => return Ok(()),
+            Err(err) => return Err(format!("write output: {err}")),
+        }
+        match writer.flush() {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => return Ok(()),
+            Err(err) => return Err(format!("flush output: {err}")),
+        }
+        prev_time = event.time;
+    }
+    Ok(())
+}
+
+/// Validate the speed value from clap. Called by the CLI value parser.
+pub fn parse_speed(s: &str) -> Result<f64, String> {
+    let f: f64 = s.parse().map_err(|_| format!("invalid speed: {s}"))?;
+    if !f.is_finite() || f <= 0.0 {
+        return Err(format!("invalid speed: {s}"));
+    }
+    Ok(f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::asciicast::EventCode;
+
+    #[test]
+    fn sleep_for_gap_default_is_identity() {
+        let opts = ReplayOptions::default();
+        assert_eq!(sleep_for_gap(Duration::from_millis(500), &opts), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn sleep_for_gap_speed_2_halves_gap() {
+        let opts = ReplayOptions { speed: 2.0, max_idle: None };
+        assert_eq!(sleep_for_gap(Duration::from_millis(500), &opts), Duration::from_millis(250));
+    }
+
+    #[test]
+    fn sleep_for_gap_speed_half_doubles_gap() {
+        let opts = ReplayOptions { speed: 0.5, max_idle: None };
+        assert_eq!(sleep_for_gap(Duration::from_millis(500), &opts), Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn sleep_for_gap_max_idle_clamps() {
+        let opts = ReplayOptions { speed: 1.0, max_idle: Some(Duration::from_millis(100)) };
+        assert_eq!(sleep_for_gap(Duration::from_millis(500), &opts), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn sleep_for_gap_max_idle_does_not_expand_below_clamp() {
+        let opts = ReplayOptions { speed: 1.0, max_idle: Some(Duration::from_millis(100)) };
+        assert_eq!(sleep_for_gap(Duration::from_millis(50), &opts), Duration::from_millis(50));
+    }
+
+    #[test]
+    fn parse_speed_accepts_positive_finite() {
+        assert_eq!(parse_speed("1.0").unwrap(), 1.0);
+        assert_eq!(parse_speed("0.5").unwrap(), 0.5);
+        assert_eq!(parse_speed("1000").unwrap(), 1000.0);
+    }
+
+    #[test]
+    fn parse_speed_rejects_zero_and_negative_and_nan_and_inf() {
+        assert!(parse_speed("0").is_err());
+        assert!(parse_speed("-1").is_err());
+        assert!(parse_speed("NaN").is_err());
+        assert!(parse_speed("inf").is_err());
+    }
+
+    #[test]
+    fn play_writes_events_with_scaled_sleeps() {
+        let events = vec![
+            Ok(Event { time: Duration::from_millis(100), code: EventCode::Output, data: "hello ".into() }),
+            Ok(Event { time: Duration::from_millis(300), code: EventCode::Output, data: "world".into() }),
+        ];
+        let opts = ReplayOptions { speed: 2.0, max_idle: None };
+        let mut buf: Vec<u8> = Vec::new();
+        let mut sleeps: Vec<Duration> = Vec::new();
+        play(events.into_iter(), &opts, &mut buf, |d| sleeps.push(d)).expect("play");
+        assert_eq!(buf, b"hello world");
+        // Gap 1: 100ms / 2 = 50ms. Gap 2: (300-100)ms / 2 = 100ms.
+        assert_eq!(sleeps, vec![Duration::from_millis(50), Duration::from_millis(100)]);
+    }
+
+    #[test]
+    fn play_propagates_iterator_errors() {
+        let events =
+            vec![Ok(Event { time: Duration::from_millis(100), code: EventCode::Output, data: "a".into() }), Err("bad event".to_string())];
+        let opts = ReplayOptions::default();
+        let mut buf: Vec<u8> = Vec::new();
+        let result = play(events.into_iter(), &opts, &mut buf, |_| {});
+        assert_eq!(result, Err("bad event".to_string()));
+        assert_eq!(buf, b"a");
+    }
+
+    #[test]
+    fn play_exits_cleanly_on_broken_pipe() {
+        use std::io;
+
+        struct BrokenPipeWriter;
+        impl Write for BrokenPipeWriter {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed"))
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let events = vec![Ok(Event { time: Duration::from_millis(100), code: EventCode::Output, data: "x".into() })];
+        let opts = ReplayOptions::default();
+        let mut w = BrokenPipeWriter;
+        let result = play(events.into_iter(), &opts, &mut w, |_| {});
+        assert_eq!(result, Ok(()));
+    }
+}

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -203,18 +203,25 @@ impl SessionService {
         self.capture_slice_inner(id, start, end)
     }
 
-    fn capture_slice_inner(&self, id: &str, start: StartBound, end: EndBound) -> Result<(String, SliceOutcome), String> {
-        let cast_path = self.layout.root().join(id).join(crate::recording::CAST_FILE_NAME);
-        if !cast_path.exists() {
-            return Err(format!("no recording for session {id}"));
-        }
-
+    /// Resolve start and end bounds into byte offsets in the cast file.
+    /// Returns `(start_offset, end_offset, end_status)` where `end_status` is
+    /// `Some(FallbackReason)` when a soft-ceiling bound fell back to EOF.
+    ///
+    /// Used by both `capture_slice_inner` (which then reads the byte range)
+    /// and `replay` (which streams it).
+    pub(crate) fn resolve_slice_range(
+        &self,
+        id: &str,
+        start: StartBound,
+        end: EndBound,
+        cast_path: &std::path::Path,
+    ) -> Result<(u64, u64, Option<FallbackReason>), String> {
         let start_offset = match start {
             StartBound::Offset(o) => o,
             StartBound::Marker(name) => self.resolve_marker(id, &name)?,
         };
 
-        let file_size = std::fs::metadata(&cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
+        let file_size = std::fs::metadata(cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
 
         let (end_offset, end_status) = match end {
             EndBound::EndOfRecording => (file_size, None),
@@ -226,9 +233,6 @@ impl SessionService {
             }
             EndBound::Marker(name) => {
                 let o = self.resolve_marker(id, &name)?;
-                // Strict "after start" for named markers — equal-offset is almost
-                // always a typo (e.g. `--since-marker m1 --until-marker m1`).
-                // Raw offsets keep `<` so `--since 0 --until 0` is a legal empty slice.
                 if o <= start_offset {
                     return Err(format!("marker '{name}' at offset {o} is not after start offset {start_offset}"));
                 }
@@ -238,11 +242,22 @@ impl SessionService {
                 Some(o) => (o, None),
                 None => (file_size, Some(FallbackReason::NoMarkerAfterStart)),
             },
-            EndBound::IdleGap(duration) => match crate::cast_reader::find_idle_gap_after(&cast_path, start_offset, duration)? {
+            EndBound::IdleGap(duration) => match crate::cast_reader::find_idle_gap_after(cast_path, start_offset, duration)? {
                 Some(o) => (o, None),
                 None => (file_size, Some(FallbackReason::NoIdleGap(duration))),
             },
         };
+
+        Ok((start_offset, end_offset, end_status))
+    }
+
+    fn capture_slice_inner(&self, id: &str, start: StartBound, end: EndBound) -> Result<(String, SliceOutcome), String> {
+        let cast_path = self.layout.root().join(id).join(crate::recording::CAST_FILE_NAME);
+        if !cast_path.exists() {
+            return Err(format!("no recording for session {id}"));
+        }
+
+        let (start_offset, end_offset, end_status) = self.resolve_slice_range(id, start, end, &cast_path)?;
 
         let events = crate::cast_reader::read_output_between(&cast_path, start_offset, end_offset)?;
         let output: String = events.iter().map(|e| e.data.as_str()).collect();

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -209,7 +209,7 @@ impl SessionService {
     ///
     /// Used by both `capture_slice_inner` (which then reads the byte range)
     /// and `replay` (which streams it).
-    pub(crate) fn resolve_slice_range(
+    pub fn resolve_slice_range(
         &self,
         id: &str,
         start: StartBound,
@@ -467,6 +467,46 @@ impl SessionService {
     pub fn serve(&self, session: &crate::runtime::SessionMetadata) -> Result<(), String> {
         run_session_daemon(self.layout.root(), session)
     }
+}
+
+/// Resolve start and end bounds into byte offsets against a cast file without
+/// going through the daemon. Marker-based bounds are rejected; the CLI is
+/// expected to prevent these combinations via clap's `conflicts_with = "path"`
+/// on the marker flags.
+///
+/// Mirrors [`SessionService::resolve_slice_range`] for path-based callers.
+pub fn resolve_range_for_path(
+    cast_path: &std::path::Path,
+    start: StartBound,
+    end: EndBound,
+) -> Result<(u64, u64, Option<FallbackReason>), String> {
+    let start_offset = match start {
+        StartBound::Offset(o) => o,
+        StartBound::Marker(_) => {
+            return Err("path-based replay does not support marker start bounds".to_string());
+        }
+    };
+
+    let file_size = std::fs::metadata(cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
+
+    let (end_offset, end_status) = match end {
+        EndBound::EndOfRecording => (file_size, None),
+        EndBound::Offset(o) => {
+            if o < start_offset {
+                return Err(format!("end offset {o} precedes start offset {start_offset}"));
+            }
+            (o, None)
+        }
+        EndBound::Marker(_) | EndBound::NextMarker => {
+            return Err("path-based replay does not support marker end bounds".to_string());
+        }
+        EndBound::IdleGap(duration) => match crate::cast_reader::find_idle_gap_after(cast_path, start_offset, duration)? {
+            Some(o) => (o, None),
+            None => (file_size, Some(FallbackReason::NoIdleGap(duration))),
+        },
+    };
+
+    Ok((start_offset, end_offset, end_status))
 }
 
 fn parse_vt_engine_kind(s: &str) -> VtEngineKind {

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -233,6 +233,10 @@ impl SessionService {
             }
             EndBound::Marker(name) => {
                 let o = self.resolve_marker(id, &name)?;
+                // Strict "after start" for named markers — equal-offset is
+                // almost always a typo (e.g. `--since-marker m1 --until-marker m1`).
+                // Raw offsets keep `<` (above) so `--since 0 --until 0` is a
+                // legal empty slice.
                 if o <= start_offset {
                     return Err(format!("marker '{name}' at offset {o} is not after start offset {start_offset}"));
                 }

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -16,6 +16,7 @@ fn help_lists_expected_subcommands() {
         "list",
         "capture",
         "transcript",
+        "replay",
         "detach",
         "kill",
         "send-keys",
@@ -589,4 +590,69 @@ fn send_keys_mark_before_parses() {
         keys: vec!["Enter".into()],
         mark_before: Some("m1".into()),
     });
+}
+
+#[test]
+fn replay_with_positional_path_parses() {
+    let cli = Cli::try_parse_from(["cleat", "replay", "/tmp/demo.cast"]).expect("parse");
+    match cli.command {
+        Command::Replay { path, session, since, speed, max_idle, .. } => {
+            assert_eq!(path.as_deref().and_then(std::path::Path::to_str), Some("/tmp/demo.cast"));
+            assert_eq!(session, None);
+            assert_eq!(since, None);
+            assert_eq!(speed, 1.0);
+            assert_eq!(max_idle, None);
+        }
+        other => panic!("expected Replay, got {other:?}"),
+    }
+}
+
+#[test]
+fn replay_with_session_parses() {
+    let cli = Cli::try_parse_from(["cleat", "replay", "--session", "alpha"]).expect("parse");
+    match cli.command {
+        Command::Replay { path, session, .. } => {
+            assert_eq!(path, None);
+            assert_eq!(session.as_deref(), Some("alpha"));
+        }
+        other => panic!("expected Replay, got {other:?}"),
+    }
+}
+
+#[test]
+fn replay_path_and_session_are_mutually_exclusive() {
+    let result = Cli::try_parse_from(["cleat", "replay", "/tmp/x.cast", "--session", "alpha"]);
+    assert!(result.is_err(), "path and --session should be mutually exclusive");
+}
+
+#[test]
+fn replay_requires_path_or_session() {
+    let result = Cli::try_parse_from(["cleat", "replay"]);
+    assert!(result.is_err(), "replay with no path or --session should error");
+}
+
+#[test]
+fn replay_since_marker_requires_session() {
+    let result = Cli::try_parse_from(["cleat", "replay", "/tmp/x.cast", "--since-marker", "a"]);
+    assert!(result.is_err(), "--since-marker without --session should error");
+}
+
+#[test]
+fn replay_speed_validates() {
+    let bad_speeds = ["0", "-1", "NaN", "inf"];
+    for s in bad_speeds {
+        let result = Cli::try_parse_from(["cleat", "replay", "/tmp/x.cast", "--speed", s]);
+        assert!(result.is_err(), "--speed {s} should be rejected");
+    }
+}
+
+#[test]
+fn replay_humantime_max_idle_parses() {
+    let cli = Cli::try_parse_from(["cleat", "replay", "/tmp/x.cast", "--max-idle", "500ms"]).expect("parse");
+    match cli.command {
+        Command::Replay { max_idle, .. } => {
+            assert_eq!(max_idle, Some(std::time::Duration::from_millis(500)));
+        }
+        other => panic!("expected Replay, got {other:?}"),
+    }
 }

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -1113,3 +1113,45 @@ fn transcript_until_raw_offset_returns_exact_range() {
     assert!(output.contains("middle"), "expected 'middle' in output, got: {output:?}");
     assert!(!output.contains("trailing"), "did not expect 'trailing', got: {output:?}");
 }
+
+#[test]
+fn replay_with_session_and_markers_while_daemon_alive() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), None, None, Some("sh -c 'stty raw; exec cat'".into()), true).expect("create");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    service.named_mark("alpha", "m1").expect("mark m1");
+    service.send_keys("alpha", b"middle").expect("send middle");
+    std::thread::sleep(Duration::from_millis(300));
+    service.named_mark("alpha", "m2").expect("mark m2");
+    service.send_keys("alpha", b"trailing").expect("send trailing");
+    std::thread::sleep(Duration::from_millis(300));
+
+    // While daemon still alive, run replay through the CLI dispatch.
+    // --speed 1000 keeps the test well under a second.
+    // --max-idle 0ms removes any residual sleep.
+    let cli = Cli::try_parse_from([
+        "cleat",
+        "replay",
+        "--session",
+        "alpha",
+        "--since-marker",
+        "m1",
+        "--until-marker",
+        "m2",
+        "--speed",
+        "1000",
+        "--max-idle",
+        "0ms",
+    ])
+    .expect("parse");
+
+    let result = cli::execute(cli, &service);
+    assert!(matches!(result, ExecResult::Ok(_)), "expected Ok, got {result:?}");
+
+    // Cleanup.
+    let _ = service.kill("alpha");
+}

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -1130,27 +1130,26 @@ fn replay_with_session_and_markers_while_daemon_alive() {
     service.send_keys("alpha", b"trailing").expect("send trailing");
     std::thread::sleep(Duration::from_millis(300));
 
-    // While daemon still alive, run replay through the CLI dispatch.
-    // --speed 1000 keeps the test well under a second.
-    // --max-idle 0ms removes any residual sleep.
-    let cli = Cli::try_parse_from([
-        "cleat",
-        "replay",
-        "--session",
-        "alpha",
-        "--since-marker",
-        "m1",
-        "--until-marker",
-        "m2",
-        "--speed",
-        "1000",
-        "--max-idle",
-        "0ms",
-    ])
-    .expect("parse");
+    // Resolve range via the live daemon (socket-backed marker lookup), then
+    // play into a buffer so we can assert the actual bytes rather than just
+    // ExecResult::Ok.
+    let cast_path = service.layout_root().join("alpha").join(cleat::recording::CAST_FILE_NAME);
+    let (so, eo, _status) = service
+        .resolve_slice_range(
+            "alpha",
+            cleat::server::StartBound::Marker("m1".into()),
+            cleat::server::EndBound::Marker("m2".into()),
+            &cast_path,
+        )
+        .expect("resolve");
 
-    let result = cli::execute(cli, &service);
-    assert!(matches!(result, ExecResult::Ok(_)), "expected Ok, got {result:?}");
+    let opts = cleat::replay::ReplayOptions { speed: 1_000_000.0, max_idle: Some(Duration::ZERO) };
+    let mut buf: Vec<u8> = Vec::new();
+    cleat::replay::run_replay(&cast_path, so, eo, &opts, &mut buf, |_| {}).expect("run_replay");
+
+    let output = String::from_utf8(buf).expect("utf-8");
+    assert!(output.contains("middle"), "expected 'middle' between m1 and m2, got {output:?}");
+    assert!(!output.contains("trailing"), "did not expect 'trailing' before m2, got {output:?}");
 
     // Cleanup.
     let _ = service.kill("alpha");

--- a/crates/cleat/tests/replay.rs
+++ b/crates/cleat/tests/replay.rs
@@ -102,12 +102,8 @@ fn replay_rejects_marker_bounds_with_path_resolver() {
 }
 
 // Parse-level tests — verify clap configuration.
-
-#[test]
-fn replay_parse_requires_path_or_session() {
-    let result = Cli::try_parse_from(["cleat", "replay"]);
-    assert!(result.is_err(), "replay with no path or --session should error");
-}
+// (`replay_requires_path_or_session` lives in `tests/cli.rs` alongside the
+// other `replay_*` parse tests; not duplicated here.)
 
 #[test]
 fn replay_parse_rejects_since_marker_with_positional_path() {

--- a/crates/cleat/tests/replay.rs
+++ b/crates/cleat/tests/replay.rs
@@ -1,17 +1,17 @@
 //! Integration tests for `cleat replay` — path-based invocation only.
 //! Session-based replay is exercised in `tests/lifecycle.rs`.
 
-use std::{io::Write, time::Duration};
+use std::{io::Write, path::PathBuf, time::Duration};
 
 use clap::Parser;
 use cleat::{
     asciicast::{encode_event, encode_header, Event, EventCode, Header},
-    cli::{self, Cli, Command, ExecResult},
-    runtime::RuntimeLayout,
-    server::SessionService,
+    cli::{Cli, Command},
+    replay::{run_replay, ReplayOptions},
+    server::{resolve_range_for_path, EndBound, FallbackReason, StartBound},
 };
 
-fn write_fixture_cast(dir: &std::path::Path, events: &[Event]) -> std::path::PathBuf {
+fn write_fixture_cast(dir: &std::path::Path, events: &[Event]) -> PathBuf {
     let path = dir.join("fixture.cast");
     let mut f = std::fs::File::create(&path).unwrap();
     let header = Header { cols: 80, rows: 24, ..Default::default() };
@@ -23,12 +23,16 @@ fn write_fixture_cast(dir: &std::path::Path, events: &[Event]) -> std::path::Pat
     path
 }
 
-fn service_for(root: &std::path::Path) -> SessionService {
-    SessionService::new(RuntimeLayout::new(root.to_path_buf()))
+fn replay_path_to_bytes(cast_path: &std::path::Path, start: StartBound, end: EndBound) -> Vec<u8> {
+    let (so, eo, _) = resolve_range_for_path(cast_path, start, end).expect("resolve");
+    let opts = ReplayOptions { speed: 1_000_000.0, max_idle: Some(Duration::ZERO) };
+    let mut buf: Vec<u8> = Vec::new();
+    run_replay(cast_path, so, eo, &opts, &mut buf, |_| {}).expect("run_replay");
+    buf
 }
 
 #[test]
-fn replay_positional_path_emits_concatenated_output() {
+fn replay_emits_concatenated_output_bytes() {
     let temp = tempfile::tempdir().unwrap();
     let events = vec![Event { time: Duration::from_millis(100), code: EventCode::Output, data: "hello ".into() }, Event {
         time: Duration::from_millis(200),
@@ -36,29 +40,12 @@ fn replay_positional_path_emits_concatenated_output() {
         data: "world".into(),
     }];
     let cast = write_fixture_cast(temp.path(), &events);
-
-    let cli = Cli::try_parse_from(["cleat", "replay", cast.to_str().unwrap(), "--speed", "1000", "--max-idle", "0ms"]).expect("parse");
-
-    let service = service_for(temp.path());
-    let result = cli::execute(cli, &service);
-    assert!(matches!(result, ExecResult::Ok(_)), "expected Ok, got {result:?}");
+    let bytes = replay_path_to_bytes(&cast, StartBound::Offset(0), EndBound::EndOfRecording);
+    assert_eq!(bytes, b"hello world");
 }
 
 #[test]
-fn replay_positional_path_errors_on_missing_file() {
-    let temp = tempfile::tempdir().unwrap();
-    let cli = Cli::try_parse_from(["cleat", "replay", "/nonexistent/file.cast", "--max-idle", "0ms"]).expect("parse");
-
-    let service = service_for(temp.path());
-    let result = cli::execute(cli, &service);
-    match result {
-        ExecResult::Err(msg) => assert!(msg.contains("no such file"), "unexpected error: {msg}"),
-        other => panic!("expected Err, got {other:?}"),
-    }
-}
-
-#[test]
-fn replay_with_until_offset_honors_end_bound() {
+fn replay_respects_until_offset_end_bound() {
     let temp = tempfile::tempdir().unwrap();
     let events = vec![Event { time: Duration::from_millis(100), code: EventCode::Output, data: "keep".into() }, Event {
         time: Duration::from_millis(200),
@@ -67,21 +54,70 @@ fn replay_with_until_offset_honors_end_bound() {
     }];
     let cast = write_fixture_cast(temp.path(), &events);
 
-    let cli = Cli::try_parse_from(["cleat", "replay", cast.to_str().unwrap(), "--since", "0", "--max-idle", "0ms"]).expect("parse");
-    let service = service_for(temp.path());
-    let result = cli::execute(cli, &service);
-    assert!(matches!(result, ExecResult::Ok(_)), "expected Ok, got {result:?}");
+    // Compute the offset that's just after the first event line.
+    let contents = std::fs::read(&cast).unwrap();
+    let header_end = contents.iter().position(|&b| b == b'\n').unwrap() as u64 + 1;
+    let first_event_end = contents.iter().skip(header_end as usize).position(|&b| b == b'\n').map(|p| header_end + p as u64 + 1).unwrap();
+
+    let bytes = replay_path_to_bytes(&cast, StartBound::Offset(0), EndBound::Offset(first_event_end));
+    assert_eq!(bytes, b"keep");
 }
 
 #[test]
-fn replay_rejects_since_marker_with_positional_path() {
+fn replay_idle_gap_fallback_reports_no_idle_found() {
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![Event { time: Duration::from_millis(10), code: EventCode::Output, data: "a".into() }, Event {
+        time: Duration::from_millis(20),
+        code: EventCode::Output,
+        data: "b".into(),
+    }];
+    let cast = write_fixture_cast(temp.path(), &events);
+
+    let (_so, eo, status) =
+        resolve_range_for_path(&cast, StartBound::Offset(0), EndBound::IdleGap(Duration::from_secs(10))).expect("resolve");
+
+    // No 10s gap in the fixture — fell back to EOF.
+    assert_eq!(eo, std::fs::metadata(&cast).unwrap().len());
+    assert!(matches!(status, Some(FallbackReason::NoIdleGap(_))));
+}
+
+#[test]
+fn replay_rejects_end_offset_before_start() {
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![Event { time: Duration::from_millis(10), code: EventCode::Output, data: "a".into() }];
+    let cast = write_fixture_cast(temp.path(), &events);
+    let err = resolve_range_for_path(&cast, StartBound::Offset(100), EndBound::Offset(50)).unwrap_err();
+    assert!(err.contains("precedes start"), "unexpected error: {err}");
+}
+
+#[test]
+fn replay_rejects_marker_bounds_with_path_resolver() {
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![Event { time: Duration::from_millis(10), code: EventCode::Output, data: "a".into() }];
+    let cast = write_fixture_cast(temp.path(), &events);
+    let err = resolve_range_for_path(&cast, StartBound::Marker("x".into()), EndBound::EndOfRecording).unwrap_err();
+    assert!(err.contains("marker"), "unexpected error: {err}");
+    let err2 = resolve_range_for_path(&cast, StartBound::Offset(0), EndBound::Marker("x".into())).unwrap_err();
+    assert!(err2.contains("marker"), "unexpected error: {err2}");
+}
+
+// Parse-level tests — verify clap configuration.
+
+#[test]
+fn replay_parse_requires_path_or_session() {
+    let result = Cli::try_parse_from(["cleat", "replay"]);
+    assert!(result.is_err(), "replay with no path or --session should error");
+}
+
+#[test]
+fn replay_parse_rejects_since_marker_with_positional_path() {
     let temp = tempfile::tempdir().unwrap();
     let result = Cli::try_parse_from(["cleat", "replay", temp.path().join("fake.cast").to_str().unwrap(), "--since-marker", "a"]);
-    assert!(result.is_err(), "--since-marker without --session should be rejected at parse time");
+    assert!(result.is_err(), "--since-marker without --session should be rejected");
 }
 
 #[test]
-fn replay_parses_full_flag_surface() {
+fn replay_parse_full_flag_surface() {
     let cli = Cli::try_parse_from([
         "cleat",
         "replay",

--- a/crates/cleat/tests/replay.rs
+++ b/crates/cleat/tests/replay.rs
@@ -1,0 +1,109 @@
+//! Integration tests for `cleat replay` — path-based invocation only.
+//! Session-based replay is exercised in `tests/lifecycle.rs`.
+
+use std::{io::Write, time::Duration};
+
+use clap::Parser;
+use cleat::{
+    asciicast::{encode_event, encode_header, Event, EventCode, Header},
+    cli::{self, Cli, Command, ExecResult},
+    runtime::RuntimeLayout,
+    server::SessionService,
+};
+
+fn write_fixture_cast(dir: &std::path::Path, events: &[Event]) -> std::path::PathBuf {
+    let path = dir.join("fixture.cast");
+    let mut f = std::fs::File::create(&path).unwrap();
+    let header = Header { cols: 80, rows: 24, ..Default::default() };
+    writeln!(f, "{}", encode_header(&header)).unwrap();
+    let mut prev = Duration::ZERO;
+    for e in events {
+        writeln!(f, "{}", encode_event(e, &mut prev)).unwrap();
+    }
+    path
+}
+
+fn service_for(root: &std::path::Path) -> SessionService {
+    SessionService::new(RuntimeLayout::new(root.to_path_buf()))
+}
+
+#[test]
+fn replay_positional_path_emits_concatenated_output() {
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![Event { time: Duration::from_millis(100), code: EventCode::Output, data: "hello ".into() }, Event {
+        time: Duration::from_millis(200),
+        code: EventCode::Output,
+        data: "world".into(),
+    }];
+    let cast = write_fixture_cast(temp.path(), &events);
+
+    let cli = Cli::try_parse_from(["cleat", "replay", cast.to_str().unwrap(), "--speed", "1000", "--max-idle", "0ms"]).expect("parse");
+
+    let service = service_for(temp.path());
+    let result = cli::execute(cli, &service);
+    assert!(matches!(result, ExecResult::Ok(_)), "expected Ok, got {result:?}");
+}
+
+#[test]
+fn replay_positional_path_errors_on_missing_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let cli = Cli::try_parse_from(["cleat", "replay", "/nonexistent/file.cast", "--max-idle", "0ms"]).expect("parse");
+
+    let service = service_for(temp.path());
+    let result = cli::execute(cli, &service);
+    match result {
+        ExecResult::Err(msg) => assert!(msg.contains("no such file"), "unexpected error: {msg}"),
+        other => panic!("expected Err, got {other:?}"),
+    }
+}
+
+#[test]
+fn replay_with_until_offset_honors_end_bound() {
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![Event { time: Duration::from_millis(100), code: EventCode::Output, data: "keep".into() }, Event {
+        time: Duration::from_millis(200),
+        code: EventCode::Output,
+        data: "drop".into(),
+    }];
+    let cast = write_fixture_cast(temp.path(), &events);
+
+    let cli = Cli::try_parse_from(["cleat", "replay", cast.to_str().unwrap(), "--since", "0", "--max-idle", "0ms"]).expect("parse");
+    let service = service_for(temp.path());
+    let result = cli::execute(cli, &service);
+    assert!(matches!(result, ExecResult::Ok(_)), "expected Ok, got {result:?}");
+}
+
+#[test]
+fn replay_rejects_since_marker_with_positional_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let result = Cli::try_parse_from(["cleat", "replay", temp.path().join("fake.cast").to_str().unwrap(), "--since-marker", "a"]);
+    assert!(result.is_err(), "--since-marker without --session should be rejected at parse time");
+}
+
+#[test]
+fn replay_parses_full_flag_surface() {
+    let cli = Cli::try_parse_from([
+        "cleat",
+        "replay",
+        "/tmp/demo.cast",
+        "--since",
+        "100",
+        "--until",
+        "500",
+        "--speed",
+        "0.5",
+        "--max-idle",
+        "2s",
+    ])
+    .expect("parse");
+    match cli.command {
+        Command::Replay { path, since, until, speed, max_idle, .. } => {
+            assert!(path.is_some());
+            assert_eq!(since, Some(100));
+            assert_eq!(until, Some(500));
+            assert_eq!(speed, 0.5);
+            assert_eq!(max_idle, Some(Duration::from_secs(2)));
+        }
+        other => panic!("expected Replay, got {other:?}"),
+    }
+}

--- a/docs/superpowers/plans/2026-04-23-cleat-replay.md
+++ b/docs/superpowers/plans/2026-04-23-cleat-replay.md
@@ -1,0 +1,1128 @@
+# `cleat replay` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `replay` subcommand that plays back cast files (or slices of them, via the transcript end-bound flags) to stdout at controlled speed, without buffering the whole recording. Closes #53.
+
+**Architecture:** One new module (`replay.rs`) with the timing loop and options. `cast_reader` gains a streaming iterator alongside its Vec-returning counterpart. `server.rs` factors its bound-resolution logic out of `capture_slice_inner` so replay can reuse it without buffering events. CLI adds a new `Replay` variant with the 6 transcript bound flags plus `--speed` and `--max-idle`; marker-based bounds are constrained to `--session` via clap's `requires`.
+
+**Tech Stack:** Rust (stable), `clap` (existing), `humantime` (added in PR #61 for `--until-idle`). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-transcript-replay-design.md`
+
+**Conventions:**
+- Run all commands from the repo root.
+- Per `CLAUDE.md`, always run these seven gates: `cargo +nightly-2026-03-12 fmt --check`, `cargo build --locked`, `cargo build --features ghostty-vt --locked`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo clippy --workspace --all-targets --features cleat/ghostty-vt --locked -- -D warnings`, `cargo test --workspace --locked`, `cargo test -p cleat --features ghostty-vt --locked`.
+- One commit per task. Each commit compiles and passes the seven gates on its own.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `crates/cleat/src/cast_reader.rs` | cast-file parsing | Modify: add streaming `iter_output_between` next to the Vec-returning `read_output_between` |
+| `crates/cleat/src/server.rs` | `SessionService` client + bound resolution | Modify: extract `resolve_slice_range` from `capture_slice_inner`; `capture_slice_inner` delegates to it |
+| `crates/cleat/src/replay.rs` | replay loop + options | Create |
+| `crates/cleat/src/lib.rs` | module exports | Modify: `pub mod replay;` |
+| `crates/cleat/src/cli.rs` | CLI dispatch | Modify: add `Command::Replay { ... }` variant and dispatch arm |
+| `crates/cleat/tests/replay.rs` | integration tests | Create |
+| `crates/cleat/tests/lifecycle.rs` | end-to-end session tests | Modify: add one test for `--session` + `--since-marker` + `--until-marker` |
+
+No other files are created.
+
+---
+
+## Task 1: Streaming iterator in `cast_reader`
+
+**Files:**
+- Modify: `crates/cleat/src/cast_reader.rs`
+
+**Goal:** Add `iter_output_between(path, start, end)` returning a streaming iterator of output events. Keeps memory O(1) regardless of recording size. Yields only `Output`-coded events; silently skips malformed lines and non-output events to match the existing reader's behavior.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `crates/cleat/src/cast_reader.rs` inside the existing `#[cfg(test)] mod tests_between_and_idle` block (added in PR #61):
+
+```rust
+    #[test]
+    fn iter_output_between_yields_same_events_as_read_output_between() {
+        let f = write_cast(&[HEADER, EVT_A, EVT_B, EVT_C]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let file_size = std::fs::metadata(f.path()).unwrap().len();
+
+        let vec_events = read_output_between(f.path(), header_len, file_size).expect("vec read");
+        let iter_events: Vec<Event> = iter_output_between(f.path(), header_len, file_size)
+            .expect("iter open")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("iter items");
+
+        assert_eq!(vec_events.len(), iter_events.len());
+        for (a, b) in vec_events.iter().zip(iter_events.iter()) {
+            assert_eq!(a.data, b.data, "data mismatch");
+            assert_eq!(a.code, b.code, "code mismatch");
+            assert_eq!(a.time, b.time, "time mismatch");
+        }
+    }
+
+    #[test]
+    fn iter_output_between_skips_non_output_events() {
+        // Write a cast with an output event, then a marker event, then another output.
+        let f = write_cast(&[
+            HEADER,
+            r#"[0.1,"o","a"]"#,
+            r#"[0.05,"m","mark-1"]"#,
+            r#"[0.05,"o","b"]"#,
+        ]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let file_size = std::fs::metadata(f.path()).unwrap().len();
+
+        let events: Vec<Event> = iter_output_between(f.path(), header_len, file_size)
+            .expect("iter open")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("iter items");
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].data, "a");
+        assert_eq!(events[1].data, "b");
+    }
+
+    #[test]
+    fn iter_output_between_empty_when_start_equals_end() {
+        let f = write_cast(&[HEADER, EVT_A]);
+        let header_len = (HEADER.len() + 1) as u64;
+        let events: Vec<Event> =
+            iter_output_between(f.path(), header_len, header_len).expect("iter").collect::<Result<Vec<_>, _>>().unwrap();
+        assert!(events.is_empty());
+    }
+```
+
+- [ ] **Step 2: Run tests — expect fail**
+
+Run: `cargo test -p cleat --lib cast_reader::tests_between_and_idle::iter_output_between --locked`
+
+Expected: compile error (`iter_output_between` undefined).
+
+- [ ] **Step 3: Implement the iterator**
+
+Add to `crates/cleat/src/cast_reader.rs`, below the existing `find_idle_gap_after` (or wherever the file's other public `pub fn` helpers end):
+
+```rust
+/// Streaming counterpart to [`read_output_between`]. Yields Output-coded
+/// events whose line starts in `[start, end)` without loading them all into
+/// memory. Malformed lines and non-Output events are silently skipped to
+/// match `read_output_between`.
+///
+/// Returns `Err` only on file-open or seek failures; mid-stream read or
+/// decode errors are folded into the iterator (decode errors skipped, read
+/// errors surface as `Err` items).
+pub fn iter_output_between(
+    path: &Path,
+    start: u64,
+    end: u64,
+) -> Result<OutputEventIter<std::fs::File>, String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("open {path:?}: {e}"))?;
+    let mut reader = BufReader::new(file);
+    if start > 0 {
+        reader.seek(SeekFrom::Start(start)).map_err(|e| format!("seek: {e}"))?;
+    }
+    Ok(OutputEventIter {
+        reader,
+        byte_pos: start,
+        end,
+        prev_time: Duration::ZERO,
+        first_line: start == 0,
+        exhausted: start >= end,
+    })
+}
+
+pub struct OutputEventIter<R: std::io::Read> {
+    reader: BufReader<R>,
+    byte_pos: u64,
+    end: u64,
+    prev_time: Duration,
+    first_line: bool,
+    exhausted: bool,
+}
+
+impl<R: std::io::Read> Iterator for OutputEventIter<R> {
+    type Item = Result<Event, String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.exhausted || self.byte_pos >= self.end {
+                return None;
+            }
+            let mut line = String::new();
+            let n = match self.reader.read_line(&mut line) {
+                Ok(0) => {
+                    self.exhausted = true;
+                    return None;
+                }
+                Ok(n) => n,
+                Err(e) => {
+                    self.exhausted = true;
+                    return Some(Err(format!("read line: {e}")));
+                }
+            };
+            self.byte_pos += n as u64;
+
+            if self.first_line {
+                self.first_line = false;
+                continue;
+            }
+
+            let trimmed = line.trim_end_matches('\n');
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            match decode_event(trimmed, &mut self.prev_time) {
+                Ok(event) if event.code == EventCode::Output => return Some(Ok(event)),
+                Ok(_) => continue,  // non-Output event, skip
+                Err(_) => continue, // malformed line, skip
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cargo test -p cleat --lib cast_reader::tests_between_and_idle::iter_output_between --locked`
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Full gates**
+
+```bash
+cargo +nightly-2026-03-12 fmt --check
+cargo build --locked
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --locked
+```
+
+All clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cleat/src/cast_reader.rs
+git commit -m "cast_reader: add iter_output_between streaming iterator"
+```
+
+---
+
+## Task 2: Extract `resolve_slice_range` from `capture_slice_inner`
+
+**Files:**
+- Modify: `crates/cleat/src/server.rs`
+
+**Goal:** Factor the start-and-end-bound resolution logic out of `capture_slice_inner` so `replay` can reuse it without paying for the `read_output_between` call (which reads all events). Behavior of `capture_slice_inner` must be unchanged.
+
+- [ ] **Step 1: Extract the helper**
+
+In `crates/cleat/src/server.rs`, find `fn capture_slice_inner` (currently around line 206). Above it, add:
+
+```rust
+    /// Resolve start and end bounds into byte offsets in the cast file.
+    /// Returns `(start_offset, end_offset, end_status)` where `end_status` is
+    /// `Some(FallbackReason)` when a soft-ceiling bound fell back to EOF.
+    ///
+    /// Used by both `capture_slice_inner` (which then reads the byte range)
+    /// and `replay` (which streams it).
+    pub(crate) fn resolve_slice_range(
+        &self,
+        id: &str,
+        start: StartBound,
+        end: EndBound,
+        cast_path: &std::path::Path,
+    ) -> Result<(u64, u64, Option<FallbackReason>), String> {
+        let start_offset = match start {
+            StartBound::Offset(o) => o,
+            StartBound::Marker(name) => self.resolve_marker(id, &name)?,
+        };
+
+        let file_size = std::fs::metadata(cast_path).map_err(|e| format!("stat cast file: {e}"))?.len();
+
+        let (end_offset, end_status) = match end {
+            EndBound::EndOfRecording => (file_size, None),
+            EndBound::Offset(o) => {
+                if o < start_offset {
+                    return Err(format!("end offset {o} precedes start offset {start_offset}"));
+                }
+                (o, None)
+            }
+            EndBound::Marker(name) => {
+                let o = self.resolve_marker(id, &name)?;
+                if o <= start_offset {
+                    return Err(format!("marker '{name}' at offset {o} is not after start offset {start_offset}"));
+                }
+                (o, None)
+            }
+            EndBound::NextMarker => match self.resolve_next_marker_after(id, start_offset)? {
+                Some(o) => (o, None),
+                None => (file_size, Some(FallbackReason::NoMarkerAfterStart)),
+            },
+            EndBound::IdleGap(duration) => match crate::cast_reader::find_idle_gap_after(cast_path, start_offset, duration)? {
+                Some(o) => (o, None),
+                None => (file_size, Some(FallbackReason::NoIdleGap(duration))),
+            },
+        };
+
+        Ok((start_offset, end_offset, end_status))
+    }
+```
+
+- [ ] **Step 2: Refactor `capture_slice_inner` to use the helper**
+
+Replace the body of `capture_slice_inner` with:
+
+```rust
+    fn capture_slice_inner(&self, id: &str, start: StartBound, end: EndBound) -> Result<(String, SliceOutcome), String> {
+        let cast_path = self.layout.root().join(id).join(crate::recording::CAST_FILE_NAME);
+        if !cast_path.exists() {
+            return Err(format!("no recording for session {id}"));
+        }
+
+        let (start_offset, end_offset, end_status) = self.resolve_slice_range(id, start, end, &cast_path)?;
+
+        let events = crate::cast_reader::read_output_between(&cast_path, start_offset, end_offset)?;
+        let output: String = events.iter().map(|e| e.data.as_str()).collect();
+        Ok((output, SliceOutcome { start_offset, end_offset, end_status }))
+    }
+```
+
+- [ ] **Step 3: Run tests — expect pass (no behavior change)**
+
+Run: `cargo test --workspace --locked`
+
+Expected: all existing tests pass, since this is a pure refactor.
+
+- [ ] **Step 4: Full gates**
+
+Run the seven gates. All clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cleat/src/server.rs
+git commit -m "server: extract resolve_slice_range from capture_slice_inner"
+```
+
+---
+
+## Task 3: `replay` module — `ReplayOptions` and timing
+
+**Files:**
+- Create: `crates/cleat/src/replay.rs`
+- Modify: `crates/cleat/src/lib.rs` (add `pub mod replay;`)
+
+**Goal:** Stand up the replay module with the timing-calculation function and options struct, with unit test coverage on the timing logic. No CLI wiring yet — Task 4 adds that.
+
+- [ ] **Step 1: Write the module scaffold and unit tests**
+
+Create `crates/cleat/src/replay.rs`:
+
+```rust
+//! `cleat replay`: play back cast files (or slices) at controlled speed.
+//!
+//! Pure timing logic and the playback loop live here. The CLI dispatch and
+//! bound resolution are in [`crate::cli`] and [`crate::server`] respectively.
+
+use std::io::Write;
+use std::time::Duration;
+
+use crate::asciicast::Event;
+
+/// Options that shape playback pacing and output.
+#[derive(Debug, Clone)]
+pub struct ReplayOptions {
+    /// Event-gap multiplier. Must be positive and finite.
+    pub speed: f64,
+    /// If set, clamp any inter-event gap to this maximum after speed scaling.
+    pub max_idle: Option<Duration>,
+}
+
+impl Default for ReplayOptions {
+    fn default() -> Self {
+        Self { speed: 1.0, max_idle: None }
+    }
+}
+
+/// Compute the sleep duration before the next event given the raw inter-event
+/// gap and the replay options.
+pub fn sleep_for_gap(gap: Duration, opts: &ReplayOptions) -> Duration {
+    let scaled = Duration::from_secs_f64(gap.as_secs_f64() / opts.speed);
+    match opts.max_idle {
+        Some(clamp) => scaled.min(clamp),
+        None => scaled,
+    }
+}
+
+/// Play an iterator of Output events to `writer`, sleeping by the scaled,
+/// optionally-clamped gap between events.
+///
+/// `sleeper` is injected so unit tests can assert the requested sleep
+/// durations without actually blocking.
+pub fn play<W, S, I>(events: I, opts: &ReplayOptions, writer: &mut W, mut sleeper: S) -> Result<(), String>
+where
+    W: Write,
+    S: FnMut(Duration),
+    I: Iterator<Item = Result<Event, String>>,
+{
+    let mut prev_time = Duration::ZERO;
+    for event in events {
+        let event = event?;
+        let gap = event.time.saturating_sub(prev_time);
+        let sleep = sleep_for_gap(gap, opts);
+        sleeper(sleep);
+        match writer.write_all(event.data.as_bytes()) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => return Ok(()),
+            Err(err) => return Err(format!("write output: {err}")),
+        }
+        match writer.flush() {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => return Ok(()),
+            Err(err) => return Err(format!("flush output: {err}")),
+        }
+        prev_time = event.time;
+    }
+    Ok(())
+}
+
+/// Validate the speed value from clap. Called by the CLI value parser.
+pub fn parse_speed(s: &str) -> Result<f64, String> {
+    let f: f64 = s.parse().map_err(|_| format!("invalid speed: {s}"))?;
+    if !f.is_finite() || f <= 0.0 {
+        return Err(format!("invalid speed: {s}"));
+    }
+    Ok(f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::asciicast::EventCode;
+
+    #[test]
+    fn sleep_for_gap_default_is_identity() {
+        let opts = ReplayOptions::default();
+        assert_eq!(sleep_for_gap(Duration::from_millis(500), &opts), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn sleep_for_gap_speed_2_halves_gap() {
+        let opts = ReplayOptions { speed: 2.0, max_idle: None };
+        assert_eq!(sleep_for_gap(Duration::from_millis(500), &opts), Duration::from_millis(250));
+    }
+
+    #[test]
+    fn sleep_for_gap_speed_half_doubles_gap() {
+        let opts = ReplayOptions { speed: 0.5, max_idle: None };
+        assert_eq!(sleep_for_gap(Duration::from_millis(500), &opts), Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn sleep_for_gap_max_idle_clamps() {
+        let opts = ReplayOptions { speed: 1.0, max_idle: Some(Duration::from_millis(100)) };
+        assert_eq!(sleep_for_gap(Duration::from_millis(500), &opts), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn sleep_for_gap_max_idle_does_not_expand_below_clamp() {
+        let opts = ReplayOptions { speed: 1.0, max_idle: Some(Duration::from_millis(100)) };
+        assert_eq!(sleep_for_gap(Duration::from_millis(50), &opts), Duration::from_millis(50));
+    }
+
+    #[test]
+    fn parse_speed_accepts_positive_finite() {
+        assert_eq!(parse_speed("1.0").unwrap(), 1.0);
+        assert_eq!(parse_speed("0.5").unwrap(), 0.5);
+        assert_eq!(parse_speed("1000").unwrap(), 1000.0);
+    }
+
+    #[test]
+    fn parse_speed_rejects_zero_and_negative_and_nan_and_inf() {
+        assert!(parse_speed("0").is_err());
+        assert!(parse_speed("-1").is_err());
+        assert!(parse_speed("NaN").is_err());
+        assert!(parse_speed("inf").is_err());
+    }
+
+    #[test]
+    fn play_writes_events_with_scaled_sleeps() {
+        let events = vec![
+            Ok(Event { time: Duration::from_millis(100), code: EventCode::Output, data: "hello ".into() }),
+            Ok(Event { time: Duration::from_millis(300), code: EventCode::Output, data: "world".into() }),
+        ];
+        let opts = ReplayOptions { speed: 2.0, max_idle: None };
+        let mut buf: Vec<u8> = Vec::new();
+        let mut sleeps: Vec<Duration> = Vec::new();
+        play(events.into_iter(), &opts, &mut buf, |d| sleeps.push(d)).expect("play");
+        assert_eq!(buf, b"hello world");
+        // Gap 1: 100ms / 2 = 50ms.
+        // Gap 2: (300-100)ms / 2 = 100ms.
+        assert_eq!(sleeps, vec![Duration::from_millis(50), Duration::from_millis(100)]);
+    }
+
+    #[test]
+    fn play_propagates_iterator_errors() {
+        let events = vec![
+            Ok(Event { time: Duration::from_millis(100), code: EventCode::Output, data: "a".into() }),
+            Err("bad event".to_string()),
+        ];
+        let opts = ReplayOptions::default();
+        let mut buf: Vec<u8> = Vec::new();
+        let result = play(events.into_iter(), &opts, &mut buf, |_| {});
+        assert_eq!(result, Err("bad event".to_string()));
+        assert_eq!(buf, b"a");
+    }
+
+    #[test]
+    fn play_exits_cleanly_on_broken_pipe() {
+        use std::io::{self, Write as _};
+
+        struct BrokenPipeWriter;
+        impl Write for BrokenPipeWriter {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed"))
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let events =
+            vec![Ok(Event { time: Duration::from_millis(100), code: EventCode::Output, data: "x".into() })];
+        let opts = ReplayOptions::default();
+        let mut w = BrokenPipeWriter;
+        let result = play(events.into_iter(), &opts, &mut w, |_| {});
+        assert_eq!(result, Ok(()));
+    }
+}
+```
+
+- [ ] **Step 2: Export the module**
+
+In `crates/cleat/src/lib.rs`, add alongside existing `pub mod` declarations (alphabetical order):
+
+```rust
+pub mod replay;
+```
+
+- [ ] **Step 3: Run tests — expect pass**
+
+Run: `cargo test -p cleat --lib replay --locked`
+
+Expected: 9 tests pass.
+
+- [ ] **Step 4: Full gates**
+
+All seven. Clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cleat/src/replay.rs crates/cleat/src/lib.rs
+git commit -m "replay: module scaffold with sleep_for_gap, play loop, parse_speed"
+```
+
+---
+
+## Task 4: CLI — `Command::Replay` variant and dispatch
+
+**Files:**
+- Modify: `crates/cleat/src/cli.rs`
+
+**Goal:** Add the new subcommand. Clap enforces the positional-path-XOR-`--session` constraint and the marker-flags-require-session constraint. Dispatch resolves the path, builds `StartBound` / `EndBound`, calls `SessionService::resolve_slice_range`, opens the streaming iterator, and invokes `replay::play`.
+
+- [ ] **Step 1: Add the `Replay` variant**
+
+In `crates/cleat/src/cli.rs`, find the `Command` enum. After the existing `Transcript { ... }` variant (around line 108-132), add:
+
+```rust
+    /// Play back a recorded cast file (or slice) at controlled speed.
+    #[command(long_about = "\
+Play a cast file to stdout at controlled speed. The positional argument is a \
+path to a .cast file; alternatively use --session <id> to replay a running \
+session's recording. \n\
+\n\
+Slice bounds (--since, --since-marker, --until, --until-marker, \
+--until-next-marker, --until-idle) match the `transcript` command's \
+semantics. Marker-based flags require --session because markers are \
+resolved through the live daemon socket. \n\
+")]
+    Replay {
+        /// Path to the .cast file. Mutually exclusive with --session.
+        #[arg(conflicts_with = "session", required_unless_present = "session")]
+        path: Option<std::path::PathBuf>,
+        /// Session ID whose recording should be replayed.
+        #[arg(long, conflicts_with = "path", required_unless_present = "path")]
+        session: Option<String>,
+
+        /// Byte offset in the cast file; slice starts at this position.
+        #[arg(long, conflicts_with = "since_marker")]
+        since: Option<u64>,
+        /// Named marker to use as the start offset (requires --session).
+        #[arg(long, conflicts_with = "since", requires = "session")]
+        since_marker: Option<String>,
+
+        /// Byte offset in the cast file; slice ends at this position.
+        #[arg(long, conflicts_with_all = ["until_marker", "until_next_marker", "until_idle"])]
+        until: Option<u64>,
+        /// Named marker to use as the end offset (requires --session).
+        #[arg(long, conflicts_with_all = ["until", "until_next_marker", "until_idle"], requires = "session")]
+        until_marker: Option<String>,
+        /// Slice until the chronologically-next named marker after the start (requires --session).
+        #[arg(long, conflicts_with_all = ["until", "until_marker", "until_idle"], requires = "session")]
+        until_next_marker: bool,
+        /// Slice until the recording is idle for this duration (e.g., 500ms, 2s).
+        #[arg(long, value_parser = crate::duration_parser::parse_humantime_or_seconds, conflicts_with_all = ["until", "until_marker", "until_next_marker"])]
+        until_idle: Option<std::time::Duration>,
+
+        /// Gap multiplier; >1 faster, <1 slower (default: 1.0).
+        #[arg(long, value_parser = crate::replay::parse_speed, default_value = "1.0")]
+        speed: f64,
+        /// Clamp any inter-event gap to this maximum after speed scaling.
+        #[arg(long, value_parser = crate::duration_parser::parse_humantime_or_seconds)]
+        max_idle: Option<std::time::Duration>,
+    },
+```
+
+Note: the exact placement of this variant doesn't affect correctness, but keeping it next to `Transcript` makes the CLI help output group them visually.
+
+- [ ] **Step 2: Add the dispatch arm**
+
+In `crates/cleat/src/cli.rs`, find `pub fn execute`. Locate the `Command::Transcript { ... }` match arm and add, immediately after it:
+
+```rust
+        Command::Replay { path, session, since, since_marker, until, until_marker, until_next_marker, until_idle, speed, max_idle } => {
+            let start = match (since, since_marker) {
+                (Some(o), None) => crate::server::StartBound::Offset(o),
+                (None, Some(name)) => crate::server::StartBound::Marker(name),
+                (None, None) => crate::server::StartBound::Offset(0),
+                _ => unreachable!("clap conflicts_with prevents this"),
+            };
+
+            let end = match (until, until_marker, until_next_marker, until_idle) {
+                (Some(o), None, false, None) => crate::server::EndBound::Offset(o),
+                (None, Some(name), false, None) => crate::server::EndBound::Marker(name),
+                (None, None, true, None) => crate::server::EndBound::NextMarker,
+                (None, None, false, Some(d)) => crate::server::EndBound::IdleGap(d),
+                (None, None, false, None) => crate::server::EndBound::EndOfRecording,
+                _ => unreachable!("clap conflicts_with prevents this"),
+            };
+
+            // Resolve the cast path and (if session form) the slice range via the
+            // daemon. For positional path, we bypass the daemon entirely and
+            // synthesize offsets from start/end directly against the file.
+            let (cast_path, start_offset, end_offset, end_status) = match (&path, &session) {
+                (Some(p), None) => {
+                    if !p.exists() {
+                        return ExecResult::Err(format!("replay: no such file: {}", p.display()));
+                    }
+                    let file_size = match std::fs::metadata(p) {
+                        Ok(m) => m.len(),
+                        Err(e) => return ExecResult::Err(format!("replay: stat {}: {e}", p.display())),
+                    };
+                    let so = match start {
+                        crate::server::StartBound::Offset(o) => o,
+                        crate::server::StartBound::Marker(_) => {
+                            unreachable!("clap `requires = session` prevents marker with path")
+                        }
+                    };
+                    let (eo, status): (u64, Option<crate::server::FallbackReason>) = match end {
+                        crate::server::EndBound::EndOfRecording => (file_size, None),
+                        crate::server::EndBound::Offset(o) => {
+                            if o < so {
+                                return ExecResult::Err(format!("end offset {o} precedes start offset {so}"));
+                            }
+                            (o, None)
+                        }
+                        crate::server::EndBound::IdleGap(duration) => {
+                            match crate::cast_reader::find_idle_gap_after(p, so, duration) {
+                                Ok(Some(o)) => (o, None),
+                                Ok(None) => (file_size, Some(crate::server::FallbackReason::NoIdleGap(duration))),
+                                Err(e) => return ExecResult::Err(e),
+                            }
+                        }
+                        crate::server::EndBound::Marker(_) | crate::server::EndBound::NextMarker => {
+                            unreachable!("clap `requires = session` prevents marker with path")
+                        }
+                    };
+                    (p.clone(), so, eo, status)
+                }
+                (None, Some(id)) => {
+                    let cast_path = service.layout_root().join(id).join(crate::recording::CAST_FILE_NAME);
+                    if !cast_path.exists() {
+                        return ExecResult::Err(format!("replay: no recording for session {id}"));
+                    }
+                    match service.resolve_slice_range(id, start, end, &cast_path) {
+                        Ok((so, eo, status)) => (cast_path, so, eo, status),
+                        Err(e) => return ExecResult::Err(e),
+                    }
+                }
+                _ => unreachable!("clap enforces exactly one of --path or --session"),
+            };
+
+            if let Some(reason) = &end_status {
+                let reason_str = match reason {
+                    crate::server::FallbackReason::NoMarkerAfterStart => "no marker after start".to_string(),
+                    crate::server::FallbackReason::NoIdleGap(d) => {
+                        format!("no {} idle found", humantime::format_duration(*d))
+                    }
+                };
+                eprintln!("# bounded by EOF ({reason_str})");
+            }
+
+            let iter = match crate::cast_reader::iter_output_between(&cast_path, start_offset, end_offset) {
+                Ok(it) => it,
+                Err(e) => return ExecResult::Err(e),
+            };
+            let opts = crate::replay::ReplayOptions { speed, max_idle };
+            let mut stdout = std::io::stdout().lock();
+            match crate::replay::play(iter, &opts, &mut stdout, |d| std::thread::sleep(d)) {
+                Ok(()) => ExecResult::Ok(None),
+                Err(e) => ExecResult::Err(e),
+            }
+        }
+```
+
+- [ ] **Step 3: Add `layout_root` accessor on `SessionService`**
+
+The dispatch needs read access to the runtime layout root. In `crates/cleat/src/server.rs`, find the `impl SessionService` block and add near the top:
+
+```rust
+    /// Read-only access to the runtime layout root, for callers that need to
+    /// derive paths (e.g. cast-file paths) without going through the socket.
+    pub fn layout_root(&self) -> &std::path::Path {
+        self.layout.root()
+    }
+```
+
+If a `layout_root` accessor already exists, skip this step.
+
+- [ ] **Step 4: Update the tests/cli.rs enum-literal tests**
+
+`tests/cli.rs` contains several `assert_eq!(cli.command, Command::Transcript { ... })` and other enum-literal comparisons. None of these test `Replay` yet, so nothing needs to change — but a `cargo build` will confirm nothing broke. If a test fails to compile because it destructures an existing enum variant without the new field, that means I missed a variant change above; no Transcript fields were altered in this task, so no such failures are expected.
+
+- [ ] **Step 5: Add CLI parse tests**
+
+Append to `crates/cleat/tests/cli.rs`:
+
+```rust
+#[test]
+fn replay_with_positional_path_parses() {
+    let cli = Cli::try_parse_from(["cleat", "replay", "/tmp/demo.cast"]).expect("parse");
+    match cli.command {
+        Command::Replay { path, session, since, speed, max_idle, .. } => {
+            assert_eq!(path.as_deref().map(std::path::Path::to_str).flatten(), Some("/tmp/demo.cast"));
+            assert_eq!(session, None);
+            assert_eq!(since, None);
+            assert_eq!(speed, 1.0);
+            assert_eq!(max_idle, None);
+        }
+        other => panic!("expected Replay, got {other:?}"),
+    }
+}
+
+#[test]
+fn replay_with_session_parses() {
+    let cli = Cli::try_parse_from(["cleat", "replay", "--session", "alpha"]).expect("parse");
+    match cli.command {
+        Command::Replay { path, session, .. } => {
+            assert_eq!(path, None);
+            assert_eq!(session.as_deref(), Some("alpha"));
+        }
+        other => panic!("expected Replay, got {other:?}"),
+    }
+}
+
+#[test]
+fn replay_path_and_session_are_mutually_exclusive() {
+    let result = Cli::try_parse_from(["cleat", "replay", "/tmp/x.cast", "--session", "alpha"]);
+    assert!(result.is_err(), "path and --session should be mutually exclusive");
+}
+
+#[test]
+fn replay_requires_path_or_session() {
+    let result = Cli::try_parse_from(["cleat", "replay"]);
+    assert!(result.is_err(), "replay with no path or --session should error");
+}
+
+#[test]
+fn replay_since_marker_requires_session() {
+    let result = Cli::try_parse_from(["cleat", "replay", "/tmp/x.cast", "--since-marker", "a"]);
+    assert!(result.is_err(), "--since-marker without --session should error");
+}
+
+#[test]
+fn replay_speed_validates() {
+    let bad_speeds = ["0", "-1", "NaN", "inf"];
+    for s in bad_speeds {
+        let result = Cli::try_parse_from(["cleat", "replay", "/tmp/x.cast", "--speed", s]);
+        assert!(result.is_err(), "--speed {s} should be rejected");
+    }
+}
+
+#[test]
+fn replay_humantime_max_idle_parses() {
+    let cli =
+        Cli::try_parse_from(["cleat", "replay", "/tmp/x.cast", "--max-idle", "500ms"]).expect("parse");
+    match cli.command {
+        Command::Replay { max_idle, .. } => {
+            assert_eq!(max_idle, Some(std::time::Duration::from_millis(500)));
+        }
+        other => panic!("expected Replay, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p cleat --test cli replay --locked`
+
+Expected: 7 new tests pass; existing tests in the file continue to pass.
+
+- [ ] **Step 7: Full gates**
+
+All seven. Clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cleat/src/cli.rs crates/cleat/src/server.rs crates/cleat/tests/cli.rs
+git commit -m "cli: add replay subcommand with bound flags + --speed + --max-idle"
+```
+
+---
+
+## Task 5: Integration tests in `tests/replay.rs`
+
+**Files:**
+- Create: `crates/cleat/tests/replay.rs`
+
+**Goal:** Cast-file-driven integration tests that exercise the full `replay` dispatch path (path-based, no session daemon). Verifies byte-for-byte output fidelity and slice bounds.
+
+- [ ] **Step 1: Write the test file**
+
+Create `crates/cleat/tests/replay.rs`:
+
+```rust
+//! Integration tests for `cleat replay` — path-based invocation only.
+//! Session-based replay is exercised in `tests/lifecycle.rs`.
+
+use std::{io::Write, time::Duration};
+
+use clap::Parser;
+use cleat::{
+    asciicast::{encode_event, encode_header, Event, EventCode, Header},
+    cli::{self, Cli, Command, ExecResult},
+    recording::CAST_FILE_NAME,
+    runtime::RuntimeLayout,
+    server::SessionService,
+};
+
+fn write_fixture_cast(dir: &std::path::Path, events: &[Event]) -> std::path::PathBuf {
+    let path = dir.join("fixture.cast");
+    let mut f = std::fs::File::create(&path).unwrap();
+    let header = Header { cols: 80, rows: 24, ..Default::default() };
+    writeln!(f, "{}", encode_header(&header)).unwrap();
+    let mut prev = Duration::ZERO;
+    for e in events {
+        writeln!(f, "{}", encode_event(e, &mut prev)).unwrap();
+    }
+    path
+}
+
+fn service_for(root: &std::path::Path) -> SessionService {
+    SessionService::new(RuntimeLayout::new(root.to_path_buf()))
+}
+
+#[test]
+fn replay_positional_path_emits_concatenated_output() {
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![
+        Event { time: Duration::from_millis(100), code: EventCode::Output, data: "hello ".into() },
+        Event { time: Duration::from_millis(200), code: EventCode::Output, data: "world".into() },
+    ];
+    let cast = write_fixture_cast(temp.path(), &events);
+
+    let cli = Cli::try_parse_from([
+        "cleat",
+        "replay",
+        cast.to_str().unwrap(),
+        "--speed",
+        "1000",
+        "--max-idle",
+        "0ms",
+    ])
+    .expect("parse");
+
+    // execute prints to stdout; we can't easily capture stdout from inside the test
+    // process, but dispatch success proves the file was read and all events emitted.
+    let service = service_for(temp.path());
+    let result = cli::execute(cli, &service);
+    assert!(matches!(result, ExecResult::Ok(_)), "expected Ok, got {result:?}");
+}
+
+#[test]
+fn replay_positional_path_errors_on_missing_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let cli = Cli::try_parse_from(["cleat", "replay", "/nonexistent/file.cast", "--max-idle", "0ms"])
+        .expect("parse");
+
+    let service = service_for(temp.path());
+    let result = cli::execute(cli, &service);
+    match result {
+        ExecResult::Err(msg) => assert!(msg.contains("no such file"), "unexpected error: {msg}"),
+        other => panic!("expected Err, got {other:?}"),
+    }
+}
+
+#[test]
+fn replay_with_until_offset_honors_end_bound() {
+    let temp = tempfile::tempdir().unwrap();
+    let events = vec![
+        Event { time: Duration::from_millis(100), code: EventCode::Output, data: "keep".into() },
+        Event { time: Duration::from_millis(200), code: EventCode::Output, data: "drop".into() },
+    ];
+    let cast = write_fixture_cast(temp.path(), &events);
+
+    // Calculate the byte offset of the second event by measuring the file
+    // after writing only the first event would be fragile; instead assert the
+    // iterator itself honors end. Use the full-file path for a sanity run.
+    let cli = Cli::try_parse_from([
+        "cleat",
+        "replay",
+        cast.to_str().unwrap(),
+        "--since",
+        "0",
+        "--max-idle",
+        "0ms",
+    ])
+    .expect("parse");
+    let service = service_for(temp.path());
+    let result = cli::execute(cli, &service);
+    assert!(matches!(result, ExecResult::Ok(_)), "expected Ok, got {result:?}");
+}
+
+#[test]
+fn replay_rejects_since_marker_with_positional_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let result = Cli::try_parse_from([
+        "cleat",
+        "replay",
+        temp.path().join("fake.cast").to_str().unwrap(),
+        "--since-marker",
+        "a",
+    ]);
+    assert!(result.is_err(), "--since-marker without --session should be rejected at parse time");
+}
+
+#[test]
+fn replay_parses_full_flag_surface() {
+    let cli = Cli::try_parse_from([
+        "cleat",
+        "replay",
+        "/tmp/demo.cast",
+        "--since",
+        "100",
+        "--until",
+        "500",
+        "--speed",
+        "0.5",
+        "--max-idle",
+        "2s",
+    ])
+    .expect("parse");
+    match cli.command {
+        Command::Replay { path, since, until, speed, max_idle, .. } => {
+            assert!(path.is_some());
+            assert_eq!(since, Some(100));
+            assert_eq!(until, Some(500));
+            assert_eq!(speed, 0.5);
+            assert_eq!(max_idle, Some(Duration::from_secs(2)));
+        }
+        other => panic!("expected Replay, got {other:?}"),
+    }
+}
+```
+
+Note: stdout capture inside `cargo test` is awkward (tests run in the parent process and stdout goes to the test harness). These integration tests focus on successful dispatch and parse-level correctness; byte-level output verification against stdout is covered by the `replay::tests::play_writes_events_with_scaled_sleeps` unit test, which uses an in-memory writer.
+
+- [ ] **Step 2: Run tests — expect pass**
+
+Run: `cargo test -p cleat --test replay --locked`
+
+Expected: 5 tests pass.
+
+- [ ] **Step 3: Full gates**
+
+All seven. Clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cleat/tests/replay.rs
+git commit -m "test: integration tests for replay subcommand (path-based)"
+```
+
+---
+
+## Task 6: Lifecycle test for `--session` + marker flags
+
+**Files:**
+- Modify: `crates/cleat/tests/lifecycle.rs`
+
+**Goal:** One end-to-end lifecycle test exercising session-based replay with named markers, specifically while the daemon is alive (marker resolution goes through the socket).
+
+- [ ] **Step 1: Write the test**
+
+In `crates/cleat/tests/lifecycle.rs`, append (follow the pattern of `transcript_between_two_named_markers_returns_exact_range`):
+
+```rust
+#[test]
+fn replay_with_session_and_markers_while_daemon_alive() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(Some("alpha".into()), None, None, Some("sh -c 'stty raw; exec cat'".into()), true)
+        .expect("create");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    service.named_mark("alpha", "m1").expect("mark m1");
+    service.send_keys("alpha", b"middle").expect("send middle");
+    std::thread::sleep(Duration::from_millis(300));
+    service.named_mark("alpha", "m2").expect("mark m2");
+    service.send_keys("alpha", b"trailing").expect("send trailing");
+    std::thread::sleep(Duration::from_millis(300));
+
+    // While daemon still alive, run replay through the CLI dispatch.
+    // --speed 1000 keeps the test well under a second.
+    // --max-idle 0ms removes any residual sleep.
+    let cli = Cli::try_parse_from([
+        "cleat",
+        "replay",
+        "--session",
+        "alpha",
+        "--since-marker",
+        "m1",
+        "--until-marker",
+        "m2",
+        "--speed",
+        "1000",
+        "--max-idle",
+        "0ms",
+    ])
+    .expect("parse");
+
+    // Dispatch succeeds (stdout output isn't asserted here — the unit test
+    // `replay::tests::play_writes_events_with_scaled_sleeps` already verifies
+    // byte correctness with an in-memory writer). The point of this test is
+    // to exercise socket-backed marker resolution end-to-end.
+    let result = cli::execute(cli, &service);
+    assert!(matches!(result, ExecResult::Ok(_)), "expected Ok, got {result:?}");
+
+    // Cleanup: kill the session.
+    let _ = service.kill("alpha");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p cleat --test lifecycle replay_with_session_and_markers --locked`
+
+Expected: test passes (under a couple of seconds).
+
+- [ ] **Step 3: Full gates**
+
+All seven.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cleat/tests/lifecycle.rs
+git commit -m "test: lifecycle replay --session with --since-marker/--until-marker"
+```
+
+---
+
+## Task 7: Final validation sweep
+
+**Goal:** Confirm every gate `CLAUDE.md` specifies is green.
+
+- [ ] **Step 1: fmt**
+
+Run: `cargo +nightly-2026-03-12 fmt --check`
+
+Expected: no output.
+
+- [ ] **Step 2: Build, feature off**
+
+Run: `cargo build --locked`
+
+Expected: clean.
+
+- [ ] **Step 3: Build, feature on**
+
+Run: `cargo build --features ghostty-vt --locked`
+
+Expected: clean.
+
+- [ ] **Step 4: Clippy, feature off**
+
+Run: `cargo clippy --workspace --all-targets --locked -- -D warnings`
+
+Expected: clean.
+
+- [ ] **Step 5: Clippy, feature on**
+
+Run: `cargo clippy --workspace --all-targets --features cleat/ghostty-vt --locked -- -D warnings`
+
+Expected: clean.
+
+- [ ] **Step 6: Tests, feature off**
+
+Run: `cargo test --workspace --locked`
+
+Expected: all pass.
+
+- [ ] **Step 7: Tests, feature on**
+
+Run: `cargo test -p cleat --features ghostty-vt --locked`
+
+Expected: all pass.
+
+- [ ] **Step 8: Release build, feature on**
+
+Run: `cargo build -p cleat --features ghostty-vt --locked --release`
+
+Expected: clean.
+
+- [ ] **Step 9: Manual smoke (optional)**
+
+```bash
+./target/debug/cleat launch --record demo --cmd bash
+./target/debug/cleat send demo 'echo hello'
+sleep 1
+./target/debug/cleat mark demo --name after-hello
+./target/debug/cleat send demo 'echo world'
+sleep 1
+
+# Session form, live daemon:
+./target/debug/cleat replay --session demo --since-marker after-hello --speed 2
+
+# Path form:
+./target/debug/cleat replay ~/.local/share/cleat/demo/session.cast --speed 2
+
+./target/debug/cleat kill demo
+```
+
+Expect the session-form replay to show just `echo world` output at 2× speed. Expect the path-form replay to show the full session.
+
+No commit for this task.

--- a/docs/superpowers/specs/2026-04-22-transcript-replay-design.md
+++ b/docs/superpowers/specs/2026-04-22-transcript-replay-design.md
@@ -19,7 +19,7 @@ Agents debugging with cleat repeatedly need to replay recorded output at human-v
 
 - New `replay` subcommand.
 - Positional path argument (common case) or `--session <id>` flag (runtime lookup).
-- Full parity with `transcript`'s 6 bound flags (`--since`, `--since-marker`, `--until`, `--until-marker`, `--until-next-marker`, `--until-idle`).
+- The same 6 bound flags `transcript` accepts (`--since`, `--since-marker`, `--until`, `--until-marker`, `--until-next-marker`, `--until-idle`), with one restriction: marker-based flags require `--session` (markers are resolved through the daemon socket). Raw offset and `--until-idle` work with either the positional path or `--session`.
 - `--speed <f64>` — gap multiplier. Validated positive finite.
 - `--max-idle <duration>` — clamp gaps after speed scaling. Humantime format shared with `--until-idle` / `wait --idle-time`.
 - Streaming event reader in `cast_reader` so replay doesn't buffer the whole file.
@@ -49,9 +49,9 @@ cleat replay <path> --since-marker a --until-marker b     # slice
 
 ### `--session` marker resolution
 
-For `--session <id>` with `--since-marker` / `--until-marker` / `--until-next-marker`, marker resolution uses the existing daemon socket path (`SessionService::resolve_marker` / `resolve_next_marker_after`). If the daemon is gone (session ended), these fail with the existing error messages. A future improvement would be a cast-file marker scanner that reads `EventCode::Marker` events directly — out of scope here, but filed as a follow-up.
+For `--session <id>` with `--since-marker` / `--until-marker` / `--until-next-marker`, marker resolution uses the existing daemon socket path (`SessionService::resolve_marker` / `resolve_next_marker_after`). **The session's daemon must be alive when replay runs** — markers live in the daemon's in-memory map, not the cast file (markers ARE written to the cast file as `EventCode::Marker` events, so a cast-file marker scanner could support offline `--session` replay in the future, but that's out of scope here).
 
-For positional path (no session context), marker flags error at dispatch time with `--since-marker requires --session (markers are resolved through the daemon)`. Raw `--since` / `--until` / `--until-idle` work with positional path.
+Marker flags with a positional path (no `--session`) are rejected by clap via `requires = "session"` on each marker flag. Raw `--since` / `--until` / `--until-idle` work with either form.
 
 ## Event handling policy
 
@@ -83,7 +83,17 @@ for event in iter_output_between(path, start, end)? {
 }
 ```
 
-Gap of the first event from the start bound is relative to the recording's zero time, which — post the existing `read_output_between` seek semantics — is reset to zero at the seek point. So the first event's scaled gap is `event.time / speed`, which is correct: play the first event at its natural offset from the slice start.
+### Timing with arbitrary start offsets
+
+The existing `cast_reader` seek semantics (documented on `read_output_since`) reset delta accumulation to zero at the seek point. Consequence for replay: when a `--since <offset>` or `--since-marker <name>` seek lands between two events in the cast file, the first decoded event's `event.time` is the delta from the *previous* event that was written to the file — which may or may not be inside our slice range.
+
+Practical effects:
+
+- **Start at marker / offset-right-after-marker** (common case): the first output event's `event.time` is the natural inter-event delay from whatever output the child emitted most recently before the mark. Replay pauses by that amount before the first output. Usually what users want — it preserves the "rhythm" of the session starting from the mark.
+- **Start at arbitrary offset that lands in a long idle period**: first event's `event.time` can be many seconds, producing an initial pause before any output. Users wanting to skip this supply `--max-idle`, which clamps exactly this case.
+- **`prev_time` initialization**: the replay loop starts with `prev_time = Duration::ZERO` to match the reader's post-seek reset. First event's gap is therefore `event.time - 0 = event.time`.
+
+This matches what `transcript` does (concatenates output without regard to timing) and is the simplest semantics to reason about. If a more sophisticated mode is ever needed (e.g. "start immediately, no leading pause"), `--max-idle 0ms` is the knob.
 
 ## Architecture
 
@@ -157,11 +167,12 @@ pub(crate) fn resolve_slice_range(
 ### Error handling
 
 - **Path doesn't exist** → `replay: no such file: <path>`
-- **Not a valid asciicast v3** → existing `decode_event` errors surface; replay reports `replay: invalid cast file at <path>: <reason>`
+- **File I/O errors** (seek fail, read fail) → surface with file-path context.
+- **Malformed lines mid-stream** → silently skipped, matching the existing `cast_reader` behavior used by `transcript` and `capture`. The `iter_output_between` iterator yields only successfully-decoded events; decode errors are swallowed inside the iterator to preserve this invariant. Changing that reader-wide would be a separate design concern with knock-on effects for the merged `capture_slice_*` path, so it stays out of this spec.
 - **Broken pipe** (stdout consumer hangs up) → handle cleanly, exit 0. Rust's default behavior is to return `ErrorKind::BrokenPipe`; the replay loop treats it as end-of-replay.
-- **SIGINT** (Ctrl-C during sleep) → standard exit code 130. `std::thread::sleep` is interruptible by signal; signal handler is not added specially — the runtime's default behavior handles it.
-- **Speed ≤ 0 or non-finite** → clap value-parser rejects at parse time with the error string above.
-- **`--since-marker` / `--until-marker` / `--until-next-marker` with positional path** (no session) → dispatch-time error: `marker flags require --session`.
+- **SIGINT** (Ctrl-C during sleep) → standard exit code 130. `std::thread::sleep` is interruptible by signal; no special handler.
+- **Speed ≤ 0 or non-finite** → clap value-parser rejects at parse time with `invalid speed: <value>`.
+- **Marker flags with positional path** (`--since-marker` / `--until-marker` / `--until-next-marker` with no `--session`) → enforced at the clap layer via `requires = "session"`; clap emits the standard `the argument '--since-marker <...>' requires '--session <...>'` message. No runtime check needed.
 
 ## Testing
 
@@ -181,14 +192,18 @@ In `cast_reader.rs`:
 In `tests/replay.rs` (new file):
 - Fixture cast file with known events. Run replay with `--speed 1000` (fast), capture stdout, verify byte-for-byte match with the output-event concatenation.
 - Same but with `--max-idle 0ms` — expect zero sleeps, output identical.
-- Slice test: replay with `--since-offset` / `--until-offset` on the fixture, verify only the sliced output appears.
+- Slice test: replay with `--since <offset>` / `--until <offset>` on the fixture, verify only the sliced output appears.
 
 ### Lifecycle test (one)
 
-In `tests/lifecycle.rs`:
-- Create a session, mark A, send a few lines with short sleeps, mark B, send more, end.
-- Run `replay --session <id> --since-marker A --until-marker B --speed 1000`.
+In `tests/lifecycle.rs`, with the session daemon kept alive for the duration:
+
+- Create a session with recording, named_mark A, send a few lines with short sleeps, named_mark B, send more.
+- **While the daemon is still running**, invoke `replay --session <id> --since-marker A --until-marker B --speed 1000`.
 - Assert stdout contains the expected middle bytes and not the trailing bytes.
+- After the assertion, kill the session.
+
+This specifically exercises the socket-backed marker-resolution path. Offline `--session` replay (post-daemon-exit) is out of scope — a cast-file marker scanner would be needed, and that's its own follow-up.
 
 Timing-sensitive; use a fast speed multiplier to keep the test under a second.
 

--- a/docs/superpowers/specs/2026-04-22-transcript-replay-design.md
+++ b/docs/superpowers/specs/2026-04-22-transcript-replay-design.md
@@ -51,7 +51,7 @@ cleat replay <path> --since-marker a --until-marker b     # slice
 
 For `--session <id>` with `--since-marker` / `--until-marker` / `--until-next-marker`, marker resolution uses the existing daemon socket path (`SessionService::resolve_marker` / `resolve_next_marker_after`). **The session's daemon must be alive when replay runs** — markers live in the daemon's in-memory map, not the cast file (markers ARE written to the cast file as `EventCode::Marker` events, so a cast-file marker scanner could support offline `--session` replay in the future, but that's out of scope here).
 
-Marker flags with a positional path (no `--session`) are rejected by clap via `requires = "session"` on each marker flag. Raw `--since` / `--until` / `--until-idle` work with either form.
+Marker flags with a positional path (no `--session`) are rejected by clap via `conflicts_with = "path"` on each marker flag (originally planned as `requires = "session"`, but clap 4.6.1 treats `requires` as satisfied when the required arg has `required_unless_present` elsewhere — `conflicts_with = "path"` is semantically equivalent given `path` ↔ `--session` are strict XOR with one required). Raw `--since` / `--until` / `--until-idle` work with either form.
 
 ## Event handling policy
 
@@ -172,7 +172,7 @@ pub(crate) fn resolve_slice_range(
 - **Broken pipe** (stdout consumer hangs up) → handle cleanly, exit 0. Rust's default behavior is to return `ErrorKind::BrokenPipe`; the replay loop treats it as end-of-replay.
 - **SIGINT** (Ctrl-C during sleep) → standard exit code 130. `std::thread::sleep` is interruptible by signal; no special handler.
 - **Speed ≤ 0 or non-finite** → clap value-parser rejects at parse time with `invalid speed: <value>`.
-- **Marker flags with positional path** (`--since-marker` / `--until-marker` / `--until-next-marker` with no `--session`) → enforced at the clap layer via `requires = "session"`; clap emits the standard `the argument '--since-marker <...>' requires '--session <...>'` message. No runtime check needed.
+- **Marker flags with positional path** (`--since-marker` / `--until-marker` / `--until-next-marker` with no `--session`) → enforced at the clap layer via `conflicts_with = "path"`; clap emits the standard "cannot be used with" error. No runtime check needed. (See the `--session` marker resolution section above for why this is `conflicts_with` rather than the originally-planned `requires`.)
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-04-22-transcript-replay-design.md
+++ b/docs/superpowers/specs/2026-04-22-transcript-replay-design.md
@@ -1,0 +1,203 @@
+# `cleat replay` design
+
+**Date:** 2026-04-22
+**Issue:** [#53](https://github.com/flotilla-org/cleat/issues/53)
+
+## Problem
+
+Agents debugging with cleat repeatedly need to replay recorded output at human-viewable pace. Today the only option is `cat session.cast | jq '.[2]' | some-decoder` — the raw pty output flashes past too fast to inspect. The stage-11 agent note flagged this as the second-highest-priority improvement after the behavioral-model docs:
+
+> We ended up manually replaying captured byte files with `cat`, which is too fast to visually inspect. A built-in timed replay for recordings or transcript slices would be very useful.
+> [...]
+> This seems especially valuable for agent debugging, where the point is often to compare two very similar streams and understand where behavior diverges.
+
+`replay` is the built-in answer: play a cast file (or a slice of one) at controlled speed to stdout, with the same bound flags the just-merged `transcript` command has.
+
+## Scope
+
+**In scope**
+
+- New `replay` subcommand.
+- Positional path argument (common case) or `--session <id>` flag (runtime lookup).
+- Full parity with `transcript`'s 6 bound flags (`--since`, `--since-marker`, `--until`, `--until-marker`, `--until-next-marker`, `--until-idle`).
+- `--speed <f64>` — gap multiplier. Validated positive finite.
+- `--max-idle <duration>` — clamp gaps after speed scaling. Humantime format shared with `--until-idle` / `wait --idle-time`.
+- Streaming event reader in `cast_reader` so replay doesn't buffer the whole file.
+
+**Out of scope**
+
+- `--step` and any stepwise mode — deferred until #23 / #24 give us a semantic definition of "step" (a step in the child program's execution, not a cast-file line or byte chunk). Filing a follow-up on whichever of those issues is the better home.
+- `--output <file>` flag — `replay > file.bin` via shell redirection is already possible.
+- Progress indicator / elapsed-time display.
+- `--diff` or side-by-side multi-stream comparison.
+- Resize-event replay (re-emit `CSI ? 8 ;row; col t` on recorded resize events). The recording and replay terminals may be different sizes regardless; flagged as a known follow-up.
+
+## CLI surface
+
+```
+cleat replay <path>                                       # positional path
+cleat replay --session <id>                               # runtime lookup
+cleat replay <path> --speed 0.5                           # half-speed
+cleat replay <path> --max-idle 200ms                      # clamp idle
+cleat replay <path> --since-marker a --until-marker b     # slice
+```
+
+- **Path vs. `--session`** — mutually exclusive, one required. Positional accepted for the common "replay this file" case. `--session <id>` is for replaying a running-or-recently-run session's cast file from the runtime root (`$XDG_RUNTIME_DIR/cleat/<id>/session.cast`).
+- **Slice bounds** — all 6 flags reused from `transcript`. Same mutual-exclusion rules among end bounds; same start-bound-required rule. Shared code path via `SessionService::resolve_slice_range` (new extracted helper — see Architecture).
+- **`--speed <f64>`** — positive, finite multiplier. Default `1.0`. `0.5` = half-speed (gaps stretched 2×), `2.0` = double (gaps halved). Rejected if ≤ 0 or non-finite with the error `invalid speed: <value>`.
+- **`--max-idle <duration>`** — clamp any inter-event gap to this maximum after speed scaling. Reuses `duration_parser::parse_humantime_or_seconds`. `0ms` is legal and means "skip all pauses, dump at maximum speed."
+
+### `--session` marker resolution
+
+For `--session <id>` with `--since-marker` / `--until-marker` / `--until-next-marker`, marker resolution uses the existing daemon socket path (`SessionService::resolve_marker` / `resolve_next_marker_after`). If the daemon is gone (session ended), these fail with the existing error messages. A future improvement would be a cast-file marker scanner that reads `EventCode::Marker` events directly — out of scope here, but filed as a follow-up.
+
+For positional path (no session context), marker flags error at dispatch time with `--since-marker requires --session (markers are resolved through the daemon)`. Raw `--since` / `--until` / `--until-idle` work with positional path.
+
+## Event handling policy
+
+Walk events from the resolved start offset to the resolved end offset. For each event:
+
+| Code | Action |
+|---|---|
+| `Output` (`o`) | Sleep for the (scaled, clamped) gap, then write `event.data` bytes to stdout and flush |
+| `Input` (`i`) | Skip — replaying input would re-send the original user's keystrokes, confusing |
+| `Resize` (`r`) | Skip — replay terminal may be a different size than the recording; see follow-up |
+| `Marker` (`m`) | Skip — metadata |
+| `Exit` (`x`) | Skip — metadata |
+| `Custom(_)` | Skip — unknown |
+
+## Timing formula
+
+```rust
+let mut prev_time = Duration::ZERO;
+for event in iter_output_between(path, start, end)? {
+    let event = event?;
+    // cast_reader already filters to Output events, so event.code is Output here.
+    let gap = event.time.saturating_sub(prev_time);
+    let scaled = Duration::from_secs_f64(gap.as_secs_f64() / speed);
+    let clamped = max_idle.map_or(scaled, |m| scaled.min(m));
+    std::thread::sleep(clamped);
+    stdout.write_all(event.data.as_bytes())?;
+    stdout.flush()?;
+    prev_time = event.time;
+}
+```
+
+Gap of the first event from the start bound is relative to the recording's zero time, which — post the existing `read_output_between` seek semantics — is reset to zero at the seek point. So the first event's scaled gap is `event.time / speed`, which is correct: play the first event at its natural offset from the slice start.
+
+## Architecture
+
+### File layout
+
+- **New module** `crates/cleat/src/replay.rs` — replay loop, `ReplayOptions` struct, unit-tested timing function. Small (< 150 lines).
+- **Modify** `crates/cleat/src/cast_reader.rs` — add `iter_output_between` streaming iterator alongside the existing `read_output_between`. The Vec-returning function stays for callers that legitimately want it all (`capture_slice_inner`).
+- **Modify** `crates/cleat/src/cli.rs` — add `Command::Replay { ... }` variant and dispatch.
+- **Modify** `crates/cleat/src/server.rs` — extract bound resolution from `capture_slice_inner` into a separate `resolve_slice_range(id, StartBound, EndBound) -> Result<(u64, u64, Option<FallbackReason>), String>`. Both `capture_slice_inner` and the new replay dispatch use it. Keeps replay independent of `capture_slice_inner` (which allocates a Vec).
+- **Modify** `crates/cleat/src/lib.rs` — export `pub mod replay;`.
+
+### Streaming iterator
+
+```rust
+// in cast_reader.rs
+pub fn iter_output_between<'a>(
+    path: &'a Path,
+    start: u64,
+    end: u64,
+) -> Result<impl Iterator<Item = Result<Event, String>> + 'a, String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("open {path:?}: {e}"))?;
+    let mut reader = BufReader::new(file);
+    if start > 0 {
+        reader.seek(SeekFrom::Start(start)).map_err(|e| format!("seek: {e}"))?;
+    }
+    Ok(OutputEventIter {
+        reader,
+        byte_pos: start,
+        end,
+        prev_time: Duration::ZERO,
+        first_line: start == 0,
+    })
+}
+
+struct OutputEventIter<R> {
+    reader: BufReader<R>,
+    byte_pos: u64,
+    end: u64,
+    prev_time: Duration,
+    first_line: bool,
+}
+
+impl<R: BufRead> Iterator for OutputEventIter<R> {
+    type Item = Result<Event, String>;
+    fn next(&mut self) -> Option<Self::Item> {
+        // Loop until we find an Output event, EOF, or the byte range ends.
+        // Returns the next Output-code Event, skipping non-Output events
+        // and updating prev_time via decode_event.
+    }
+}
+```
+
+Implementation detail: the iterator filters to `EventCode::Output` internally so the replay loop doesn't need to.
+
+### Bound resolution extraction
+
+Current `capture_slice_inner` in `server.rs` does all of: resolve start, resolve end (with fallback-on-miss bookkeeping), read output, format result. The bound-resolution half is reusable. Extract:
+
+```rust
+pub(crate) fn resolve_slice_range(
+    &self,
+    id: &str,
+    start: StartBound,
+    end: EndBound,
+    cast_path: &Path,
+) -> Result<(u64, u64, Option<FallbackReason>), String> { ... }
+```
+
+`capture_slice_inner` calls this and then reads via `read_output_between`. Replay calls this and then reads via `iter_output_between`. No duplicated logic.
+
+### Error handling
+
+- **Path doesn't exist** → `replay: no such file: <path>`
+- **Not a valid asciicast v3** → existing `decode_event` errors surface; replay reports `replay: invalid cast file at <path>: <reason>`
+- **Broken pipe** (stdout consumer hangs up) → handle cleanly, exit 0. Rust's default behavior is to return `ErrorKind::BrokenPipe`; the replay loop treats it as end-of-replay.
+- **SIGINT** (Ctrl-C during sleep) → standard exit code 130. `std::thread::sleep` is interruptible by signal; signal handler is not added specially — the runtime's default behavior handles it.
+- **Speed ≤ 0 or non-finite** → clap value-parser rejects at parse time with the error string above.
+- **`--since-marker` / `--until-marker` / `--until-next-marker` with positional path** (no session) → dispatch-time error: `marker flags require --session`.
+
+## Testing
+
+### Unit tests
+
+In `replay.rs`:
+- Timing calculation: gap × speed / speed + clamp edge cases. Table-driven (gap, speed, max_idle) → expected sleep.
+- Speed validator: positive-finite cases pass, ≤ 0 / NaN / inf fail.
+
+In `cast_reader.rs`:
+- Iterator yields same events as the Vec-returning version on a fixture file (equivalence test).
+- Iterator respects byte-range bounds (same as existing `read_output_between` tests).
+- Iterator skips non-output events.
+
+### Integration tests
+
+In `tests/replay.rs` (new file):
+- Fixture cast file with known events. Run replay with `--speed 1000` (fast), capture stdout, verify byte-for-byte match with the output-event concatenation.
+- Same but with `--max-idle 0ms` — expect zero sleeps, output identical.
+- Slice test: replay with `--since-offset` / `--until-offset` on the fixture, verify only the sliced output appears.
+
+### Lifecycle test (one)
+
+In `tests/lifecycle.rs`:
+- Create a session, mark A, send a few lines with short sleeps, mark B, send more, end.
+- Run `replay --session <id> --since-marker A --until-marker B --speed 1000`.
+- Assert stdout contains the expected middle bytes and not the trailing bytes.
+
+Timing-sensitive; use a fast speed multiplier to keep the test under a second.
+
+## Rollout
+
+Single PR, single branch `transcript-replay`. No feature flag — new subcommand.
+
+Follow-ups:
+- Stepwise (`--step`) when #23/#24 land. A comment on the right issue will point back to this spec's omission.
+- Resize-event replay (follow-up issue if anyone asks).
+- Cast-file marker scanning for `--session <id>` with dead daemons (follow-up issue).
+- `--diff` / side-by-side mode (not this PR).


### PR DESCRIPTION
## Summary

Adds a \`cleat replay\` subcommand that plays back cast files (or slices of them) to stdout at controlled speed. Closes #53.

\`\`\`
cleat replay <path>                                       # positional path
cleat replay --session <id>                               # runtime lookup (live daemon)
cleat replay <path> --speed 0.5                           # half-speed
cleat replay <path> --max-idle 200ms                      # clamp gaps after speed scaling
cleat replay <path> --since X --until Y                   # slice (path can use offset/idle bounds)
cleat replay --session id --since-marker A --until-marker B   # session form supports markers
\`\`\`

The 6 transcript end-bound flags (\`--since\`, \`--since-marker\`, \`--until\`, \`--until-marker\`, \`--until-next-marker\`, \`--until-idle\`) compose with replay. Marker-based bounds require \`--session\` (markers live in the daemon's in-memory map). Soft-ceiling fallback emits the same \`# bounded by EOF (...)\` stderr note as \`transcript\`.

## Architecture

- **Streaming.** New \`cast_reader::iter_output_between\` yields \`Output\` events without buffering. \`replay::run_replay\` consumes the iterator and writes to stdout with inter-event sleeps. \`read_output_between\` (Vec) stays for \`capture_slice_inner\` which legitimately wants a Vec.
- **Bound resolution shared.** \`SessionService::resolve_slice_range\` (extracted from \`capture_slice_inner\`) is the session-form resolver; \`server::resolve_range_for_path\` is the parallel free function for path-form. CLI dispatch picks one and calls \`run_replay\` against the result.
- **Testable core.** \`run_replay(cast_path, start, end, opts, writer, sleeper)\` separates the pure playback loop from CLI plumbing. Integration tests pass a \`Vec<u8>\` writer and a no-op sleeper to assert byte-level output.
- **Speed validation.** \`--speed\` uses a custom value parser (positive finite). \`sleep_for_gap\` saturates at \`Duration::MAX\` rather than panicking on extreme values (e.g. \`--speed 1e-20\`).

## Out of scope (deliberate)

- \`--step\` and any stepwise mode — deferred until #23 / #24 give us a semantic step definition. Filing a follow-up on the right issue post-merge.
- Resize-event replay (recording and replay terminals can be different sizes; complicated and not commonly needed).
- Cast-file marker scanner for \`--session\` after the daemon exits — possible follow-up.
- \`--diff\` / side-by-side multi-stream comparison.

## Commits

10 commits — bisect-clean, each compiles + passes its own gates:

\`\`\`
docs: design spec for cleat replay (#53)
review: apply codex review fixes to replay spec
docs: implementation plan for cleat replay (#53)
cast_reader: add iter_output_between streaming iterator
server: extract resolve_slice_range from capture_slice_inner
replay: module scaffold with sleep_for_gap, play loop, parse_speed
cli: add replay subcommand with bound flags + --speed + --max-idle
test: integration tests for replay subcommand (path-based)
test: lifecycle replay --session with --since-marker/--until-marker
review: saturate extreme speed, extract run_replay + path resolver, assert bytes in tests
\`\`\`

The final \"review: saturate extreme speed...\" commit folds in fixes from a pre-PR holistic review (panic on extreme \`--speed\`, integration tests not asserting bytes, code duplication between path and session arms). No outstanding review items.

## Implementation note

clap 4.6.1 has a quirk: \`requires = \"session\"\` is satisfied when \`session\` has \`required_unless_present\` elsewhere, even if \`session\` isn't actually provided. The marker flags use \`conflicts_with = \"path\"\` instead — semantically equivalent given path↔session are strict XOR with one required.

## Test plan

- [x] \`cargo +nightly-2026-03-12 fmt --check\` — clean
- [x] \`cargo build --locked\` and \`cargo build --features ghostty-vt --locked\` — clean
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\` — clean
- [x] \`cargo clippy --workspace --all-targets --features cleat/ghostty-vt --locked -- -D warnings\` — clean
- [x] \`cargo test --workspace --locked\` — 249 passed
- [x] \`cargo test -p cleat --features ghostty-vt --locked\` — 280 passed
  - New: 11 \`replay::tests\` (timing, validation, broken pipe, iterator errors, saturation), 3 \`cast_reader\` iterator tests, 8 integration tests in \`tests/replay.rs\` (5 byte-asserting + 3 parse-level), 1 lifecycle test (asserts middle/trailing bytes)
- [x] \`cargo build -p cleat --features ghostty-vt --locked --release\` — clean

## Related

- #29 — VT stream transcoding (the \"transformed bytes for less-capable consumer\" story this is adjacent to)
- #53 — closes