### PR TITLE
Support Windows foreground attach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,10 @@ If you say a change matches CI locally, it should have been checked against thes
 ## Ghostty Build Metadata
 
 - `ghostty-vt` stays optional and must not affect the default Rust-only build.
-- The local helper at [`tools/prepare-ghostty-vt.sh`](tools/prepare-ghostty-vt.sh) reads pinned inputs from [`tools/ghostty-toolchain.toml`](tools/ghostty-toolchain.toml), verifies the configured Zig version, clones or refreshes the Ghostty fork in `.tools/ghostty-src`, and installs the Ghostty VT headers and libraries into `.tools/ghostty-install`.
+- The local helpers at [`tools/prepare-ghostty-vt.sh`](tools/prepare-ghostty-vt.sh) and [`tools/prepare-ghostty-vt.ps1`](tools/prepare-ghostty-vt.ps1) read pinned inputs from [`tools/ghostty-toolchain.toml`](tools/ghostty-toolchain.toml), verify or install the configured Zig version, clone or refresh the Ghostty fork in `.tools/ghostty-src`, and install the Ghostty VT headers and libraries into `.tools/ghostty-install`.
 - Re-run the helper after changing the pinned ref or Zig version; it is expected to be idempotent and to refresh the repo-local checkout and install prefix.
-- `cleat` treats Ghostty as a prefix-only shared-library dependency: headers at `.tools/ghostty-install/include/ghostty/vt.h` and `libghostty-vt.so` at `.tools/ghostty-install/lib/libghostty-vt.so`.
-- Feature-on builds and tests must set `LD_LIBRARY_PATH="$PWD/.tools/ghostty-install/lib"` so the dynamic loader can find `libghostty-vt.so`.
-- Verify the helper with `./tools/prepare-ghostty-vt.sh`, `find .tools/ghostty-install -maxdepth 3 | sort`, `LD_LIBRARY_PATH="$PWD/.tools/ghostty-install/lib" cargo build -p cleat --locked --features ghostty-vt`, and `LD_LIBRARY_PATH="$PWD/.tools/ghostty-install/lib" cargo test -p cleat --locked --features ghostty-vt`.
+- `cleat` treats Ghostty as a prefix dependency: headers at `.tools/ghostty-install/include/ghostty/vt.h` and libraries under `.tools/ghostty-install/lib`. Static linking is preferred on Unix when `libghostty-vt.a` is available; shared library linkage remains a fallback. Windows links via `ghostty-vt.lib` and copies `ghostty-vt.dll` next to the built executable.
+- Verify the helper with `./tools/prepare-ghostty-vt.sh` on Unix or `powershell -NoProfile -ExecutionPolicy Bypass -File tools\prepare-ghostty-vt.ps1` on Windows, then `cargo build -p cleat --locked --features ghostty-vt` and `cargo test -p cleat --locked --features ghostty-vt`.
 
 ## Repo Scope
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "uuid",
+ "windows-sys",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -33,19 +33,27 @@ Use the repo-local helper to fetch the pinned Ghostty ref and build a local inst
 
 On **Linux**:
 ```bash
-LD_LIBRARY_PATH="$PWD/.tools/ghostty-install/lib" cargo build -p cleat --locked --features ghostty-vt
-LD_LIBRARY_PATH="$PWD/.tools/ghostty-install/lib" cargo test -p cleat --locked --features ghostty-vt
+cargo build -p cleat --locked --features ghostty-vt
+cargo test -p cleat --locked --features ghostty-vt
 ```
 
 On **macOS**:
 ```bash
-DYLD_LIBRARY_PATH="$PWD/.tools/ghostty-install/lib" cargo build -p cleat --locked --features ghostty-vt
-DYLD_LIBRARY_PATH="$PWD/.tools/ghostty-install/lib" cargo test -p cleat --locked --features ghostty-vt
+cargo build -p cleat --locked --features ghostty-vt
+cargo test -p cleat --locked --features ghostty-vt
 ```
 
-The helper reads pinned inputs from [`tools/ghostty-toolchain.toml`](tools/ghostty-toolchain.toml), verifies Zig `0.15.2`, clones or refreshes Ghostty into `.tools/ghostty-src`, and installs the Ghostty VT headers and shared library into `.tools/ghostty-install`.
+On **Windows**:
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File tools\prepare-ghostty-vt.ps1
+$env:CLEAT_GHOSTTY_PREFIX = (Resolve-Path .tools\ghostty-install).Path
+cargo build -p cleat --locked --features ghostty-vt
+cargo test -p cleat --locked --features ghostty-vt
+```
 
-The `ghostty-vt` build path defaults to the repo-local prefix at `.tools/ghostty-install`. You can still override it with `CLEAT_GHOSTTY_PREFIX`, but feature-on runs and tests must set the library path (`LD_LIBRARY_PATH` on Linux, `DYLD_LIBRARY_PATH` on macOS) so the loader can find the shared library.
+The helpers read pinned inputs from [`tools/ghostty-toolchain.toml`](tools/ghostty-toolchain.toml), verify or install Zig `0.15.2`, clone or refresh Ghostty into `.tools/ghostty-src`, and install the Ghostty VT headers and libraries into `.tools/ghostty-install`.
+
+The `ghostty-vt` build path defaults to the repo-local prefix at `.tools/ghostty-install`. You can still override it with `CLEAT_GHOSTTY_PREFIX`. Cleat prefers the static Ghostty VT library on Unix when present (`libghostty-vt.a`) and falls back to the shared library otherwise. On Windows, cleat links against `ghostty-vt.lib` and copies `ghostty-vt.dll` next to the built executable.
 
 ```bash
 find .tools/ghostty-install -maxdepth 3 | sort

--- a/crates/cleat/Cargo.toml
+++ b/crates/cleat/Cargo.toml
@@ -21,5 +21,14 @@ nix = { version = "0.31.2", features = ["fs", "poll", "process", "signal", "term
 sysinfo = "0.38"
 uuid = { version = "1", features = ["v4"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Console",
+    "Win32_System_Pipes",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cleat/Cargo.toml
+++ b/crates/cleat/Cargo.toml
@@ -25,7 +25,9 @@ uuid = { version = "1", features = ["v4"] }
 windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_Console",
+    "Win32_System_IO",
     "Win32_System_Pipes",
     "Win32_System_Threading",
 ] }

--- a/crates/cleat/build.rs
+++ b/crates/cleat/build.rs
@@ -11,11 +11,15 @@ fn main() {
         println!("cargo:warning=building cleat without ghostty-vt; this binary is non-functional for real terminal usage");
         println!("cargo:warning=Ghostty is currently the only functional VT engine");
         println!("cargo:warning=passthrough is a placeholder/testing engine only");
-        println!("cargo:warning=run ./tools/prepare-ghostty-vt.sh and rebuild with --features ghostty-vt for a functional binary");
+        if cfg!(target_os = "windows") {
+            println!("cargo:warning=run ./tools/prepare-ghostty-vt.ps1 and rebuild with --features ghostty-vt for a functional binary");
+        } else {
+            println!("cargo:warning=run ./tools/prepare-ghostty-vt.sh and rebuild with --features ghostty-vt for a functional binary");
+        }
         return;
     }
     if !ghostty_supported_target() {
-        panic!("ghostty-vt feature requires Linux or macOS");
+        panic!("ghostty-vt feature requires Linux, macOS, or Windows");
     }
 
     println!("cargo:rerun-if-env-changed=CLEAT_GHOSTTY_PREFIX");
@@ -24,16 +28,32 @@ fn main() {
     let repo_root = repo_root().unwrap_or_else(|err| panic!("{err}"));
     let install = ghostty_install(&repo_root).unwrap_or_else(|err| panic!("{err}"));
     watch_ghostty_install(&install.prefix);
+    if cfg!(target_os = "windows") && install.link_mode == LinkMode::Dynamic {
+        copy_windows_runtime_dll(&install).unwrap_or_else(|err| panic!("{err}"));
+    }
 
     println!("cargo:rustc-env=CLEAT_GHOSTTY_PREFIX={}", install.prefix.display());
     println!("cargo:rustc-link-search=native={}", install.lib_dir.display());
-    println!("cargo:rustc-link-lib=dylib=ghostty-vt");
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", install.lib_dir.display());
+    match install.link_mode {
+        LinkMode::Static => println!("cargo:rustc-link-lib=static={}", static_link_name()),
+        LinkMode::Dynamic => println!("cargo:rustc-link-lib=dylib=ghostty-vt"),
+    }
+    if install.link_mode == LinkMode::Dynamic && cfg!(any(target_os = "linux", target_os = "macos")) {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{}", install.lib_dir.display());
+    }
 }
 
 struct GhosttyInstall {
     prefix: PathBuf,
     lib_dir: PathBuf,
+    link_mode: LinkMode,
+    shared_lib: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LinkMode {
+    Static,
+    Dynamic,
 }
 
 fn ghostty_install(repo_root: &Path) -> Result<GhosttyInstall, String> {
@@ -57,12 +77,31 @@ fn ghostty_install(repo_root: &Path) -> Result<GhosttyInstall, String> {
         return Err(missing_ghostty_install_message(&prefix, format!("missing Ghostty library directory at {}", lib_dir.display())));
     }
 
-    let shared_lib = lib_dir.join(shared_library_filename());
-    if !shared_lib.exists() {
-        return Err(missing_ghostty_install_message(&prefix, format!("missing shared ghostty library at {}", shared_lib.display())));
+    let shared_lib = shared_library_path(&prefix, &lib_dir);
+    if cfg!(target_os = "windows") {
+        let import_lib = lib_dir.join(import_library_filename());
+        if !shared_lib.exists() {
+            return Err(missing_ghostty_install_message(&prefix, format!("missing ghostty DLL at {}", shared_lib.display())));
+        }
+        if !import_lib.exists() {
+            return Err(missing_ghostty_install_message(&prefix, format!("missing ghostty import library at {}", import_lib.display())));
+        }
+        return Ok(GhosttyInstall { prefix, lib_dir, link_mode: LinkMode::Dynamic, shared_lib: Some(shared_lib) });
     }
 
-    Ok(GhosttyInstall { prefix, lib_dir })
+    let static_lib = lib_dir.join(static_library_filename());
+    if static_lib.exists() {
+        return Ok(GhosttyInstall { prefix, lib_dir, link_mode: LinkMode::Static, shared_lib: None });
+    }
+
+    if !shared_lib.exists() {
+        return Err(missing_ghostty_install_message(
+            &prefix,
+            format!("missing ghostty library; expected {} or {}", static_lib.display(), shared_lib.display()),
+        ));
+    }
+
+    Ok(GhosttyInstall { prefix, lib_dir, link_mode: LinkMode::Dynamic, shared_lib: Some(shared_lib) })
 }
 
 fn ghostty_prefix(repo_root: &Path) -> Result<PathBuf, String> {
@@ -88,16 +127,48 @@ fn watch_ghostty_install(prefix: &Path) {
     let lib_dir = prefix.join("lib");
     let header = prefix.join("include/ghostty/vt.h");
     println!("cargo:rerun-if-changed={}", header.display());
+    println!("cargo:rerun-if-changed={}", lib_dir.join(static_library_filename()).display());
     println!("cargo:rerun-if-changed={}", lib_dir.join(shared_library_filename()).display());
+    if cfg!(target_os = "windows") {
+        println!("cargo:rerun-if-changed={}", prefix.join("bin").join(shared_library_filename()).display());
+        println!("cargo:rerun-if-changed={}", lib_dir.join(import_library_filename()).display());
+    }
 }
 
 fn missing_ghostty_install_message(prefix: &Path, reason: String) -> String {
-    format!(
-        "ghostty-vt feature requires a prepared Ghostty install prefix. {reason}.\n\
+    if cfg!(target_os = "windows") {
+        format!(
+            "ghostty-vt feature requires a prepared Ghostty install prefix. {reason}.\n\
+run ./tools/prepare-ghostty-vt.ps1 and retry with:\n\
+$env:CLEAT_GHOSTTY_PREFIX=\"{}\"; $env:PATH=\"{}\\bin;{}\\lib;$env:PATH\"; cargo build -p cleat --locked --features ghostty-vt",
+            prefix.display(),
+            prefix.display(),
+            prefix.display()
+        )
+    } else {
+        format!(
+            "ghostty-vt feature requires a prepared Ghostty install prefix. {reason}.\n\
 run ./tools/prepare-ghostty-vt.sh and retry with:\n\
-LD_LIBRARY_PATH=\"{}/lib\" cargo build -p cleat --locked --features ghostty-vt",
-        prefix.display()
-    )
+CLEAT_GHOSTTY_PREFIX=\"{}\" cargo build -p cleat --locked --features ghostty-vt",
+            prefix.display()
+        )
+    }
+}
+
+fn static_library_filename() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "ghostty-vt-static.lib"
+    } else {
+        "libghostty-vt.a"
+    }
+}
+
+fn static_link_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "ghostty-vt-static"
+    } else {
+        "ghostty-vt"
+    }
 }
 
 fn shared_library_filename() -> &'static str {
@@ -105,11 +176,46 @@ fn shared_library_filename() -> &'static str {
         "libghostty-vt.so"
     } else if cfg!(target_os = "macos") {
         "libghostty-vt.dylib"
+    } else if cfg!(target_os = "windows") {
+        "ghostty-vt.dll"
     } else {
-        panic!("ghostty-vt feature requires Linux or macOS")
+        panic!("ghostty-vt feature requires Linux, macOS, or Windows")
     }
 }
 
+fn shared_library_path(prefix: &Path, lib_dir: &Path) -> PathBuf {
+    let lib_path = lib_dir.join(shared_library_filename());
+    if cfg!(target_os = "windows") {
+        let bin_path = prefix.join("bin").join(shared_library_filename());
+        if bin_path.exists() {
+            return bin_path;
+        }
+    }
+    lib_path
+}
+
+fn import_library_filename() -> &'static str {
+    "ghostty-vt.lib"
+}
+
+fn copy_windows_runtime_dll(install: &GhosttyInstall) -> Result<(), String> {
+    let dll = install.shared_lib.as_ref().ok_or_else(|| "dynamic Ghostty install has no DLL path".to_string())?;
+    let profile_dir = profile_dir_from_out_dir()?;
+    let target = profile_dir.join(shared_library_filename());
+    std::fs::copy(dll, &target).map_err(|err| format!("copy {} to {}: {err}", dll.display(), target.display()))?;
+    println!("cargo:rerun-if-changed={}", dll.display());
+    Ok(())
+}
+
+fn profile_dir_from_out_dir() -> Result<PathBuf, String> {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").ok_or_else(|| "OUT_DIR is not set".to_string())?);
+    out_dir
+        .ancestors()
+        .nth(3)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| format!("could not determine Cargo profile directory from OUT_DIR={}", out_dir.display()))
+}
+
 fn ghostty_supported_target() -> bool {
-    cfg!(any(target_os = "linux", target_os = "macos"))
+    cfg!(any(target_os = "linux", target_os = "macos", target_os = "windows"))
 }

--- a/crates/cleat/build.rs
+++ b/crates/cleat/build.rs
@@ -90,14 +90,13 @@ fn ghostty_install(repo_root: &Path) -> Result<GhosttyInstall, String> {
     }
 
     let static_lib = lib_dir.join(static_library_filename());
-    if static_lib.exists() {
-        return Ok(GhosttyInstall { prefix, lib_dir, link_mode: LinkMode::Static, shared_lib: None });
-    }
-
     if !shared_lib.exists() {
+        if static_lib.exists() {
+            return Ok(GhosttyInstall { prefix, lib_dir, link_mode: LinkMode::Static, shared_lib: None });
+        }
         return Err(missing_ghostty_install_message(
             &prefix,
-            format!("missing ghostty library; expected {} or {}", static_lib.display(), shared_lib.display()),
+            format!("missing ghostty library; expected {} or {}", shared_lib.display(), static_lib.display()),
         ));
     }
 

--- a/crates/cleat/examples/windows-conpty-spike.rs
+++ b/crates/cleat/examples/windows-conpty-spike.rs
@@ -3,7 +3,7 @@ mod spike {
     use std::error::Error;
     use std::ffi::c_void;
     use std::fs::File;
-    use std::io::Read;
+    use std::io::{Read, Write};
     use std::mem::{size_of, zeroed};
     use std::os::windows::io::FromRawHandle;
     use std::ptr::{null, null_mut};
@@ -22,11 +22,19 @@ mod spike {
     const READY_MARKER: &str = "cleat-conpty-ready";
 
     pub fn run() -> Result<(), Box<dyn Error>> {
+        run_probe("command-line", "cmd.exe /D /Q /C echo cleat-conpty-ready && exit /b 7", None)?;
+        run_probe("interactive", "cmd.exe /D /Q /K", Some(b"echo cleat-conpty-ready\r\nexit /b 7\r\n"))?;
+
+        Ok(())
+    }
+
+    fn run_probe(name: &str, command_line: &str, input_bytes: Option<&[u8]>) -> Result<(), Box<dyn Error>> {
         let pipes = Pipes::new()?;
         let conpty = PseudoConsole::new(80, 24, pipes.input_read, pipes.output_write)?;
 
-        let child = ChildProcess::spawn_with_conpty("cmd.exe /D /Q /C echo cleat-conpty-ready && exit /b 7", conpty.handle)?;
+        let child = ChildProcess::spawn_with_conpty(command_line, conpty.handle)?;
 
+        let mut input = input_bytes.map(|_| unsafe { File::from_raw_handle(pipes.input_write) });
         let mut output = unsafe { File::from_raw_handle(pipes.output_read) };
 
         let reader = thread::spawn(move || {
@@ -34,17 +42,27 @@ mod spike {
             output.read_to_end(&mut transcript).map(|_| transcript)
         });
 
+        if let Some(bytes) = input_bytes {
+            thread::sleep(std::time::Duration::from_millis(250));
+            let input = input.as_mut().expect("input file is created when input bytes exist");
+            input.write_all(bytes)?;
+            input.flush()?;
+        }
+
         let wait_status = unsafe { WaitForSingleObject(child.process, 5_000) };
+        drop(input);
         unsafe {
-            CloseHandle(pipes.input_write);
+            if input_bytes.is_none() {
+                CloseHandle(pipes.input_write);
+            }
             CloseHandle(pipes.input_read);
             CloseHandle(pipes.output_write);
         }
         if wait_status == WAIT_TIMEOUT {
-            return Err("timed out waiting for ConPTY child process".into());
+            return Err(format!("{name} probe timed out waiting for ConPTY child process").into());
         }
         if wait_status != WAIT_OBJECT_0 {
-            return Err(format!("unexpected WaitForSingleObject status {wait_status}").into());
+            return Err(format!("{name} probe got unexpected WaitForSingleObject status {wait_status}").into());
         }
 
         let mut exit_code = 0;
@@ -60,13 +78,14 @@ mod spike {
             reader.join().map_err(|_| "reader thread panicked")?.map_err(|err| format!("failed to read ConPTY output: {err}"))?;
         let transcript = String::from_utf8_lossy(&transcript);
 
+        println!("=== {name} ===");
         println!("{transcript}");
         println!("exit_code={exit_code}");
 
         let normalized_transcript = transcript.replace('\0', "");
         if !normalized_transcript.contains(READY_MARKER) {
             return Err(format!(
-                "ConPTY transcript did not contain {READY_MARKER:?}: {:?}",
+                "{name} probe ConPTY transcript did not contain {READY_MARKER:?}: {:?}",
                 normalized_transcript.escape_debug().to_string()
             )
             .into());

--- a/crates/cleat/examples/windows-conpty-spike.rs
+++ b/crates/cleat/examples/windows-conpty-spike.rs
@@ -1,0 +1,244 @@
+#[cfg(windows)]
+mod spike {
+    use std::error::Error;
+    use std::ffi::c_void;
+    use std::fs::File;
+    use std::io::Read;
+    use std::mem::{size_of, zeroed};
+    use std::os::windows::io::FromRawHandle;
+    use std::ptr::{null, null_mut};
+    use std::thread;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+    use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+    use windows_sys::Win32::System::Console::{ClosePseudoConsole, CreatePseudoConsole, COORD, HPCON};
+    use windows_sys::Win32::System::Pipes::CreatePipe;
+    use windows_sys::Win32::System::Threading::{
+        CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess, InitializeProcThreadAttributeList, UpdateProcThreadAttribute,
+        WaitForSingleObject, EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION,
+        PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+    };
+
+    const READY_MARKER: &str = "cleat-conpty-ready";
+
+    pub fn run() -> Result<(), Box<dyn Error>> {
+        let pipes = Pipes::new()?;
+        let conpty = PseudoConsole::new(80, 24, pipes.input_read, pipes.output_write)?;
+
+        let child = ChildProcess::spawn_with_conpty("cmd.exe /D /Q /C echo cleat-conpty-ready && exit /b 7", conpty.handle)?;
+
+        let mut output = unsafe { File::from_raw_handle(pipes.output_read) };
+
+        let reader = thread::spawn(move || {
+            let mut transcript = Vec::new();
+            output.read_to_end(&mut transcript).map(|_| transcript)
+        });
+
+        let wait_status = unsafe { WaitForSingleObject(child.process, 5_000) };
+        unsafe {
+            CloseHandle(pipes.input_write);
+            CloseHandle(pipes.input_read);
+            CloseHandle(pipes.output_write);
+        }
+        if wait_status == WAIT_TIMEOUT {
+            return Err("timed out waiting for ConPTY child process".into());
+        }
+        if wait_status != WAIT_OBJECT_0 {
+            return Err(format!("unexpected WaitForSingleObject status {wait_status}").into());
+        }
+
+        let mut exit_code = 0;
+        let got_exit_code = unsafe { GetExitCodeProcess(child.process, &mut exit_code) };
+        if got_exit_code == 0 {
+            return Err(last_error("GetExitCodeProcess").into());
+        }
+
+        drop(conpty);
+        drop(child);
+
+        let transcript =
+            reader.join().map_err(|_| "reader thread panicked")?.map_err(|err| format!("failed to read ConPTY output: {err}"))?;
+        let transcript = String::from_utf8_lossy(&transcript);
+
+        println!("{transcript}");
+        println!("exit_code={exit_code}");
+
+        let normalized_transcript = transcript.replace('\0', "");
+        if !normalized_transcript.contains(READY_MARKER) {
+            return Err(format!(
+                "ConPTY transcript did not contain {READY_MARKER:?}: {:?}",
+                normalized_transcript.escape_debug().to_string()
+            )
+            .into());
+        }
+        if exit_code != 7 {
+            return Err(format!("expected exit code 7, got {exit_code}").into());
+        }
+
+        Ok(())
+    }
+
+    struct Pipes {
+        input_read: HANDLE,
+        input_write: HANDLE,
+        output_read: HANDLE,
+        output_write: HANDLE,
+    }
+
+    impl Pipes {
+        fn new() -> Result<Self, String> {
+            let mut attrs = SECURITY_ATTRIBUTES {
+                nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+                lpSecurityDescriptor: null_mut(),
+                bInheritHandle: 0,
+            };
+
+            let mut input_read = null_mut();
+            let mut input_write = null_mut();
+            let mut output_read = null_mut();
+            let mut output_write = null_mut();
+
+            unsafe {
+                if CreatePipe(&mut input_read, &mut input_write, &mut attrs, 0) == 0 {
+                    return Err(last_error("CreatePipe input"));
+                }
+                if CreatePipe(&mut output_read, &mut output_write, &mut attrs, 0) == 0 {
+                    CloseHandle(input_read);
+                    CloseHandle(input_write);
+                    return Err(last_error("CreatePipe output"));
+                }
+            }
+
+            Ok(Self { input_read, input_write, output_read, output_write })
+        }
+    }
+
+    struct PseudoConsole {
+        handle: HPCON,
+    }
+
+    impl PseudoConsole {
+        fn new(width: i16, height: i16, input: HANDLE, output: HANDLE) -> Result<Self, String> {
+            let mut handle = 0;
+            let result = unsafe { CreatePseudoConsole(COORD { X: width, Y: height }, input, output, 0, &mut handle) };
+
+            if result < 0 {
+                return Err(format!("CreatePseudoConsole failed with HRESULT 0x{result:08x}"));
+            }
+
+            Ok(Self { handle })
+        }
+    }
+
+    impl Drop for PseudoConsole {
+        fn drop(&mut self) {
+            unsafe {
+                ClosePseudoConsole(self.handle);
+            }
+        }
+    }
+
+    struct ChildProcess {
+        process: HANDLE,
+        thread: HANDLE,
+    }
+
+    impl ChildProcess {
+        fn spawn_with_conpty(command_line: &str, conpty: HPCON) -> Result<Self, String> {
+            let mut attr_size = 0;
+            unsafe {
+                InitializeProcThreadAttributeList(null_mut(), 1, 0, &mut attr_size);
+            }
+
+            let mut attr_storage = vec![0u8; attr_size];
+            let attr_list = attr_storage.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST;
+
+            let initialized = unsafe { InitializeProcThreadAttributeList(attr_list, 1, 0, &mut attr_size) };
+            if initialized == 0 {
+                return Err(last_error("InitializeProcThreadAttributeList"));
+            }
+
+            let updated = unsafe {
+                UpdateProcThreadAttribute(
+                    attr_list,
+                    0,
+                    PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE as usize,
+                    conpty as *const c_void,
+                    size_of::<HPCON>(),
+                    null_mut(),
+                    null(),
+                )
+            };
+            if updated == 0 {
+                unsafe {
+                    DeleteProcThreadAttributeList(attr_list);
+                }
+                return Err(last_error("UpdateProcThreadAttribute"));
+            }
+
+            let mut startup_info: STARTUPINFOEXW = unsafe { zeroed() };
+            startup_info.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as u32;
+            startup_info.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+            startup_info.StartupInfo.hStdInput = null_mut();
+            startup_info.StartupInfo.hStdOutput = null_mut();
+            startup_info.StartupInfo.hStdError = null_mut();
+            startup_info.lpAttributeList = attr_list;
+
+            let mut process_info: PROCESS_INFORMATION = unsafe { zeroed() };
+            let mut command_line = wide_null(command_line);
+
+            let created = unsafe {
+                CreateProcessW(
+                    null(),
+                    command_line.as_mut_ptr(),
+                    null(),
+                    null(),
+                    0,
+                    EXTENDED_STARTUPINFO_PRESENT,
+                    null(),
+                    null(),
+                    &startup_info as *const STARTUPINFOEXW as *const _,
+                    &mut process_info,
+                )
+            };
+
+            unsafe {
+                DeleteProcThreadAttributeList(attr_list);
+            }
+
+            if created == 0 {
+                return Err(last_error("CreateProcessW"));
+            }
+
+            Ok(Self { process: process_info.hProcess, thread: process_info.hThread })
+        }
+    }
+
+    impl Drop for ChildProcess {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.thread);
+                CloseHandle(self.process);
+            }
+        }
+    }
+
+    fn wide_null(value: &str) -> Vec<u16> {
+        value.encode_utf16().chain(Some(0)).collect()
+    }
+
+    fn last_error(operation: &str) -> String {
+        let code = unsafe { GetLastError() };
+        format!("{operation} failed with Windows error {code}")
+    }
+}
+
+#[cfg(windows)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    spike::run()
+}
+
+#[cfg(not(windows))]
+fn main() {
+    println!("windows-conpty-spike only runs on Windows");
+}

--- a/crates/cleat/examples/windows-conpty-spike.rs
+++ b/crates/cleat/examples/windows-conpty-spike.rs
@@ -1,22 +1,28 @@
 #[cfg(windows)]
 mod spike {
-    use std::error::Error;
-    use std::ffi::c_void;
-    use std::fs::File;
-    use std::io::{Read, Write};
-    use std::mem::{size_of, zeroed};
-    use std::os::windows::io::FromRawHandle;
-    use std::ptr::{null, null_mut};
-    use std::thread;
+    use std::{
+        error::Error,
+        ffi::c_void,
+        fs::File,
+        io::{Read, Write},
+        mem::{size_of, zeroed},
+        os::windows::io::FromRawHandle,
+        ptr::{null, null_mut},
+        thread,
+    };
 
-    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
-    use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
-    use windows_sys::Win32::System::Console::{ClosePseudoConsole, CreatePseudoConsole, COORD, HPCON};
-    use windows_sys::Win32::System::Pipes::CreatePipe;
-    use windows_sys::Win32::System::Threading::{
-        CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess, InitializeProcThreadAttributeList, UpdateProcThreadAttribute,
-        WaitForSingleObject, EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION,
-        PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, GetLastError, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT},
+        Security::SECURITY_ATTRIBUTES,
+        System::{
+            Console::{ClosePseudoConsole, CreatePseudoConsole, COORD, HPCON},
+            Pipes::CreatePipe,
+            Threading::{
+                CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess, InitializeProcThreadAttributeList,
+                UpdateProcThreadAttribute, WaitForSingleObject, EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST,
+                PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+            },
+        },
     };
 
     const READY_MARKER: &str = "cleat-conpty-ready";

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -387,6 +387,7 @@ impl ExecResult {
 pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
     match cli.command {
         Command::Attach { id, no_create, vt, cwd, cmd, record } => {
+            #[cfg(not(windows))]
             if !no_create && !crate::vt::functional_vt_available() {
                 return ExecResult::Err(crate::vt::nonfunctional_build_error());
             }

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -405,6 +405,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             }
         }
         Command::Launch { id, json, vt, cwd, cmd, record } => {
+            #[cfg(not(windows))]
             if !crate::vt::functional_vt_available() {
                 return ExecResult::Err(crate::vt::nonfunctional_build_error());
             }

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -387,6 +387,8 @@ impl ExecResult {
 pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
     match cli.command {
         Command::Attach { id, no_create, vt, cwd, cmd, record } => {
+            // Windows can provide basic sessions through ConPTY plus the
+            // passthrough engine while Ghostty VT support is still optional.
             #[cfg(not(windows))]
             if !no_create && !crate::vt::functional_vt_available() {
                 return ExecResult::Err(crate::vt::nonfunctional_build_error());
@@ -406,6 +408,8 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             }
         }
         Command::Launch { id, json, vt, cwd, cmd, record } => {
+            // Windows can provide basic sessions through ConPTY plus the
+            // passthrough engine while Ghostty VT support is still optional.
             #[cfg(not(windows))]
             if !crate::vt::functional_vt_available() {
                 return ExecResult::Err(crate::vt::nonfunctional_build_error());

--- a/crates/cleat/src/platform/ipc/mod.rs
+++ b/crates/cleat/src/platform/ipc/mod.rs
@@ -2,13 +2,17 @@ use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 mod unix;
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 mod unsupported;
+#[cfg(windows)]
+mod windows;
 
 #[cfg(unix)]
 pub use unix::*;
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 pub use unsupported::*;
+#[cfg(windows)]
+pub use windows::*;
 
 const SOCKET_NAME: &str = "socket";
 

--- a/crates/cleat/src/platform/ipc/windows.rs
+++ b/crates/cleat/src/platform/ipc/windows.rs
@@ -3,6 +3,7 @@ use std::{
     fs,
     hash::{Hash, Hasher},
     io::{self, Read, Write},
+    mem::zeroed,
     path::Path,
     ptr::{null, null_mut},
     sync::Mutex,
@@ -11,17 +12,15 @@ use std::{
 
 use windows_sys::Win32::{
     Foundation::{
-        CloseHandle, DuplicateHandle, GetLastError, DUPLICATE_SAME_ACCESS, ERROR_BROKEN_PIPE, ERROR_FILE_NOT_FOUND, ERROR_NO_DATA,
-        ERROR_OPERATION_ABORTED, ERROR_PIPE_BUSY, ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, GENERIC_READ, GENERIC_WRITE, HANDLE,
-        INVALID_HANDLE_VALUE,
+        CloseHandle, DuplicateHandle, GetLastError, DUPLICATE_SAME_ACCESS, ERROR_BROKEN_PIPE, ERROR_FILE_NOT_FOUND, ERROR_IO_PENDING,
+        ERROR_NO_DATA, ERROR_OPERATION_ABORTED, ERROR_PIPE_BUSY, ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, GENERIC_READ, GENERIC_WRITE,
+        HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT,
     },
-    Storage::FileSystem::{CreateFileW, ReadFile, WriteFile, OPEN_EXISTING, PIPE_ACCESS_DUPLEX},
+    Storage::FileSystem::{CreateFileW, ReadFile, WriteFile, FILE_FLAG_OVERLAPPED, OPEN_EXISTING, PIPE_ACCESS_DUPLEX},
     System::{
-        Pipes::{
-            ConnectNamedPipe, CreateNamedPipeW, PeekNamedPipe, SetNamedPipeHandleState, WaitNamedPipeW, PIPE_NOWAIT, PIPE_READMODE_BYTE,
-            PIPE_TYPE_BYTE, PIPE_WAIT,
-        },
-        Threading::GetCurrentProcess,
+        Pipes::{ConnectNamedPipe, CreateNamedPipeW, PeekNamedPipe, WaitNamedPipeW, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT},
+        Threading::{CreateEventW, GetCurrentProcess, ResetEvent, SetEvent, WaitForSingleObject},
+        IO::{CancelIoEx, GetOverlappedResult, OVERLAPPED},
     },
 };
 
@@ -30,10 +29,9 @@ pub struct SessionStream {
     handle: HANDLE,
 }
 
-#[derive(Debug)]
 pub struct SessionListener {
     pipe_name: Vec<u16>,
-    pending: Mutex<Option<HANDLE>>,
+    pending: Mutex<Option<PendingPipeInstance>>,
 }
 
 // Win32 HANDLE values are process-local kernel handle values. These wrappers
@@ -46,28 +44,14 @@ unsafe impl Sync for SessionListener {}
 impl SessionListener {
     pub fn accept(&self) -> io::Result<(SessionStream, ())> {
         let mut pending = self.pending.lock().map_err(|_| io::Error::other("session listener mutex poisoned"))?;
-        let handle = pending.take().ok_or_else(|| io::Error::other("session listener has no pending pipe instance"))?;
-
-        let connected = unsafe { ConnectNamedPipe(handle, null_mut()) };
-        if connected == 0 {
-            let error = unsafe { GetLastError() };
-            match error {
-                ERROR_PIPE_CONNECTED => {}
-                ERROR_PIPE_LISTENING | ERROR_NO_DATA => {
-                    *pending = Some(handle);
-                    return Err(io::Error::new(io::ErrorKind::WouldBlock, "no named-pipe client is waiting"));
-                }
-                _ => {
-                    unsafe {
-                        CloseHandle(handle);
-                    }
-                    return Err(io_error_from_code(error));
-                }
-            }
+        let instance = pending.as_mut().ok_or_else(|| io::Error::other("session listener has no pending pipe instance"))?;
+        if !instance.poll_connected()? {
+            return Err(io::Error::new(io::ErrorKind::WouldBlock, "no named-pipe client is waiting"));
         }
 
-        *pending = Some(create_pipe_instance(&self.pipe_name, true)?);
-        Ok((SessionStream { handle }, ()))
+        let instance = pending.take().expect("pending checked");
+        *pending = Some(PendingPipeInstance::new(&self.pipe_name)?);
+        Ok((SessionStream { handle: instance.into_handle() }, ()))
     }
 }
 
@@ -75,9 +59,7 @@ impl Drop for SessionListener {
     fn drop(&mut self) {
         if let Ok(mut pending) = self.pending.lock() {
             if let Some(handle) = pending.take() {
-                unsafe {
-                    CloseHandle(handle);
-                }
+                drop(handle);
             }
         }
     }
@@ -95,8 +77,8 @@ impl SessionStream {
         }
     }
 
-    pub(crate) fn has_available_bytes(&self) -> Result<bool, String> {
-        handle_has_available_bytes(self.handle)
+    pub(crate) fn overlapped_reader(&self, capacity: usize) -> io::Result<OverlappedRead> {
+        OverlappedRead::new(self.handle, capacity)
     }
 }
 
@@ -110,30 +92,13 @@ impl Drop for SessionStream {
 
 impl Read for SessionStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut read = 0;
-        let ok = unsafe { ReadFile(self.handle, buf.as_mut_ptr(), buf.len().min(u32::MAX as usize) as u32, &mut read, null_mut()) };
-        if ok == 0 {
-            let error = unsafe { GetLastError() };
-            match error {
-                ERROR_NO_DATA | ERROR_PIPE_LISTENING => Err(io::Error::new(io::ErrorKind::WouldBlock, "named pipe would block")),
-                ERROR_BROKEN_PIPE | ERROR_OPERATION_ABORTED => Ok(0),
-                _ => Err(io_error_from_code(error)),
-            }
-        } else {
-            Ok(read as usize)
-        }
+        overlapped_read_blocking(self.handle, buf)
     }
 }
 
 impl Write for SessionStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut written = 0;
-        let ok = unsafe { WriteFile(self.handle, buf.as_ptr(), buf.len().min(u32::MAX as usize) as u32, &mut written, null_mut()) };
-        if ok == 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(written as usize)
-        }
+        overlapped_write_blocking(self.handle, buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -153,33 +118,285 @@ pub fn try_connect_session_stream(socket_path: &Path) -> io::Result<SessionStrea
 
 pub fn bind_session_listener(socket_path: &Path) -> Result<SessionListener, String> {
     let pipe_name = pipe_name_for_socket_path(socket_path);
-    let handle = create_pipe_instance(&pipe_name, true).map_err(|err| format!("create named pipe {}: {err}", display_wide(&pipe_name)))?;
+    let handle = PendingPipeInstance::new(&pipe_name).map_err(|err| format!("create named pipe {}: {err}", display_wide(&pipe_name)))?;
     fs::write(socket_path, display_wide(&pipe_name)).map_err(|err| format!("write named-pipe marker {}: {err}", socket_path.display()))?;
 
     Ok(SessionListener { pipe_name, pending: Mutex::new(Some(handle)) })
 }
 
-pub fn set_listener_nonblocking(listener: &SessionListener, nonblocking: bool) -> Result<(), String> {
-    let pending = listener.pending.lock().map_err(|_| "session listener mutex poisoned".to_string())?;
-    if let Some(handle) = *pending {
-        set_pipe_nonblocking(handle, nonblocking)?;
-    }
+pub fn set_listener_nonblocking(_listener: &SessionListener, _nonblocking: bool) -> Result<(), String> {
+    // Windows uses overlapped pipe operations for nonblocking readiness. PIPE_NOWAIT
+    // is intentionally not used; Microsoft documents it as a LAN Manager
+    // compatibility mode, not an async I/O mechanism.
     Ok(())
 }
 
-pub fn set_stream_nonblocking(stream: &SessionStream, nonblocking: bool) -> Result<(), String> {
-    set_pipe_nonblocking(stream.handle, nonblocking)
+pub fn set_stream_nonblocking(_stream: &SessionStream, _nonblocking: bool) -> Result<(), String> {
+    Ok(())
 }
 
 pub fn set_stream_read_timeout(_stream: &SessionStream, _timeout: Option<Duration>) -> Result<(), String> {
     Ok(())
 }
 
-pub fn shutdown_stream(_stream: &SessionStream) {}
+pub fn shutdown_stream(stream: &SessionStream) {
+    unsafe {
+        CancelIoEx(stream.handle, null_mut());
+    }
+}
 
-fn create_pipe_instance(pipe_name: &[u16], nonblocking: bool) -> io::Result<HANDLE> {
-    let pipe_mode = PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | if nonblocking { PIPE_NOWAIT } else { PIPE_WAIT };
-    let handle = unsafe { CreateNamedPipeW(pipe_name.as_ptr(), PIPE_ACCESS_DUPLEX, pipe_mode, 255, 64 * 1024, 64 * 1024, 0, null()) };
+struct PendingPipeInstance {
+    handle: HANDLE,
+    connect: Option<PendingConnect>,
+}
+
+impl PendingPipeInstance {
+    fn new(pipe_name: &[u16]) -> io::Result<Self> {
+        Ok(Self { handle: create_pipe_instance(pipe_name)?, connect: None })
+    }
+
+    fn poll_connected(&mut self) -> io::Result<bool> {
+        if self.connect.is_none() {
+            let mut connect = PendingConnect::new()?;
+            let connected = unsafe { ConnectNamedPipe(self.handle, connect.overlapped_mut()) };
+            if connected != 0 {
+                return Ok(true);
+            }
+            match unsafe { GetLastError() } {
+                ERROR_PIPE_CONNECTED => {
+                    unsafe {
+                        SetEvent(connect.event);
+                    }
+                    return Ok(true);
+                }
+                ERROR_IO_PENDING => {
+                    self.connect = Some(connect);
+                    return Ok(false);
+                }
+                ERROR_NO_DATA | ERROR_PIPE_LISTING_ALIAS => return Ok(false),
+                err => return Err(io_error_from_code(err)),
+            }
+        }
+
+        let connect = self.connect.as_mut().expect("connect initialized");
+        match unsafe { WaitForSingleObject(connect.event, 0) } {
+            WAIT_TIMEOUT => Ok(false),
+            WAIT_OBJECT_0 => {
+                let mut transferred = 0;
+                let ok = unsafe { GetOverlappedResult(self.handle, connect.overlapped_mut(), &mut transferred, 0) };
+                if ok == 0 {
+                    let err = unsafe { GetLastError() };
+                    if err == ERROR_PIPE_CONNECTED {
+                        self.connect = None;
+                        Ok(true)
+                    } else {
+                        Err(io_error_from_code(err))
+                    }
+                } else {
+                    self.connect = None;
+                    Ok(true)
+                }
+            }
+            status => Err(io::Error::other(format!("WaitForSingleObject connect returned {status}"))),
+        }
+    }
+
+    fn into_handle(mut self) -> HANDLE {
+        self.connect = None;
+        let handle = self.handle;
+        self.handle = null_mut();
+        handle
+    }
+}
+
+impl Drop for PendingPipeInstance {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                CancelIoEx(self.handle, null_mut());
+                CloseHandle(self.handle);
+            }
+        }
+    }
+}
+
+struct PendingConnect {
+    event: HANDLE,
+    overlapped: Box<OVERLAPPED>,
+}
+
+impl PendingConnect {
+    fn new() -> io::Result<Self> {
+        let event = unsafe { CreateEventW(null(), 1, 0, null()) };
+        if event.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let mut overlapped = Box::new(unsafe { zeroed::<OVERLAPPED>() });
+        overlapped.hEvent = event;
+        Ok(Self { event, overlapped })
+    }
+
+    fn overlapped_mut(&mut self) -> *mut OVERLAPPED {
+        &mut *self.overlapped
+    }
+}
+
+impl Drop for PendingConnect {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.event);
+        }
+    }
+}
+
+pub(crate) struct OverlappedRead {
+    handle: HANDLE,
+    event: HANDLE,
+    overlapped: Box<OVERLAPPED>,
+    buffer: Vec<u8>,
+    pending: bool,
+}
+
+impl OverlappedRead {
+    fn new(handle: HANDLE, capacity: usize) -> io::Result<Self> {
+        let event = unsafe { CreateEventW(null(), 1, 0, null()) };
+        if event.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let mut overlapped = Box::new(unsafe { zeroed::<OVERLAPPED>() });
+        overlapped.hEvent = event;
+        Ok(Self { handle, event, overlapped, buffer: vec![0; capacity], pending: false })
+    }
+
+    pub(crate) fn poll(&mut self) -> io::Result<Option<Vec<u8>>> {
+        if !self.pending {
+            unsafe {
+                ResetEvent(self.event);
+            }
+            *self.overlapped = unsafe { zeroed::<OVERLAPPED>() };
+            self.overlapped.hEvent = self.event;
+            let mut read = 0;
+            let ok = unsafe {
+                ReadFile(
+                    self.handle,
+                    self.buffer.as_mut_ptr(),
+                    self.buffer.len().min(u32::MAX as usize) as u32,
+                    &mut read,
+                    &mut *self.overlapped,
+                )
+            };
+            if ok != 0 {
+                return Ok(Some(self.buffer[..read as usize].to_vec()));
+            }
+            match unsafe { GetLastError() } {
+                ERROR_IO_PENDING => self.pending = true,
+                ERROR_BROKEN_PIPE | ERROR_OPERATION_ABORTED | ERROR_NO_DATA => return Ok(Some(Vec::new())),
+                err => return Err(io_error_from_code(err)),
+            }
+        }
+
+        match unsafe { WaitForSingleObject(self.event, 0) } {
+            WAIT_TIMEOUT => Ok(None),
+            WAIT_OBJECT_0 => {
+                let mut transferred = 0;
+                let ok = unsafe { GetOverlappedResult(self.handle, &mut *self.overlapped, &mut transferred, 0) };
+                self.pending = false;
+                if ok == 0 {
+                    let err = unsafe { GetLastError() };
+                    match err {
+                        ERROR_BROKEN_PIPE | ERROR_OPERATION_ABORTED | ERROR_NO_DATA => Ok(Some(Vec::new())),
+                        _ => Err(io_error_from_code(err)),
+                    }
+                } else {
+                    Ok(Some(self.buffer[..transferred as usize].to_vec()))
+                }
+            }
+            status => Err(io::Error::other(format!("WaitForSingleObject read returned {status}"))),
+        }
+    }
+}
+
+impl Drop for OverlappedRead {
+    fn drop(&mut self) {
+        unsafe {
+            if self.pending {
+                CancelIoEx(self.handle, &mut *self.overlapped);
+            }
+            CloseHandle(self.event);
+        }
+    }
+}
+
+const ERROR_PIPE_LISTING_ALIAS: u32 = ERROR_PIPE_LISTENING;
+
+fn overlapped_read_blocking(handle: HANDLE, buf: &mut [u8]) -> io::Result<usize> {
+    let event = unsafe { CreateEventW(null(), 1, 0, null()) };
+    if event.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let mut overlapped: OVERLAPPED = unsafe { zeroed() };
+    overlapped.hEvent = event;
+    let mut read = 0;
+    let ok = unsafe { ReadFile(handle, buf.as_mut_ptr(), buf.len().min(u32::MAX as usize) as u32, &mut read, &mut overlapped) };
+    let result = if ok != 0 {
+        Ok(read as usize)
+    } else {
+        match unsafe { GetLastError() } {
+            ERROR_IO_PENDING => wait_overlapped(handle, &mut overlapped),
+            ERROR_BROKEN_PIPE | ERROR_OPERATION_ABORTED => Ok(0),
+            err => Err(io_error_from_code(err)),
+        }
+    };
+    unsafe {
+        CloseHandle(event);
+    }
+    result
+}
+
+fn overlapped_write_blocking(handle: HANDLE, buf: &[u8]) -> io::Result<usize> {
+    let event = unsafe { CreateEventW(null(), 1, 0, null()) };
+    if event.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let mut overlapped: OVERLAPPED = unsafe { zeroed() };
+    overlapped.hEvent = event;
+    let mut written = 0;
+    let ok = unsafe { WriteFile(handle, buf.as_ptr(), buf.len().min(u32::MAX as usize) as u32, &mut written, &mut overlapped) };
+    let result = if ok != 0 {
+        Ok(written as usize)
+    } else {
+        match unsafe { GetLastError() } {
+            ERROR_IO_PENDING => wait_overlapped(handle, &mut overlapped),
+            ERROR_BROKEN_PIPE | ERROR_OPERATION_ABORTED => Ok(0),
+            err => Err(io_error_from_code(err)),
+        }
+    };
+    unsafe {
+        CloseHandle(event);
+    }
+    result
+}
+
+fn wait_overlapped(handle: HANDLE, overlapped: &mut OVERLAPPED) -> io::Result<usize> {
+    match unsafe { WaitForSingleObject(overlapped.hEvent, u32::MAX) } {
+        WAIT_OBJECT_0 => {
+            let mut transferred = 0;
+            let ok = unsafe { GetOverlappedResult(handle, overlapped, &mut transferred, 0) };
+            if ok == 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(transferred as usize)
+            }
+        }
+        status => Err(io::Error::other(format!("WaitForSingleObject overlapped returned {status}"))),
+    }
+}
+
+fn create_pipe_instance(pipe_name: &[u16]) -> io::Result<HANDLE> {
+    let pipe_mode = PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT;
+    let handle = unsafe {
+        CreateNamedPipeW(pipe_name.as_ptr(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED, pipe_mode, 255, 64 * 1024, 64 * 1024, 0, null())
+    };
     if handle == INVALID_HANDLE_VALUE {
         Err(io::Error::last_os_error())
     } else {
@@ -189,9 +406,10 @@ fn create_pipe_instance(pipe_name: &[u16], nonblocking: bool) -> io::Result<HAND
 
 fn open_pipe(pipe_name: &[u16]) -> io::Result<HANDLE> {
     loop {
-        let handle = unsafe { CreateFileW(pipe_name.as_ptr(), GENERIC_READ | GENERIC_WRITE, 0, null(), OPEN_EXISTING, 0, null_mut()) };
+        let handle = unsafe {
+            CreateFileW(pipe_name.as_ptr(), GENERIC_READ | GENERIC_WRITE, 0, null(), OPEN_EXISTING, FILE_FLAG_OVERLAPPED, null_mut())
+        };
         if handle != INVALID_HANDLE_VALUE {
-            set_pipe_nonblocking(handle, false).map_err(io::Error::other)?;
             return Ok(handle);
         }
 
@@ -206,16 +424,6 @@ fn open_pipe(pipe_name: &[u16]) -> io::Result<HANDLE> {
             ERROR_FILE_NOT_FOUND => return Err(io_error_from_code(error)),
             _ => return Err(io_error_from_code(error)),
         }
-    }
-}
-
-fn set_pipe_nonblocking(handle: HANDLE, nonblocking: bool) -> Result<(), String> {
-    let mode = PIPE_READMODE_BYTE | if nonblocking { PIPE_NOWAIT } else { PIPE_WAIT };
-    let ok = unsafe { SetNamedPipeHandleState(handle, &mode, null(), null()) };
-    if ok == 0 {
-        Err(format!("set named-pipe handle state: {}", io::Error::last_os_error()))
-    } else {
-        Ok(())
     }
 }
 

--- a/crates/cleat/src/platform/ipc/windows.rs
+++ b/crates/cleat/src/platform/ipc/windows.rs
@@ -7,7 +7,7 @@ use std::{
     path::Path,
     ptr::{null, null_mut},
     sync::Mutex,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use windows_sys::Win32::{
@@ -111,7 +111,7 @@ pub fn connect_session_stream(socket_path: &Path) -> Result<SessionStream, Strin
 }
 
 pub fn try_connect_session_stream(socket_path: &Path) -> io::Result<SessionStream> {
-    let pipe_name = pipe_name_for_socket_path(socket_path);
+    let pipe_name = pipe_name_from_marker_file(socket_path)?;
     let handle = open_pipe(&pipe_name)?;
     Ok(SessionStream { handle })
 }
@@ -269,6 +269,10 @@ impl OverlappedRead {
     }
 
     pub(crate) fn poll(&mut self) -> io::Result<Option<Vec<u8>>> {
+        self.poll_timeout(Duration::ZERO)
+    }
+
+    pub(crate) fn poll_timeout(&mut self, timeout: Duration) -> io::Result<Option<Vec<u8>>> {
         if !self.pending {
             unsafe {
                 ResetEvent(self.event);
@@ -295,7 +299,7 @@ impl OverlappedRead {
             }
         }
 
-        match unsafe { WaitForSingleObject(self.event, 0) } {
+        match unsafe { WaitForSingleObject(self.event, wait_timeout_ms(timeout)) } {
             WAIT_TIMEOUT => Ok(None),
             WAIT_OBJECT_0 => {
                 let mut transferred = 0;
@@ -327,6 +331,8 @@ impl Drop for OverlappedRead {
     }
 }
 
+// windows-sys imports Win32 constants as static values, which cannot be used
+// directly in Rust match patterns.
 const ERROR_PIPE_LISTING_ALIAS: u32 = ERROR_PIPE_LISTENING;
 
 fn overlapped_read_blocking(handle: HANDLE, buf: &mut [u8]) -> io::Result<usize> {
@@ -405,6 +411,7 @@ fn create_pipe_instance(pipe_name: &[u16]) -> io::Result<HANDLE> {
 }
 
 fn open_pipe(pipe_name: &[u16]) -> io::Result<HANDLE> {
+    let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         let handle = unsafe {
             CreateFileW(pipe_name.as_ptr(), GENERIC_READ | GENERIC_WRITE, 0, null(), OPEN_EXISTING, FILE_FLAG_OVERLAPPED, null_mut())
@@ -416,9 +423,17 @@ fn open_pipe(pipe_name: &[u16]) -> io::Result<HANDLE> {
         let error = unsafe { GetLastError() };
         match error {
             ERROR_PIPE_BUSY => {
-                let waited = unsafe { WaitNamedPipeW(pipe_name.as_ptr(), 5_000) };
+                let now = Instant::now();
+                if now >= deadline {
+                    return Err(io::Error::new(io::ErrorKind::TimedOut, "timed out waiting for named pipe"));
+                }
+                let remaining_ms = deadline.saturating_duration_since(now).as_millis().min(5_000) as u32;
+                let waited = unsafe { WaitNamedPipeW(pipe_name.as_ptr(), remaining_ms) };
                 if waited == 0 {
-                    return Err(io::Error::last_os_error());
+                    let err = io::Error::last_os_error();
+                    if Instant::now() >= deadline {
+                        return Err(io::Error::new(io::ErrorKind::TimedOut, format!("timed out waiting for named pipe: {err}")));
+                    }
                 }
             }
             ERROR_FILE_NOT_FOUND => return Err(io_error_from_code(error)),
@@ -447,8 +462,21 @@ fn pipe_name_for_socket_path(socket_path: &Path) -> Vec<u16> {
     format!(r"\\.\pipe\cleat-{:016x}", hasher.finish()).encode_utf16().chain(Some(0)).collect()
 }
 
+fn pipe_name_from_marker_file(socket_path: &Path) -> io::Result<Vec<u16>> {
+    let pipe_name = fs::read_to_string(socket_path)?;
+    let pipe_name = pipe_name.trim_end_matches(['\r', '\n']);
+    if pipe_name.is_empty() {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, format!("empty named-pipe marker {}", socket_path.display())));
+    }
+    Ok(pipe_name.encode_utf16().chain(Some(0)).collect())
+}
+
 fn display_wide(value: &[u16]) -> String {
     String::from_utf16_lossy(value.strip_suffix(&[0]).unwrap_or(value))
+}
+
+fn wait_timeout_ms(timeout: Duration) -> u32 {
+    timeout.as_millis().min(u32::MAX as u128) as u32
 }
 
 fn io_error_from_code(code: u32) -> io::Error {

--- a/crates/cleat/src/platform/ipc/windows.rs
+++ b/crates/cleat/src/platform/ipc/windows.rs
@@ -1,0 +1,288 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    fs,
+    hash::{Hash, Hasher},
+    io::{self, Read, Write},
+    path::Path,
+    ptr::{null, null_mut},
+    sync::Mutex,
+    time::Duration,
+};
+
+use windows_sys::Win32::{
+    Foundation::{
+        CloseHandle, DuplicateHandle, GetLastError, DUPLICATE_SAME_ACCESS, ERROR_BROKEN_PIPE, ERROR_FILE_NOT_FOUND, ERROR_NO_DATA,
+        ERROR_OPERATION_ABORTED, ERROR_PIPE_BUSY, ERROR_PIPE_CONNECTED, ERROR_PIPE_LISTENING, GENERIC_READ, GENERIC_WRITE, HANDLE,
+        INVALID_HANDLE_VALUE,
+    },
+    Storage::FileSystem::{CreateFileW, ReadFile, WriteFile, OPEN_EXISTING, PIPE_ACCESS_DUPLEX},
+    System::{
+        Pipes::{
+            ConnectNamedPipe, CreateNamedPipeW, PeekNamedPipe, SetNamedPipeHandleState, WaitNamedPipeW, PIPE_NOWAIT, PIPE_READMODE_BYTE,
+            PIPE_TYPE_BYTE, PIPE_WAIT,
+        },
+        Threading::GetCurrentProcess,
+    },
+};
+
+#[derive(Debug)]
+pub struct SessionStream {
+    handle: HANDLE,
+}
+
+#[derive(Debug)]
+pub struct SessionListener {
+    pipe_name: Vec<u16>,
+    pending: Mutex<Option<HANDLE>>,
+}
+
+// Win32 HANDLE values are process-local kernel handle values. These wrappers
+// own their handles and close them on drop, so moving them between threads is
+// equivalent to moving a Unix file descriptor wrapper.
+unsafe impl Send for SessionStream {}
+unsafe impl Send for SessionListener {}
+unsafe impl Sync for SessionListener {}
+
+impl SessionListener {
+    pub fn accept(&self) -> io::Result<(SessionStream, ())> {
+        let mut pending = self.pending.lock().map_err(|_| io::Error::other("session listener mutex poisoned"))?;
+        let handle = pending.take().ok_or_else(|| io::Error::other("session listener has no pending pipe instance"))?;
+
+        let connected = unsafe { ConnectNamedPipe(handle, null_mut()) };
+        if connected == 0 {
+            let error = unsafe { GetLastError() };
+            match error {
+                ERROR_PIPE_CONNECTED => {}
+                ERROR_PIPE_LISTENING | ERROR_NO_DATA => {
+                    *pending = Some(handle);
+                    return Err(io::Error::new(io::ErrorKind::WouldBlock, "no named-pipe client is waiting"));
+                }
+                _ => {
+                    unsafe {
+                        CloseHandle(handle);
+                    }
+                    return Err(io_error_from_code(error));
+                }
+            }
+        }
+
+        *pending = Some(create_pipe_instance(&self.pipe_name, true)?);
+        Ok((SessionStream { handle }, ()))
+    }
+}
+
+impl Drop for SessionListener {
+    fn drop(&mut self) {
+        if let Ok(mut pending) = self.pending.lock() {
+            if let Some(handle) = pending.take() {
+                unsafe {
+                    CloseHandle(handle);
+                }
+            }
+        }
+    }
+}
+
+impl SessionStream {
+    pub fn try_clone(&self) -> io::Result<Self> {
+        let process = unsafe { GetCurrentProcess() };
+        let mut handle = null_mut();
+        let ok = unsafe { DuplicateHandle(process, self.handle, process, &mut handle, 0, 0, DUPLICATE_SAME_ACCESS) };
+        if ok == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Self { handle })
+        }
+    }
+
+    pub(crate) fn has_available_bytes(&self) -> Result<bool, String> {
+        handle_has_available_bytes(self.handle)
+    }
+}
+
+impl Drop for SessionStream {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.handle);
+        }
+    }
+}
+
+impl Read for SessionStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut read = 0;
+        let ok = unsafe { ReadFile(self.handle, buf.as_mut_ptr(), buf.len().min(u32::MAX as usize) as u32, &mut read, null_mut()) };
+        if ok == 0 {
+            let error = unsafe { GetLastError() };
+            match error {
+                ERROR_NO_DATA | ERROR_PIPE_LISTENING => Err(io::Error::new(io::ErrorKind::WouldBlock, "named pipe would block")),
+                ERROR_BROKEN_PIPE | ERROR_OPERATION_ABORTED => Ok(0),
+                _ => Err(io_error_from_code(error)),
+            }
+        } else {
+            Ok(read as usize)
+        }
+    }
+}
+
+impl Write for SessionStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut written = 0;
+        let ok = unsafe { WriteFile(self.handle, buf.as_ptr(), buf.len().min(u32::MAX as usize) as u32, &mut written, null_mut()) };
+        if ok == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(written as usize)
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub fn connect_session_stream(socket_path: &Path) -> Result<SessionStream, String> {
+    try_connect_session_stream(socket_path).map_err(|err| format!("connect {}: {err}", socket_path.display()))
+}
+
+pub fn try_connect_session_stream(socket_path: &Path) -> io::Result<SessionStream> {
+    let pipe_name = pipe_name_for_socket_path(socket_path);
+    let handle = open_pipe(&pipe_name)?;
+    Ok(SessionStream { handle })
+}
+
+pub fn bind_session_listener(socket_path: &Path) -> Result<SessionListener, String> {
+    let pipe_name = pipe_name_for_socket_path(socket_path);
+    let handle = create_pipe_instance(&pipe_name, true).map_err(|err| format!("create named pipe {}: {err}", display_wide(&pipe_name)))?;
+    fs::write(socket_path, display_wide(&pipe_name)).map_err(|err| format!("write named-pipe marker {}: {err}", socket_path.display()))?;
+
+    Ok(SessionListener { pipe_name, pending: Mutex::new(Some(handle)) })
+}
+
+pub fn set_listener_nonblocking(listener: &SessionListener, nonblocking: bool) -> Result<(), String> {
+    let pending = listener.pending.lock().map_err(|_| "session listener mutex poisoned".to_string())?;
+    if let Some(handle) = *pending {
+        set_pipe_nonblocking(handle, nonblocking)?;
+    }
+    Ok(())
+}
+
+pub fn set_stream_nonblocking(stream: &SessionStream, nonblocking: bool) -> Result<(), String> {
+    set_pipe_nonblocking(stream.handle, nonblocking)
+}
+
+pub fn set_stream_read_timeout(_stream: &SessionStream, _timeout: Option<Duration>) -> Result<(), String> {
+    Ok(())
+}
+
+pub fn shutdown_stream(_stream: &SessionStream) {}
+
+fn create_pipe_instance(pipe_name: &[u16], nonblocking: bool) -> io::Result<HANDLE> {
+    let pipe_mode = PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | if nonblocking { PIPE_NOWAIT } else { PIPE_WAIT };
+    let handle = unsafe { CreateNamedPipeW(pipe_name.as_ptr(), PIPE_ACCESS_DUPLEX, pipe_mode, 255, 64 * 1024, 64 * 1024, 0, null()) };
+    if handle == INVALID_HANDLE_VALUE {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(handle)
+    }
+}
+
+fn open_pipe(pipe_name: &[u16]) -> io::Result<HANDLE> {
+    loop {
+        let handle = unsafe { CreateFileW(pipe_name.as_ptr(), GENERIC_READ | GENERIC_WRITE, 0, null(), OPEN_EXISTING, 0, null_mut()) };
+        if handle != INVALID_HANDLE_VALUE {
+            set_pipe_nonblocking(handle, false).map_err(io::Error::other)?;
+            return Ok(handle);
+        }
+
+        let error = unsafe { GetLastError() };
+        match error {
+            ERROR_PIPE_BUSY => {
+                let waited = unsafe { WaitNamedPipeW(pipe_name.as_ptr(), 5_000) };
+                if waited == 0 {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+            ERROR_FILE_NOT_FOUND => return Err(io_error_from_code(error)),
+            _ => return Err(io_error_from_code(error)),
+        }
+    }
+}
+
+fn set_pipe_nonblocking(handle: HANDLE, nonblocking: bool) -> Result<(), String> {
+    let mode = PIPE_READMODE_BYTE | if nonblocking { PIPE_NOWAIT } else { PIPE_WAIT };
+    let ok = unsafe { SetNamedPipeHandleState(handle, &mode, null(), null()) };
+    if ok == 0 {
+        Err(format!("set named-pipe handle state: {}", io::Error::last_os_error()))
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn handle_has_available_bytes(handle: HANDLE) -> Result<bool, String> {
+    let mut available = 0;
+    let ok = unsafe { PeekNamedPipe(handle, null_mut(), 0, null_mut(), &mut available, null_mut()) };
+    if ok == 0 {
+        let err = unsafe { GetLastError() };
+        match err {
+            ERROR_BROKEN_PIPE | ERROR_OPERATION_ABORTED | ERROR_NO_DATA => Ok(false),
+            _ => Err(format!("peek named pipe: {}", io_error_from_code(err))),
+        }
+    } else {
+        Ok(available > 0)
+    }
+}
+
+fn pipe_name_for_socket_path(socket_path: &Path) -> Vec<u16> {
+    let mut hasher = DefaultHasher::new();
+    socket_path.to_string_lossy().hash(&mut hasher);
+    format!(r"\\.\pipe\cleat-{:016x}", hasher.finish()).encode_utf16().chain(Some(0)).collect()
+}
+
+fn display_wide(value: &[u16]) -> String {
+    String::from_utf16_lossy(value.strip_suffix(&[0]).unwrap_or(value))
+}
+
+fn io_error_from_code(code: u32) -> io::Error {
+    io::Error::from_raw_os_error(code as i32)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::Read, thread};
+
+    use super::*;
+
+    #[test]
+    fn named_pipe_stream_round_trips_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let socket_path = temp.path().join("socket");
+        let listener = bind_session_listener(&socket_path).expect("bind listener");
+        set_listener_nonblocking(&listener, true).expect("listener nonblocking");
+
+        let client = thread::spawn({
+            let socket_path = socket_path.clone();
+            move || {
+                let mut stream = connect_session_stream(&socket_path).expect("connect client");
+                stream.write_all(b"ping").expect("write ping");
+                let mut buf = [0u8; 4];
+                stream.read_exact(&mut buf).expect("read pong");
+                assert_eq!(&buf, b"pong");
+            }
+        });
+
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(value) => break value,
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => thread::sleep(Duration::from_millis(10)),
+                Err(err) => panic!("accept: {err}"),
+            }
+        };
+
+        let mut buf = [0u8; 4];
+        stream.read_exact(&mut buf).expect("read ping");
+        assert_eq!(&buf, b"ping");
+        stream.write_all(b"pong").expect("write pong");
+        client.join().expect("client thread");
+    }
+}

--- a/crates/cleat/src/platform/ipc/windows.rs
+++ b/crates/cleat/src/platform/ipc/windows.rs
@@ -325,6 +325,8 @@ impl Drop for OverlappedRead {
         unsafe {
             if self.pending {
                 CancelIoEx(self.handle, &mut *self.overlapped);
+                let mut transferred = 0;
+                let _ = GetOverlappedResult(self.handle, &mut *self.overlapped, &mut transferred, 1);
             }
             CloseHandle(self.event);
         }

--- a/crates/cleat/src/platform/pty/mod.rs
+++ b/crates/cleat/src/platform/pty/mod.rs
@@ -1,8 +1,14 @@
-#[cfg(not(unix))]
+#[cfg(windows)]
+mod windows;
+
+#[cfg(all(not(unix), not(windows)))]
 mod unsupported;
 
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 pub use unsupported::*;
 
 #[cfg(unix)]
 pub use super::unix::*;
+
+#[cfg(windows)]
+pub use windows::*;

--- a/crates/cleat/src/platform/pty/mod.rs
+++ b/crates/cleat/src/platform/pty/mod.rs
@@ -6,9 +6,8 @@ mod unsupported;
 
 #[cfg(all(not(unix), not(windows)))]
 pub use unsupported::*;
+#[cfg(windows)]
+pub use windows::*;
 
 #[cfg(unix)]
 pub use super::unix::*;
-
-#[cfg(windows)]
-pub use windows::*;

--- a/crates/cleat/src/platform/pty/unsupported.rs
+++ b/crates/cleat/src/platform/pty/unsupported.rs
@@ -19,10 +19,10 @@ pub struct PollResult {
 }
 
 pub fn poll_session_ready(
-    _listener_fd: i32,
-    _client_fd: Option<i32>,
+    _listener: &SessionListener,
+    _client: Option<&SessionStream>,
     _client_needs_write: bool,
-    _pty_fd: i32,
+    _pty_child: &PtyChild,
     _timeout_ms: i32,
 ) -> Result<PollResult, String> {
     Err("PTY sessions are only supported on Unix".to_string())
@@ -30,12 +30,4 @@ pub fn poll_session_ready(
 
 pub fn exit_code_from_wait_status(_status: &()) -> i32 {
     1
-}
-
-pub fn stream_fd(_stream: &SessionStream) -> i32 {
-    -1
-}
-
-pub fn listener_fd(_listener: &SessionListener) -> i32 {
-    -1
 }

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -4,6 +4,8 @@ use std::{
     mem::{size_of, zeroed},
     path::PathBuf,
     ptr::{null, null_mut},
+    thread,
+    time::Duration,
 };
 
 use windows_sys::Win32::{
@@ -21,7 +23,11 @@ use windows_sys::Win32::{
     },
 };
 
-use crate::{protocol::SignalTarget, runtime::SessionMetadata};
+use crate::{
+    platform::ipc::{handle_has_available_bytes, SessionListener, SessionStream},
+    protocol::SignalTarget,
+    runtime::SessionMetadata,
+};
 
 pub struct PtyChild {
     conpty: HPCON,
@@ -136,6 +142,10 @@ impl PtyChild {
             _ => Err(format!("signal {signal} is not supported on Windows")),
         }
     }
+
+    pub(crate) fn output_available(&self) -> Result<bool, String> {
+        handle_has_available_bytes(self.output_read)
+    }
 }
 
 impl Drop for PtyChild {
@@ -164,25 +174,25 @@ pub struct PollResult {
 }
 
 pub fn poll_session_ready(
-    _listener_fd: i32,
-    _client_fd: Option<i32>,
-    _client_needs_write: bool,
-    _pty_fd: i32,
-    _timeout_ms: i32,
+    _listener: &SessionListener,
+    client: Option<&SessionStream>,
+    client_needs_write: bool,
+    pty_child: &PtyChild,
+    timeout_ms: i32,
 ) -> Result<PollResult, String> {
-    Err("Windows session polling requires named-pipe IPC integration".to_string())
+    let client_readable = client.map(SessionStream::has_available_bytes).transpose()?.unwrap_or(false);
+    let pty_readable = pty_child.output_available()?;
+    let listener_readable = true;
+
+    if !client_readable && !pty_readable && timeout_ms > 0 {
+        thread::sleep(Duration::from_millis(timeout_ms as u64));
+    }
+
+    Ok(PollResult { listener_readable, client_readable, client_writable: client_needs_write, pty_readable })
 }
 
 pub fn exit_code_from_wait_status(status: &WindowsExitStatus) -> i32 {
     status.code as i32
-}
-
-pub fn stream_fd(_stream: &crate::platform::ipc::SessionStream) -> i32 {
-    -1
-}
-
-pub fn listener_fd(_listener: &crate::platform::ipc::SessionListener) -> i32 {
-    -1
 }
 
 struct Pipes {

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -29,6 +29,10 @@ use crate::{
     runtime::SessionMetadata,
 };
 
+const POSIX_SIGINT: i32 = 2;
+const POSIX_SIGKILL: i32 = 9;
+const POSIX_SIGTERM: i32 = 15;
+
 pub struct PtyChild {
     conpty: HPCON,
     process: HANDLE,
@@ -129,7 +133,7 @@ impl PtyChild {
 
     pub fn dispatch_signal(&self, signal: i32, _target: SignalTarget) -> Result<(), String> {
         match signal {
-            2 => {
+            POSIX_SIGINT => {
                 let ok = unsafe { GenerateConsoleCtrlEvent(CTRL_C_EVENT, self.process_id) };
                 if ok == 0 {
                     Err(last_error("GenerateConsoleCtrlEvent"))
@@ -137,7 +141,7 @@ impl PtyChild {
                     Ok(())
                 }
             }
-            9 | 15 => {
+            POSIX_SIGKILL | POSIX_SIGTERM => {
                 let ok = unsafe { TerminateProcess(self.process, signal as u32) };
                 if ok == 0 {
                     Err(last_error("TerminateProcess"))
@@ -186,7 +190,8 @@ pub fn poll_session_ready(
 ) -> Result<PollResult, String> {
     // Named-pipe byte availability is not a reliable readiness boundary for
     // the foreground client stream here. The session loop owns an overlapped
-    // read and applies the idle timeout when it drains client input.
+    // read and applies the idle timeout when it drains client input, so this
+    // flag means "client connected" on Windows rather than "bytes available".
     let client_readable = client.is_some();
     let pty_readable = pty_child.output_available()?;
     let listener_readable = true;

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -34,10 +34,8 @@ pub struct PtyChild {
     process: HANDLE,
     thread: HANDLE,
     process_id: u32,
-    input_read: HANDLE,
     input_write: HANDLE,
     output_read: HANDLE,
-    output_write: HANDLE,
 }
 
 impl PtyChild {
@@ -45,16 +43,18 @@ impl PtyChild {
         let pipes = Pipes::new()?;
         let conpty = create_pseudo_console(80, 24, pipes.input_read, pipes.output_write)?;
         let process = spawn_with_conpty(&windows_shell_command(session), conpty, session.cwd.as_ref())?;
+        unsafe {
+            CloseHandle(pipes.input_read);
+            CloseHandle(pipes.output_write);
+        }
 
         Ok(Self {
             conpty,
             process: process.hProcess,
             thread: process.hThread,
             process_id: process.dwProcessId,
-            input_read: pipes.input_read,
             input_write: pipes.input_write,
             output_read: pipes.output_read,
-            output_write: pipes.output_write,
         })
     }
 
@@ -158,9 +158,7 @@ impl Drop for PtyChild {
     fn drop(&mut self) {
         unsafe {
             CloseHandle(self.input_write);
-            CloseHandle(self.input_read);
             CloseHandle(self.output_read);
-            CloseHandle(self.output_write);
             CloseHandle(self.thread);
             CloseHandle(self.process);
             ClosePseudoConsole(self.conpty);
@@ -186,7 +184,10 @@ pub fn poll_session_ready(
     pty_child: &PtyChild,
     timeout_ms: i32,
 ) -> Result<PollResult, String> {
-    let client_readable = client.map(SessionStream::has_available_bytes).transpose()?.unwrap_or(false);
+    // Named-pipe byte availability is not a reliable readiness boundary for
+    // the foreground client stream here. The session stream is nonblocking, so
+    // the daemon loop can cheaply attempt a read and let WouldBlock mean idle.
+    let client_readable = client.is_some();
     let pty_readable = pty_child.output_available()?;
     let listener_readable = true;
 

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -317,9 +317,41 @@ fn spawn_with_conpty(command_line: &str, conpty: HPCON, cwd: Option<&PathBuf>) -
 
 fn windows_shell_command(session: &SessionMetadata) -> String {
     match &session.cmd {
-        Some(cmd) => format!("powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command {cmd}"),
+        Some(cmd) => format!("cmd.exe /D /C {}", quote_windows_arg(cmd)),
         None => "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass".to_string(),
     }
+}
+
+fn quote_windows_arg(arg: &str) -> String {
+    if arg.is_empty() {
+        return "\"\"".to_string();
+    }
+
+    let needs_quotes = arg.chars().any(|ch| ch.is_whitespace() || ch == '"');
+    if !needs_quotes {
+        return arg.to_string();
+    }
+
+    let mut quoted = String::from("\"");
+    let mut backslashes = 0;
+    for ch in arg.chars() {
+        match ch {
+            '\\' => backslashes += 1,
+            '"' => {
+                quoted.extend(std::iter::repeat('\\').take(backslashes * 2 + 1));
+                quoted.push('"');
+                backslashes = 0;
+            }
+            _ => {
+                quoted.extend(std::iter::repeat('\\').take(backslashes));
+                quoted.push(ch);
+                backslashes = 0;
+            }
+        }
+    }
+    quoted.extend(std::iter::repeat('\\').take(backslashes * 2));
+    quoted.push('"');
+    quoted
 }
 
 fn write_handle_all(handle: HANDLE, mut bytes: &[u8]) -> Result<(), String> {
@@ -344,4 +376,49 @@ fn wide_null(value: &str) -> Vec<u16> {
 fn last_error(operation: &str) -> String {
     let code = unsafe { GetLastError() };
     format!("{operation} failed with Windows error {code}")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{runtime::SessionMetadata, vt::VtEngineKind};
+
+    use super::{quote_windows_arg, windows_shell_command};
+
+    #[test]
+    fn quotes_empty_argument() {
+        assert_eq!(quote_windows_arg(""), "\"\"");
+    }
+
+    #[test]
+    fn leaves_simple_argument_unquoted() {
+        assert_eq!(quote_windows_arg("Write-Output"), "Write-Output");
+    }
+
+    #[test]
+    fn quotes_script_as_single_argument() {
+        assert_eq!(
+            quote_windows_arg("Start-Sleep -Milliseconds 800; Write-Output ready"),
+            "\"Start-Sleep -Milliseconds 800; Write-Output ready\""
+        );
+    }
+
+    #[test]
+    fn escapes_quotes_and_trailing_backslashes() {
+        assert_eq!(quote_windows_arg("Write-Output \"C:\\tmp\\\""), "\"Write-Output \\\"C:\\tmp\\\\\\\"\"");
+    }
+
+    #[test]
+    fn command_uses_cmd_shell_for_batch_commands() {
+        let session = SessionMetadata {
+            id: "test".into(),
+            vt_engine: VtEngineKind::Passthrough,
+            cwd: None,
+            cmd: Some("echo ready".into()),
+            record: false,
+        };
+
+        let command = windows_shell_command(&session);
+
+        assert_eq!(command, "cmd.exe /D /C \"echo ready\"");
+    }
 }

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -67,6 +67,12 @@ impl PtyChild {
     }
 
     pub fn read_output(&self, buf: &mut [u8]) -> Result<usize, io::Error> {
+        match self.output_available() {
+            Ok(true) => {}
+            Ok(false) => return Err(io::Error::new(io::ErrorKind::WouldBlock, "ConPTY output pipe would block")),
+            Err(err) => return Err(io::Error::other(err)),
+        }
+
         let mut read = 0;
         let ok = unsafe { ReadFile(self.output_read, buf.as_mut_ptr(), buf.len() as u32, &mut read, null_mut()) };
         if ok == 0 {

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -1,0 +1,331 @@
+use std::{
+    ffi::c_void,
+    io,
+    mem::{size_of, zeroed},
+    path::PathBuf,
+    ptr::{null, null_mut},
+};
+
+use windows_sys::Win32::{
+    Foundation::{CloseHandle, GetLastError, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT},
+    Security::SECURITY_ATTRIBUTES,
+    Storage::FileSystem::{ReadFile, WriteFile},
+    System::{
+        Console::{ClosePseudoConsole, CreatePseudoConsole, GenerateConsoleCtrlEvent, ResizePseudoConsole, COORD, CTRL_C_EVENT, HPCON},
+        Pipes::CreatePipe,
+        Threading::{
+            CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess, InitializeProcThreadAttributeList, TerminateProcess,
+            UpdateProcThreadAttribute, WaitForSingleObject, CREATE_NEW_PROCESS_GROUP, EXTENDED_STARTUPINFO_PRESENT,
+            LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+        },
+    },
+};
+
+use crate::{protocol::SignalTarget, runtime::SessionMetadata};
+
+pub struct PtyChild {
+    conpty: HPCON,
+    process: HANDLE,
+    thread: HANDLE,
+    process_id: u32,
+    input_read: HANDLE,
+    input_write: HANDLE,
+    output_read: HANDLE,
+    output_write: HANDLE,
+}
+
+impl PtyChild {
+    pub fn spawn(session: &SessionMetadata) -> Result<Self, String> {
+        let pipes = Pipes::new()?;
+        let conpty = create_pseudo_console(80, 24, pipes.input_read, pipes.output_write)?;
+        let process = spawn_with_conpty(&windows_shell_command(session), conpty, session.cwd.as_ref())?;
+
+        Ok(Self {
+            conpty,
+            process: process.hProcess,
+            thread: process.hThread,
+            process_id: process.dwProcessId,
+            input_read: pipes.input_read,
+            input_write: pipes.input_write,
+            output_read: pipes.output_read,
+            output_write: pipes.output_write,
+        })
+    }
+
+    pub fn master_fd(&self) -> i32 {
+        -1
+    }
+
+    pub fn set_nonblocking(&self) -> Result<(), String> {
+        Ok(())
+    }
+
+    pub fn read_output(&self, buf: &mut [u8]) -> Result<usize, io::Error> {
+        let mut read = 0;
+        let ok = unsafe { ReadFile(self.output_read, buf.as_mut_ptr(), buf.len() as u32, &mut read, null_mut()) };
+        if ok == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(read as usize)
+        }
+    }
+
+    pub fn write_all(&self, bytes: &[u8]) -> Result<(), String> {
+        write_handle_all(self.input_write, bytes)
+    }
+
+    pub fn resize(&self, cols: u16, rows: u16) -> Result<(), String> {
+        let result = unsafe { ResizePseudoConsole(self.conpty, COORD { X: cols as i16, Y: rows as i16 }) };
+        if result < 0 {
+            Err(format!("ResizePseudoConsole failed with HRESULT 0x{result:08x}"))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn exited(&self) -> Result<Option<WindowsExitStatus>, String> {
+        match unsafe { WaitForSingleObject(self.process, 0) } {
+            WAIT_OBJECT_0 => {
+                let mut code = 0;
+                let ok = unsafe { GetExitCodeProcess(self.process, &mut code) };
+                if ok == 0 {
+                    Err(last_error("GetExitCodeProcess"))
+                } else {
+                    Ok(Some(WindowsExitStatus { code }))
+                }
+            }
+            WAIT_TIMEOUT => Ok(None),
+            status => Err(format!("unexpected WaitForSingleObject status {status}")),
+        }
+    }
+
+    pub fn leader_pid(&self) -> u32 {
+        self.process_id
+    }
+
+    pub fn foreground_pgid(&self) -> Option<u32> {
+        None
+    }
+
+    pub fn leader_cwd(&self) -> Option<PathBuf> {
+        None
+    }
+
+    pub fn foreground_cwd(&self) -> Option<PathBuf> {
+        None
+    }
+
+    pub fn dispatch_signal(&self, signal: i32, _target: SignalTarget) -> Result<(), String> {
+        match signal {
+            2 => {
+                let ok = unsafe { GenerateConsoleCtrlEvent(CTRL_C_EVENT, self.process_id) };
+                if ok == 0 {
+                    Err(last_error("GenerateConsoleCtrlEvent"))
+                } else {
+                    Ok(())
+                }
+            }
+            9 | 15 => {
+                let ok = unsafe { TerminateProcess(self.process, signal as u32) };
+                if ok == 0 {
+                    Err(last_error("TerminateProcess"))
+                } else {
+                    Ok(())
+                }
+            }
+            _ => Err(format!("signal {signal} is not supported on Windows")),
+        }
+    }
+}
+
+impl Drop for PtyChild {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.input_write);
+            CloseHandle(self.input_read);
+            CloseHandle(self.output_read);
+            CloseHandle(self.output_write);
+            CloseHandle(self.thread);
+            CloseHandle(self.process);
+            ClosePseudoConsole(self.conpty);
+        }
+    }
+}
+
+pub struct WindowsExitStatus {
+    code: u32,
+}
+
+pub struct PollResult {
+    pub listener_readable: bool,
+    pub client_readable: bool,
+    pub client_writable: bool,
+    pub pty_readable: bool,
+}
+
+pub fn poll_session_ready(
+    _listener_fd: i32,
+    _client_fd: Option<i32>,
+    _client_needs_write: bool,
+    _pty_fd: i32,
+    _timeout_ms: i32,
+) -> Result<PollResult, String> {
+    Err("Windows session polling requires named-pipe IPC integration".to_string())
+}
+
+pub fn exit_code_from_wait_status(status: &WindowsExitStatus) -> i32 {
+    status.code as i32
+}
+
+pub fn stream_fd(_stream: &crate::platform::ipc::SessionStream) -> i32 {
+    -1
+}
+
+pub fn listener_fd(_listener: &crate::platform::ipc::SessionListener) -> i32 {
+    -1
+}
+
+struct Pipes {
+    input_read: HANDLE,
+    input_write: HANDLE,
+    output_read: HANDLE,
+    output_write: HANDLE,
+}
+
+impl Pipes {
+    fn new() -> Result<Self, String> {
+        let attrs =
+            SECURITY_ATTRIBUTES { nLength: size_of::<SECURITY_ATTRIBUTES>() as u32, lpSecurityDescriptor: null_mut(), bInheritHandle: 0 };
+
+        let mut input_read = null_mut();
+        let mut input_write = null_mut();
+        let mut output_read = null_mut();
+        let mut output_write = null_mut();
+
+        unsafe {
+            if CreatePipe(&mut input_read, &mut input_write, &attrs, 0) == 0 {
+                return Err(last_error("CreatePipe input"));
+            }
+            if CreatePipe(&mut output_read, &mut output_write, &attrs, 0) == 0 {
+                CloseHandle(input_read);
+                CloseHandle(input_write);
+                return Err(last_error("CreatePipe output"));
+            }
+        }
+
+        Ok(Self { input_read, input_write, output_read, output_write })
+    }
+}
+
+fn create_pseudo_console(cols: u16, rows: u16, input: HANDLE, output: HANDLE) -> Result<HPCON, String> {
+    let mut conpty = 0;
+    let result = unsafe { CreatePseudoConsole(COORD { X: cols as i16, Y: rows as i16 }, input, output, 0, &mut conpty) };
+
+    if result < 0 {
+        Err(format!("CreatePseudoConsole failed with HRESULT 0x{result:08x}"))
+    } else {
+        Ok(conpty)
+    }
+}
+
+fn spawn_with_conpty(command_line: &str, conpty: HPCON, cwd: Option<&PathBuf>) -> Result<PROCESS_INFORMATION, String> {
+    let mut attr_size = 0;
+    unsafe {
+        InitializeProcThreadAttributeList(null_mut(), 1, 0, &mut attr_size);
+    }
+
+    let mut attr_storage = vec![0u8; attr_size];
+    let attr_list = attr_storage.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST;
+
+    let initialized = unsafe { InitializeProcThreadAttributeList(attr_list, 1, 0, &mut attr_size) };
+    if initialized == 0 {
+        return Err(last_error("InitializeProcThreadAttributeList"));
+    }
+
+    let updated = unsafe {
+        UpdateProcThreadAttribute(
+            attr_list,
+            0,
+            PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE as usize,
+            conpty as *const c_void,
+            size_of::<HPCON>(),
+            null_mut(),
+            null(),
+        )
+    };
+    if updated == 0 {
+        unsafe {
+            DeleteProcThreadAttributeList(attr_list);
+        }
+        return Err(last_error("UpdateProcThreadAttribute"));
+    }
+
+    let mut startup_info: STARTUPINFOEXW = unsafe { zeroed() };
+    startup_info.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as u32;
+    startup_info.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    startup_info.StartupInfo.hStdInput = null_mut();
+    startup_info.StartupInfo.hStdOutput = null_mut();
+    startup_info.StartupInfo.hStdError = null_mut();
+    startup_info.lpAttributeList = attr_list;
+
+    let mut process_info: PROCESS_INFORMATION = unsafe { zeroed() };
+    let mut command_line = wide_null(command_line);
+    let cwd = cwd.map(|path| wide_null(&path.to_string_lossy()));
+    let cwd_ptr = cwd.as_ref().map(|value| value.as_ptr()).unwrap_or_else(null);
+
+    let created = unsafe {
+        CreateProcessW(
+            null(),
+            command_line.as_mut_ptr(),
+            null(),
+            null(),
+            0,
+            EXTENDED_STARTUPINFO_PRESENT | CREATE_NEW_PROCESS_GROUP,
+            null(),
+            cwd_ptr,
+            &startup_info as *const STARTUPINFOEXW as *const _,
+            &mut process_info,
+        )
+    };
+
+    unsafe {
+        DeleteProcThreadAttributeList(attr_list);
+    }
+
+    if created == 0 {
+        Err(last_error("CreateProcessW"))
+    } else {
+        Ok(process_info)
+    }
+}
+
+fn windows_shell_command(session: &SessionMetadata) -> String {
+    match &session.cmd {
+        Some(cmd) => format!("powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command {cmd}"),
+        None => "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass".to_string(),
+    }
+}
+
+fn write_handle_all(handle: HANDLE, mut bytes: &[u8]) -> Result<(), String> {
+    while !bytes.is_empty() {
+        let mut written = 0;
+        let ok = unsafe { WriteFile(handle, bytes.as_ptr(), bytes.len().min(u32::MAX as usize) as u32, &mut written, null_mut()) };
+        if ok == 0 {
+            return Err(last_error("WriteFile"));
+        }
+        if written == 0 {
+            return Err("WriteFile wrote zero bytes".to_string());
+        }
+        bytes = &bytes[written as usize..];
+    }
+    Ok(())
+}
+
+fn wide_null(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(Some(0)).collect()
+}
+
+fn last_error(operation: &str) -> String {
+    let code = unsafe { GetLastError() };
+    format!("{operation} failed with Windows error {code}")
+}

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -185,8 +185,8 @@ pub fn poll_session_ready(
     timeout_ms: i32,
 ) -> Result<PollResult, String> {
     // Named-pipe byte availability is not a reliable readiness boundary for
-    // the foreground client stream here. The session stream is nonblocking, so
-    // the daemon loop can cheaply attempt a read and let WouldBlock mean idle.
+    // the foreground client stream here. The session loop owns an overlapped
+    // read and applies the idle timeout when it drains client input.
     let client_readable = client.is_some();
     let pty_readable = pty_child.output_available()?;
     let listener_readable = true;
@@ -318,6 +318,8 @@ fn spawn_with_conpty(command_line: &str, conpty: HPCON, cwd: Option<&PathBuf>) -
 
 fn windows_shell_command(session: &SessionMetadata) -> String {
     match &session.cmd {
+        // Keep explicit commands in cmd.exe syntax for now. A PowerShell
+        // command path would need separate quoting and -Command semantics.
         Some(cmd) => format!("cmd.exe /D /C {}", quote_windows_arg(cmd)),
         None => "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass".to_string(),
     }
@@ -381,9 +383,8 @@ fn last_error(operation: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::{runtime::SessionMetadata, vt::VtEngineKind};
-
     use super::{quote_windows_arg, windows_shell_command};
+    use crate::{runtime::SessionMetadata, vt::VtEngineKind};
 
     #[test]
     fn quotes_empty_argument() {

--- a/crates/cleat/src/platform/terminal/mod.rs
+++ b/crates/cleat/src/platform/terminal/mod.rs
@@ -1,12 +1,16 @@
 #[cfg(unix)]
 mod unix;
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 mod unsupported;
+#[cfg(windows)]
+mod windows;
 
 #[cfg(unix)]
 pub use unix::*;
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 pub use unsupported::*;
+#[cfg(windows)]
+pub use windows::*;
 
 pub fn current_terminal_size() -> (u16, u16) {
     if let Some(size) = os_terminal_size() {

--- a/crates/cleat/src/platform/terminal/unix.rs
+++ b/crates/cleat/src/platform/terminal/unix.rs
@@ -13,13 +13,13 @@ use nix::{
 
 static ATTACH_SIGNAL_EXIT: AtomicBool = AtomicBool::new(false);
 
-pub struct TerminalModeGuard {
+pub struct ForegroundTerminal {
     fd: RawFd,
     original: Option<termios::Termios>,
 }
 
-impl TerminalModeGuard {
-    pub fn activate() -> Result<Self, String> {
+impl ForegroundTerminal {
+    pub fn enter() -> Result<Self, String> {
         let fd = std::io::stdin().as_raw_fd();
         // SAFETY: stdin remains open for the lifetime of the guard; we only borrow its fd.
         let borrowed_fd = unsafe { BorrowedFd::borrow_raw(fd) };
@@ -34,9 +34,16 @@ impl TerminalModeGuard {
 
         Ok(Self { fd, original: Some(original) })
     }
+
+    pub fn read_input(&mut self, timeout: Duration, buf: &mut [u8]) -> std::io::Result<Option<usize>> {
+        if !poll_fd_readable(self.fd, timeout).map_err(std::io::Error::other)? {
+            return Ok(None);
+        }
+        std::io::Read::read(&mut std::io::stdin().lock(), buf).map(Some)
+    }
 }
 
-impl Drop for TerminalModeGuard {
+impl Drop for ForegroundTerminal {
     fn drop(&mut self) {
         if let Some(original) = self.original.as_ref() {
             // SAFETY: stdin remains open for the lifetime of the guard; we only borrow its fd.
@@ -96,11 +103,6 @@ pub fn stdout_is_tty() -> Result<bool, String> {
     // SAFETY: stdout remains open for the duration of this check; we only borrow its fd.
     let borrowed_fd = unsafe { BorrowedFd::borrow_raw(fd) };
     isatty(borrowed_fd).map_err(|err| format!("detect terminal stdout: {err}"))
-}
-
-pub fn poll_stdin_readable(timeout: Duration) -> Result<bool, String> {
-    let fd = std::io::stdin().as_raw_fd();
-    poll_fd_readable(fd, timeout)
 }
 
 pub fn os_terminal_size() -> Option<(u16, u16)> {

--- a/crates/cleat/src/platform/terminal/unsupported.rs
+++ b/crates/cleat/src/platform/terminal/unsupported.rs
@@ -1,10 +1,14 @@
 use std::time::Duration;
 
-pub struct TerminalModeGuard;
+pub struct ForegroundTerminal;
 
-impl TerminalModeGuard {
-    pub fn activate() -> Result<Self, String> {
+impl ForegroundTerminal {
+    pub fn enter() -> Result<Self, String> {
         Ok(Self)
+    }
+
+    pub fn read_input(&mut self, _timeout: Duration, _buf: &mut [u8]) -> std::io::Result<Option<usize>> {
+        Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "foreground attach input is not supported on this platform"))
     }
 }
 
@@ -22,10 +26,6 @@ pub fn attach_signal_exit_requested() -> bool {
 
 pub fn stdout_is_tty() -> Result<bool, String> {
     Ok(false)
-}
-
-pub fn poll_stdin_readable(_timeout: Duration) -> Result<bool, String> {
-    Err("foreground attach stdin polling is only supported on Unix".to_string())
 }
 
 pub fn os_terminal_size() -> Option<(u16, u16)> {

--- a/crates/cleat/src/platform/terminal/windows.rs
+++ b/crates/cleat/src/platform/terminal/windows.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use windows_sys::Win32::{
-    Foundation::{CloseHandle, GetLastError, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT},
+    Foundation::{CloseHandle, GetLastError, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT},
     Storage::FileSystem::{CreateFileW, ReadFile, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING},
     System::{
         Console::{
@@ -19,7 +19,7 @@ use windows_sys::Win32::{
     },
 };
 
-const GENERIC_READ_WRITE: u32 = 0x8000_0000 | 0x4000_0000;
+const GENERIC_READ_WRITE: u32 = GENERIC_READ | GENERIC_WRITE;
 const VK_BACK: u16 = 0x08;
 const VK_TAB: u16 = 0x09;
 const VK_RETURN: u16 = 0x0d;

--- a/crates/cleat/src/platform/terminal/windows.rs
+++ b/crates/cleat/src/platform/terminal/windows.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::VecDeque,
     io,
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
@@ -53,7 +54,12 @@ impl ForegroundTerminal {
                     & !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT | ENABLE_MOUSE_INPUT);
                 set_console_mode(input_handle.handle, raw)?;
                 let vt_input = set_console_mode(input_handle.handle, raw | ENABLE_VIRTUAL_TERMINAL_INPUT).is_ok();
-                let input_reader = TerminalInput::Console { handle: input_handle.handle, vt_input, pending_high_surrogate: None };
+                let input_reader = TerminalInput::Console {
+                    handle: input_handle.handle,
+                    vt_input,
+                    pending_high_surrogate: None,
+                    pending_bytes: VecDeque::new(),
+                };
                 (input_reader, Some(ConsoleHandleMode { handle: input_handle, original }))
             }
             None => (TerminalInput::ByteStream { handle: input_handle.handle }, None),
@@ -136,15 +142,15 @@ pub fn stdout_is_tty() -> Result<bool, String> {
 }
 
 enum TerminalInput {
-    Console { handle: HANDLE, vt_input: bool, pending_high_surrogate: Option<u16> },
+    Console { handle: HANDLE, vt_input: bool, pending_high_surrogate: Option<u16>, pending_bytes: VecDeque<u8> },
     ByteStream { handle: HANDLE },
 }
 
 impl TerminalInput {
     fn read(&mut self, timeout: Duration, buf: &mut [u8]) -> io::Result<Option<usize>> {
         match self {
-            Self::Console { handle, vt_input, pending_high_surrogate } => {
-                read_console_input(*handle, *vt_input, pending_high_surrogate, timeout, buf)
+            Self::Console { handle, vt_input, pending_high_surrogate, pending_bytes } => {
+                read_console_input(*handle, *vt_input, pending_high_surrogate, pending_bytes, timeout, buf)
             }
             Self::ByteStream { handle } => read_byte_stream(*handle, buf).map(Some),
         }
@@ -165,9 +171,14 @@ fn read_console_input(
     handle: HANDLE,
     vt_input: bool,
     pending_high_surrogate: &mut Option<u16>,
+    pending_bytes: &mut VecDeque<u8>,
     timeout: Duration,
     buf: &mut [u8],
 ) -> io::Result<Option<usize>> {
+    if !pending_bytes.is_empty() {
+        return Ok(Some(drain_pending_bytes(pending_bytes, buf)));
+    }
+
     if !wait_for_handle(handle, timeout)? {
         return Ok(None);
     }
@@ -209,6 +220,7 @@ fn read_console_input(
         if !out.is_empty() {
             let n = out.len().min(buf.len());
             buf[..n].copy_from_slice(&out[..n]);
+            pending_bytes.extend(out[n..].iter().copied());
             return Ok(Some(n));
         }
 
@@ -216,6 +228,14 @@ fn read_console_input(
             return Ok(None);
         }
     }
+}
+
+fn drain_pending_bytes(pending: &mut VecDeque<u8>, buf: &mut [u8]) -> usize {
+    let n = pending.len().min(buf.len());
+    for slot in buf.iter_mut().take(n) {
+        *slot = pending.pop_front().expect("pending byte available");
+    }
+    n
 }
 
 fn append_key_event_bytes(virtual_key: u16, unicode: u16, pending_high_surrogate: &mut Option<u16>, out: &mut Vec<u8>) {

--- a/crates/cleat/src/platform/terminal/windows.rs
+++ b/crates/cleat/src/platform/terminal/windows.rs
@@ -1,0 +1,166 @@
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+
+use windows_sys::Win32::{
+    Foundation::{GetLastError, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT},
+    System::{
+        Console::{
+            GetConsoleMode, GetConsoleScreenBufferInfo, GetStdHandle, SetConsoleCtrlHandler, SetConsoleMode, CONSOLE_SCREEN_BUFFER_INFO,
+            CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT, CTRL_C_EVENT, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT,
+            ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+        },
+        Threading::WaitForSingleObject,
+    },
+};
+
+static ATTACH_SIGNAL_EXIT: AtomicBool = AtomicBool::new(false);
+
+pub struct TerminalModeGuard {
+    input: Option<(HANDLE, u32)>,
+    output: Option<(HANDLE, u32)>,
+}
+
+impl TerminalModeGuard {
+    pub fn activate() -> Result<Self, String> {
+        let input_handle = std_handle(STD_INPUT_HANDLE)?;
+        let output_handle = std_handle(STD_OUTPUT_HANDLE)?;
+
+        let input = match console_mode(input_handle)? {
+            Some(original) => {
+                let raw = (original | ENABLE_VIRTUAL_TERMINAL_INPUT) & !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
+                set_console_mode(input_handle, raw)?;
+                Some((input_handle, original))
+            }
+            None => None,
+        };
+
+        let output = match console_mode(output_handle)? {
+            Some(original) => {
+                set_console_mode(output_handle, original | ENABLE_VIRTUAL_TERMINAL_PROCESSING)?;
+                Some((output_handle, original))
+            }
+            None => None,
+        };
+
+        Ok(Self { input, output })
+    }
+}
+
+impl Drop for TerminalModeGuard {
+    fn drop(&mut self) {
+        if let Some((handle, mode)) = self.input {
+            let _ = set_console_mode(handle, mode);
+        }
+        if let Some((handle, mode)) = self.output {
+            let _ = set_console_mode(handle, mode);
+        }
+    }
+}
+
+pub struct AttachSignalHandlers {
+    installed: bool,
+}
+
+impl AttachSignalHandlers {
+    pub fn install() -> Result<Self, String> {
+        ATTACH_SIGNAL_EXIT.store(false, Ordering::SeqCst);
+        let ok = unsafe { SetConsoleCtrlHandler(Some(attach_console_handler), 1) };
+        if ok == 0 {
+            Err(last_error("SetConsoleCtrlHandler"))
+        } else {
+            Ok(Self { installed: true })
+        }
+    }
+}
+
+impl Drop for AttachSignalHandlers {
+    fn drop(&mut self) {
+        ATTACH_SIGNAL_EXIT.store(false, Ordering::SeqCst);
+        if self.installed {
+            unsafe {
+                SetConsoleCtrlHandler(Some(attach_console_handler), 0);
+            }
+        }
+    }
+}
+
+unsafe extern "system" fn attach_console_handler(ctrl_type: u32) -> i32 {
+    match ctrl_type {
+        CTRL_C_EVENT | CTRL_BREAK_EVENT | CTRL_CLOSE_EVENT => {
+            ATTACH_SIGNAL_EXIT.store(true, Ordering::SeqCst);
+            1
+        }
+        _ => 0,
+    }
+}
+
+pub fn attach_signal_exit_requested() -> bool {
+    ATTACH_SIGNAL_EXIT.load(Ordering::SeqCst)
+}
+
+pub fn stdout_is_tty() -> Result<bool, String> {
+    let handle = std_handle(STD_OUTPUT_HANDLE)?;
+    Ok(console_mode(handle)?.is_some())
+}
+
+pub fn poll_stdin_readable(timeout: Duration) -> Result<bool, String> {
+    let handle = std_handle(STD_INPUT_HANDLE)?;
+    if console_mode(handle)?.is_none() {
+        return Ok(true);
+    }
+
+    let timeout_ms = u32::try_from(timeout.as_millis()).map_err(|_| format!("poll timeout too large: {}ms", timeout.as_millis()))?;
+    match unsafe { WaitForSingleObject(handle, timeout_ms) } {
+        WAIT_OBJECT_0 => Ok(true),
+        WAIT_TIMEOUT => Ok(false),
+        status => Err(format!("WaitForSingleObject stdin returned {status}")),
+    }
+}
+
+pub fn os_terminal_size() -> Option<(u16, u16)> {
+    let handle = std_handle(STD_OUTPUT_HANDLE).ok()?;
+    let mut info: CONSOLE_SCREEN_BUFFER_INFO = unsafe { std::mem::zeroed() };
+    let ok = unsafe { GetConsoleScreenBufferInfo(handle, &mut info) };
+    if ok == 0 {
+        return None;
+    }
+
+    let cols = (info.srWindow.Right - info.srWindow.Left + 1).try_into().ok()?;
+    let rows = (info.srWindow.Bottom - info.srWindow.Top + 1).try_into().ok()?;
+    Some((cols, rows))
+}
+
+fn std_handle(which: u32) -> Result<HANDLE, String> {
+    let handle = unsafe { GetStdHandle(which) };
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        Err(last_error("GetStdHandle"))
+    } else {
+        Ok(handle)
+    }
+}
+
+fn console_mode(handle: HANDLE) -> Result<Option<u32>, String> {
+    let mut mode = 0;
+    let ok = unsafe { GetConsoleMode(handle, &mut mode) };
+    if ok == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(mode))
+    }
+}
+
+fn set_console_mode(handle: HANDLE, mode: u32) -> Result<(), String> {
+    let ok = unsafe { SetConsoleMode(handle, mode) };
+    if ok == 0 {
+        Err(last_error("SetConsoleMode"))
+    } else {
+        Ok(())
+    }
+}
+
+fn last_error(operation: &str) -> String {
+    let code = unsafe { GetLastError() };
+    format!("{operation} failed with Windows error {code}")
+}

--- a/crates/cleat/src/platform/terminal/windows.rs
+++ b/crates/cleat/src/platform/terminal/windows.rs
@@ -1,60 +1,90 @@
 use std::{
+    io,
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
 
 use windows_sys::Win32::{
-    Foundation::{GetLastError, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT},
+    Foundation::{CloseHandle, GetLastError, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT},
+    Storage::FileSystem::{CreateFileW, ReadFile, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING},
     System::{
         Console::{
-            GetConsoleMode, GetConsoleScreenBufferInfo, GetStdHandle, SetConsoleCtrlHandler, SetConsoleMode, CONSOLE_SCREEN_BUFFER_INFO,
-            CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT, CTRL_C_EVENT, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT,
-            ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+            GetConsoleMode, GetConsoleScreenBufferInfo, GetStdHandle, ReadConsoleInputW, SetConsoleCtrlHandler, SetConsoleMode,
+            CONSOLE_SCREEN_BUFFER_INFO, CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT, CTRL_C_EVENT, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT,
+            ENABLE_MOUSE_INPUT, ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+            ENABLE_WINDOW_INPUT, INPUT_RECORD, KEY_EVENT, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, WINDOW_BUFFER_SIZE_EVENT,
         },
         Threading::WaitForSingleObject,
     },
 };
 
+const GENERIC_READ_WRITE: u32 = 0x8000_0000 | 0x4000_0000;
+const VK_BACK: u16 = 0x08;
+const VK_TAB: u16 = 0x09;
+const VK_RETURN: u16 = 0x0d;
+const VK_ESCAPE: u16 = 0x1b;
+const VK_PRIOR: u16 = 0x21;
+const VK_NEXT: u16 = 0x22;
+const VK_END: u16 = 0x23;
+const VK_HOME: u16 = 0x24;
+const VK_LEFT: u16 = 0x25;
+const VK_UP: u16 = 0x26;
+const VK_RIGHT: u16 = 0x27;
+const VK_DOWN: u16 = 0x28;
+const VK_INSERT: u16 = 0x2d;
+const VK_DELETE: u16 = 0x2e;
+
 static ATTACH_SIGNAL_EXIT: AtomicBool = AtomicBool::new(false);
 
-pub struct TerminalModeGuard {
-    input: Option<(HANDLE, u32)>,
-    output: Option<(HANDLE, u32)>,
+pub struct ForegroundTerminal {
+    input_reader: TerminalInput,
+    input: Option<ConsoleHandleMode>,
+    output: Option<ConsoleHandleMode>,
 }
 
-impl TerminalModeGuard {
-    pub fn activate() -> Result<Self, String> {
-        let input_handle = std_handle(STD_INPUT_HANDLE)?;
-        let output_handle = std_handle(STD_OUTPUT_HANDLE)?;
+impl ForegroundTerminal {
+    pub fn enter() -> Result<Self, String> {
+        let input_handle = interactive_console_input_handle()?;
+        let output_handle = interactive_console_output_handle()?;
 
-        let input = match console_mode(input_handle)? {
+        let (input_reader, input) = match console_mode(input_handle.handle)? {
             Some(original) => {
-                let raw = (original | ENABLE_VIRTUAL_TERMINAL_INPUT) & !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
-                set_console_mode(input_handle, raw)?;
-                Some((input_handle, original))
+                let raw = (original | ENABLE_WINDOW_INPUT)
+                    & !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT | ENABLE_MOUSE_INPUT);
+                set_console_mode(input_handle.handle, raw)?;
+                let vt_input = set_console_mode(input_handle.handle, raw | ENABLE_VIRTUAL_TERMINAL_INPUT).is_ok();
+                let input_reader = TerminalInput::Console { handle: input_handle.handle, vt_input, pending_high_surrogate: None };
+                (input_reader, Some(ConsoleHandleMode { handle: input_handle, original }))
+            }
+            None => (TerminalInput::ByteStream { handle: input_handle.handle }, None),
+        };
+
+        let output = match console_mode(output_handle.handle)? {
+            Some(original) => {
+                set_console_mode(output_handle.handle, original | ENABLE_VIRTUAL_TERMINAL_PROCESSING)?;
+                Some(ConsoleHandleMode { handle: output_handle, original })
             }
             None => None,
         };
 
-        let output = match console_mode(output_handle)? {
-            Some(original) => {
-                set_console_mode(output_handle, original | ENABLE_VIRTUAL_TERMINAL_PROCESSING)?;
-                Some((output_handle, original))
-            }
-            None => None,
-        };
+        Ok(Self { input_reader, input, output })
+    }
 
-        Ok(Self { input, output })
+    pub fn read_input(&mut self, timeout: Duration, buf: &mut [u8]) -> io::Result<Option<usize>> {
+        if buf.is_empty() {
+            return Ok(Some(0));
+        }
+        self.input_reader.read(timeout, buf)
     }
 }
 
-impl Drop for TerminalModeGuard {
+impl Drop for ForegroundTerminal {
     fn drop(&mut self) {
-        if let Some((handle, mode)) = self.input {
-            let _ = set_console_mode(handle, mode);
+        if let Some(state) = self.input.as_ref() {
+            let _ = set_console_mode(state.handle.handle, state.original);
         }
-        if let Some((handle, mode)) = self.output {
-            let _ = set_console_mode(handle, mode);
+        if let Some(state) = self.output.as_ref() {
+            let _ = set_console_mode(state.handle.handle, state.original);
         }
     }
 }
@@ -105,24 +135,144 @@ pub fn stdout_is_tty() -> Result<bool, String> {
     Ok(console_mode(handle)?.is_some())
 }
 
-pub fn poll_stdin_readable(timeout: Duration) -> Result<bool, String> {
-    let handle = std_handle(STD_INPUT_HANDLE)?;
-    if console_mode(handle)?.is_none() {
-        return Ok(true);
+enum TerminalInput {
+    Console { handle: HANDLE, vt_input: bool, pending_high_surrogate: Option<u16> },
+    ByteStream { handle: HANDLE },
+}
+
+impl TerminalInput {
+    fn read(&mut self, timeout: Duration, buf: &mut [u8]) -> io::Result<Option<usize>> {
+        match self {
+            Self::Console { handle, vt_input, pending_high_surrogate } => {
+                read_console_input(*handle, *vt_input, pending_high_surrogate, timeout, buf)
+            }
+            Self::ByteStream { handle } => read_byte_stream(*handle, buf).map(Some),
+        }
+    }
+}
+
+fn read_byte_stream(handle: HANDLE, buf: &mut [u8]) -> io::Result<usize> {
+    let mut read = 0;
+    let ok = unsafe { ReadFile(handle, buf.as_mut_ptr(), buf.len() as u32, &mut read, std::ptr::null_mut()) };
+    if ok == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(read as usize)
+    }
+}
+
+fn read_console_input(
+    handle: HANDLE,
+    vt_input: bool,
+    pending_high_surrogate: &mut Option<u16>,
+    timeout: Duration,
+    buf: &mut [u8],
+) -> io::Result<Option<usize>> {
+    if !wait_for_handle(handle, timeout)? {
+        return Ok(None);
     }
 
-    let timeout_ms = u32::try_from(timeout.as_millis()).map_err(|_| format!("poll timeout too large: {}ms", timeout.as_millis()))?;
+    loop {
+        let mut records = [INPUT_RECORD::default(); 16];
+        let mut read = 0;
+        let ok = unsafe { ReadConsoleInputW(handle, records.as_mut_ptr(), records.len() as u32, &mut read) };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut out = Vec::new();
+        for record in records.iter().take(read as usize) {
+            match record.EventType as u32 {
+                KEY_EVENT => {
+                    let key = unsafe { record.Event.KeyEvent };
+                    if key.bKeyDown == 0 {
+                        continue;
+                    }
+                    let repeat = key.wRepeatCount.max(1);
+                    for _ in 0..repeat {
+                        let unicode = unsafe { key.uChar.UnicodeChar };
+                        if vt_input && unicode != 0 {
+                            append_unicode_char(unicode, pending_high_surrogate, &mut out);
+                        } else {
+                            append_key_event_bytes(key.wVirtualKeyCode, unicode, pending_high_surrogate, &mut out);
+                        }
+                    }
+                }
+                WINDOW_BUFFER_SIZE_EVENT => {}
+                _ => {}
+            }
+            if out.len() >= buf.len() {
+                break;
+            }
+        }
+
+        if !out.is_empty() {
+            let n = out.len().min(buf.len());
+            buf[..n].copy_from_slice(&out[..n]);
+            return Ok(Some(n));
+        }
+
+        if !wait_for_handle(handle, Duration::ZERO)? {
+            return Ok(None);
+        }
+    }
+}
+
+fn append_key_event_bytes(virtual_key: u16, unicode: u16, pending_high_surrogate: &mut Option<u16>, out: &mut Vec<u8>) {
+    match virtual_key {
+        VK_RETURN => out.push(b'\r'),
+        VK_BACK => out.push(0x08),
+        VK_TAB => out.push(b'\t'),
+        VK_ESCAPE => out.push(0x1b),
+        VK_UP => out.extend_from_slice(b"\x1b[A"),
+        VK_DOWN => out.extend_from_slice(b"\x1b[B"),
+        VK_RIGHT => out.extend_from_slice(b"\x1b[C"),
+        VK_LEFT => out.extend_from_slice(b"\x1b[D"),
+        VK_HOME => out.extend_from_slice(b"\x1b[H"),
+        VK_END => out.extend_from_slice(b"\x1b[F"),
+        VK_INSERT => out.extend_from_slice(b"\x1b[2~"),
+        VK_DELETE => out.extend_from_slice(b"\x1b[3~"),
+        VK_PRIOR => out.extend_from_slice(b"\x1b[5~"),
+        VK_NEXT => out.extend_from_slice(b"\x1b[6~"),
+        _ if unicode != 0 => {
+            append_unicode_char(unicode, pending_high_surrogate, out);
+        }
+        _ => {}
+    }
+}
+
+fn append_unicode_char(unicode: u16, pending_high_surrogate: &mut Option<u16>, out: &mut Vec<u8>) {
+    if unicode == 0 {
+        return;
+    }
+
+    if (0xd800..=0xdbff).contains(&unicode) {
+        *pending_high_surrogate = Some(unicode);
+        return;
+    }
+
+    let units = if let Some(high) = pending_high_surrogate.take() { vec![high, unicode] } else { vec![unicode] };
+    for decoded in char::decode_utf16(units) {
+        let ch = decoded.unwrap_or(char::REPLACEMENT_CHARACTER);
+        let mut encoded = [0u8; 4];
+        out.extend_from_slice(ch.encode_utf8(&mut encoded).as_bytes());
+    }
+}
+
+fn wait_for_handle(handle: HANDLE, timeout: Duration) -> io::Result<bool> {
+    let timeout_ms =
+        u32::try_from(timeout.as_millis()).map_err(|_| io::Error::other(format!("poll timeout too large: {}ms", timeout.as_millis())))?;
     match unsafe { WaitForSingleObject(handle, timeout_ms) } {
         WAIT_OBJECT_0 => Ok(true),
         WAIT_TIMEOUT => Ok(false),
-        status => Err(format!("WaitForSingleObject stdin returned {status}")),
+        status => Err(io::Error::other(format!("WaitForSingleObject stdin returned {status}"))),
     }
 }
 
 pub fn os_terminal_size() -> Option<(u16, u16)> {
-    let handle = std_handle(STD_OUTPUT_HANDLE).ok()?;
+    let handle = interactive_console_output_handle().ok()?;
     let mut info: CONSOLE_SCREEN_BUFFER_INFO = unsafe { std::mem::zeroed() };
-    let ok = unsafe { GetConsoleScreenBufferInfo(handle, &mut info) };
+    let ok = unsafe { GetConsoleScreenBufferInfo(handle.handle, &mut info) };
     if ok == 0 {
         return None;
     }
@@ -130,6 +280,92 @@ pub fn os_terminal_size() -> Option<(u16, u16)> {
     let cols = (info.srWindow.Right - info.srWindow.Left + 1).try_into().ok()?;
     let rows = (info.srWindow.Bottom - info.srWindow.Top + 1).try_into().ok()?;
     Some((cols, rows))
+}
+
+struct ConsoleHandleMode {
+    handle: BorrowedHandle,
+    original: u32,
+}
+
+struct BorrowedHandle {
+    handle: HANDLE,
+    close_on_drop: bool,
+}
+
+impl BorrowedHandle {
+    fn new(handle: HANDLE) -> Self {
+        Self { handle, close_on_drop: false }
+    }
+
+    fn owned(handle: HANDLE) -> Self {
+        Self { handle, close_on_drop: true }
+    }
+}
+
+impl Drop for BorrowedHandle {
+    fn drop(&mut self) {
+        if self.close_on_drop {
+            unsafe {
+                CloseHandle(self.handle);
+            }
+        }
+    }
+}
+
+impl std::ops::Deref for BorrowedHandle {
+    type Target = HANDLE;
+
+    fn deref(&self) -> &Self::Target {
+        &self.handle
+    }
+}
+
+fn console_input_handle() -> Result<BorrowedHandle, String> {
+    open_console_handle("CONIN$")
+}
+
+fn console_output_handle() -> Result<BorrowedHandle, String> {
+    open_console_handle("CONOUT$")
+}
+
+fn interactive_console_input_handle() -> Result<BorrowedHandle, String> {
+    let std = std_handle(STD_INPUT_HANDLE)?;
+    if console_mode(std)?.is_none() {
+        return Ok(BorrowedHandle::new(std));
+    }
+    console_input_handle().or_else(|_| Ok(BorrowedHandle::new(std)))
+}
+
+fn interactive_console_output_handle() -> Result<BorrowedHandle, String> {
+    let std = std_handle(STD_OUTPUT_HANDLE)?;
+    if console_mode(std)?.is_none() {
+        return Ok(BorrowedHandle::new(std));
+    }
+    console_output_handle().or_else(|_| Ok(BorrowedHandle::new(std)))
+}
+
+fn open_console_handle(name: &str) -> Result<BorrowedHandle, String> {
+    let wide = wide_null(name);
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            0,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        Err(last_error(&format!("CreateFileW {name}")))
+    } else {
+        Ok(BorrowedHandle::owned(handle))
+    }
+}
+
+fn wide_null(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
 fn std_handle(which: u32) -> Result<HANDLE, String> {

--- a/crates/cleat/src/platform/unix.rs
+++ b/crates/cleat/src/platform/unix.rs
@@ -17,7 +17,11 @@ use nix::{
     unistd::{chdir, execvp, read as nix_read, tcgetpgrp, write as nix_write, Pid},
 };
 
-use crate::{protocol::SignalTarget, runtime::SessionMetadata};
+use crate::{
+    platform::ipc::{SessionListener, SessionStream},
+    protocol::SignalTarget,
+    runtime::SessionMetadata,
+};
 
 const STRIP_ENV_VARS: &[&str] = &["SSH_TTY", "SSH_CONNECTION", "SSH_CLIENT"];
 
@@ -100,12 +104,15 @@ pub struct PollResult {
 }
 
 pub fn poll_session_ready(
-    listener_fd: RawFd,
-    client_fd: Option<RawFd>,
+    listener: &SessionListener,
+    client: Option<&SessionStream>,
     client_needs_write: bool,
-    pty_fd: RawFd,
+    pty_child: &PtyChild,
     timeout_ms: i32,
 ) -> Result<PollResult, String> {
+    let listener_fd = listener.as_raw_fd();
+    let client_fd = client.map(AsRawFd::as_raw_fd);
+    let pty_fd = pty_child.master_fd();
     let listener_borrowed = borrow_raw(listener_fd);
     let pty_borrowed = borrow_raw(pty_fd);
     let mut fds = vec![PollFd::new(listener_borrowed, PollFlags::POLLIN), PollFd::new(pty_borrowed, PollFlags::POLLIN)];

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -160,6 +160,21 @@ impl Frame {
         Self::decode(tag, payload)
     }
 
+    pub(crate) fn read_from_buffer(buffer: &mut Vec<u8>) -> std::io::Result<Option<Self>> {
+        if buffer.len() < 5 {
+            return Ok(None);
+        }
+        let tag = buffer[0];
+        let len = u32::from_le_bytes([buffer[1], buffer[2], buffer[3], buffer[4]]) as usize;
+        let frame_len = 5usize.checked_add(len).ok_or_else(|| Error::new(ErrorKind::InvalidData, "frame length overflow"))?;
+        if buffer.len() < frame_len {
+            return Ok(None);
+        }
+        let payload = buffer[5..frame_len].to_vec();
+        buffer.drain(..frame_len);
+        Self::decode(tag, payload).map(Some)
+    }
+
     pub fn write(&self, writer: &mut impl Write) -> std::io::Result<()> {
         let (tag, payload) = self.encode();
         let mut header = [0u8; 5];

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::VecDeque,
     fs,
-    io::{Read, Write},
+    io::Write,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -22,10 +22,7 @@ use crate::{
             set_stream_nonblocking, set_stream_read_timeout, shutdown_stream, SessionStream,
         },
         pty::{exit_code_from_wait_status, poll_session_ready, PtyChild},
-        terminal::{
-            attach_signal_exit_requested, current_terminal_size, poll_stdin_readable, stdout_is_tty, AttachSignalHandlers,
-            TerminalModeGuard,
-        },
+        terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
     protocol::Frame,
     runtime::{RuntimeLayout, SessionMetadata},
@@ -35,7 +32,8 @@ use crate::{
 const FOREGROUND_NAME: &str = "foreground";
 const DEFAULT_TERMINAL_COLS: u16 = 80;
 const DEFAULT_TERMINAL_ROWS: u16 = 24;
-const DETACH_CLEANUP_SEQUENCE: &[u8] = b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[?1049l\x1b[<u\x1b[?25h";
+const DETACH_CLEANUP_SEQUENCE: &[u8] =
+    b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[<u\x1b[r\x1b[0m\x1b[?25h\x1b[2J\x1b[H\x1b[?1049l";
 const REATTACH_CLEAR_SEQUENCE: &[u8] = b"\x1b[2J\x1b[H";
 const PTY_READ_BUFFER_SIZE: usize = 64 * 1024;
 const MAX_PENDING_CLIENT_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
@@ -48,7 +46,7 @@ pub struct ForegroundAttach {
 impl ForegroundAttach {
     pub fn relay_stdio(self) -> Result<(), String> {
         let mut cleanup = AttachCleanupGuard::stdout();
-        let _tty_mode = TerminalModeGuard::activate()?;
+        let mut terminal = ForegroundTerminal::enter()?;
         let _signal_handlers = AttachSignalHandlers::install()?;
         let read_handle = {
             let stream = self.stream.lock().map_err(|_| "attach stream lock poisoned".to_string())?;
@@ -93,21 +91,15 @@ impl ForegroundAttach {
             Ok(())
         });
 
-        let mut stdin = std::io::stdin().lock();
         let mut buf = [0u8; 4096];
         let stdin_result = loop {
             if !alive.load(Ordering::SeqCst) || attach_signal_exit_requested() {
                 break Ok(());
             }
-            match poll_stdin_readable(Duration::from_millis(100)) {
-                Ok(false) => continue,
-                Ok(true) => {}
-                Err(_err) if attach_signal_exit_requested() => break Ok(()),
-                Err(err) => break Err(err),
-            }
-            match stdin.read(&mut buf) {
-                Ok(0) => break Ok(()),
-                Ok(n) => {
+            match terminal.read_input(Duration::from_millis(100), &mut buf) {
+                Ok(None) => continue,
+                Ok(Some(0)) => break Ok(()),
+                Ok(Some(n)) => {
                     let mut stream = self.stream.lock().map_err(|_| "attach stream lock poisoned".to_string())?;
                     if let Err(err) = Frame::Input(buf[..n].to_vec()).write(&mut *stream) {
                         if is_graceful_socket_shutdown(&err) {
@@ -115,6 +107,17 @@ impl ForegroundAttach {
                         }
                         break Err(format!("write input frame: {err}"));
                     }
+                }
+                Err(err)
+                    if matches!(
+                        err.kind(),
+                        std::io::ErrorKind::UnexpectedEof
+                            | std::io::ErrorKind::BrokenPipe
+                            | std::io::ErrorKind::ConnectionReset
+                            | std::io::ErrorKind::ConnectionAborted
+                    ) =>
+                {
+                    break Ok(())
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
                 Err(err) => break Err(format!("read stdin: {err}")),
@@ -449,8 +452,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                                 pty_child.resize(cols, rows)?;
                                 let replay = apply_attach_state(vt_engine.as_mut(), cols, rows, &capabilities)?;
                                 Frame::Ack.write(&mut stream).map_err(|err| format!("write attach ack: {err}"))?;
-                                set_stream_nonblocking(&stream, true).map_err(|err| format!("set client nonblocking: {err}"))?;
-                                let mut client = ActiveClient::new(stream);
+                                let mut client = ActiveClient::new(stream)?;
                                 if let Some(payload) = replay {
                                     if !payload.is_empty() {
                                         if had_foreground_client {
@@ -702,28 +704,14 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
             }
         }
 
-        if poll_result.client_readable {
+        if active_client.is_some() {
             let mut client_disconnected = false;
             let mut pending = VecDeque::new();
-            if let Some(stream) = active_client.as_mut() {
-                loop {
-                    match Frame::read(&mut stream.stream) {
-                        Ok(frame) => pending.push_back(frame),
-                        Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
-                        Err(err)
-                            if matches!(
-                                err.kind(),
-                                std::io::ErrorKind::UnexpectedEof
-                                    | std::io::ErrorKind::BrokenPipe
-                                    | std::io::ErrorKind::ConnectionReset
-                                    | std::io::ErrorKind::ConnectionAborted
-                            ) =>
-                        {
-                            client_disconnected = true;
-                            break;
-                        }
-                        Err(err) => return Err(format!("read client frame: {err}")),
-                    }
+            if let Some(client) = active_client.as_mut() {
+                match client.drain_input_frames(&mut pending) {
+                    Ok(true) => {}
+                    Ok(false) => client_disconnected = true,
+                    Err(err) => return Err(format!("read client frame: {err}")),
                 }
             }
 
@@ -1058,11 +1046,29 @@ fn drain_pty_output_after_exit(
 struct ActiveClient {
     stream: SessionStream,
     pending_output: Vec<u8>,
+    input_reader: crate::platform::ipc::OverlappedRead,
+    input_buffer: Vec<u8>,
 }
 
 impl ActiveClient {
-    fn new(stream: SessionStream) -> Self {
-        Self { stream, pending_output: Vec::new() }
+    fn new(stream: SessionStream) -> Result<Self, String> {
+        let input_reader = stream.overlapped_reader(64 * 1024).map_err(|err| format!("create foreground client reader: {err}"))?;
+        Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new() })
+    }
+
+    fn drain_input_frames(&mut self, pending: &mut VecDeque<Frame>) -> Result<bool, std::io::Error> {
+        loop {
+            match self.input_reader.poll()? {
+                Some(bytes) if bytes.is_empty() => return Ok(false),
+                Some(bytes) => self.input_buffer.extend_from_slice(&bytes),
+                None => break,
+            }
+        }
+
+        while let Some(frame) = Frame::read_from_buffer(&mut self.input_buffer)? {
+            pending.push_back(frame);
+        }
+        Ok(true)
     }
 
     fn enqueue_frame(&mut self, frame: &Frame) -> Result<(), String> {
@@ -1120,7 +1126,7 @@ mod tests {
 
         assert_eq!(
             *output.lock().expect("lock output"),
-            b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[?1049l\x1b[<u\x1b[?25h"
+            b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[<u\x1b[r\x1b[0m\x1b[?25h\x1b[2J\x1b[H\x1b[?1049l"
         );
     }
 
@@ -1134,7 +1140,7 @@ mod tests {
 
         assert_eq!(
             *output.lock().expect("lock output"),
-            b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[?1049l\x1b[<u\x1b[?25h"
+            b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[<u\x1b[r\x1b[0m\x1b[?25h\x1b[2J\x1b[H\x1b[?1049l"
         );
     }
 

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1034,11 +1034,23 @@ fn drain_pty_output_after_exit(
                     }
                 }
             }
-            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock || is_pty_eof_after_exit(&err) => break,
             Err(err) => return Err(format!("read pty output after exit: {err}")),
         }
     }
     Ok(())
+}
+
+fn is_pty_eof_after_exit(err: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        err.raw_os_error() == Some(libc::EIO)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = err;
+        false
+    }
 }
 
 struct DrainExitContext<'a> {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -903,6 +903,18 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
         }
 
         if let Some(status) = pty_child.exited()? {
+            drain_pty_output_after_exit(
+                &pty_child,
+                vt_engine.as_mut(),
+                &mut recorder,
+                &mut active_client,
+                &mut detached_da,
+                root,
+                id,
+                session.vt_engine,
+                epoch,
+                &mut last_pty_output_at,
+            )?;
             for mut wait in pending_waits.drain(..) {
                 let elapsed_ms = wait.registered_at.elapsed().as_millis() as u64;
                 let _ = Frame::WaitResult { status: crate::protocol::WaitStatus::SessionGone, elapsed_ms }.write(&mut wait.stream);
@@ -917,6 +929,9 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                 rec.flush_final();
                 let code = exit_code_from_wait_status(&status);
                 rec.event(crate::asciicast::EventCode::Exit, &code.to_string(), epoch.elapsed());
+            }
+            if let Some(client) = active_client.as_mut() {
+                let _ = client.flush_pending_output();
             }
             break;
         }
@@ -977,6 +992,67 @@ fn build_inspect_result(
             markers: markers.clone(),
         },
     }
+}
+
+fn drain_pty_output_after_exit(
+    pty_child: &PtyChild,
+    vt_engine: &mut dyn VtEngine,
+    recorder: &mut Option<crate::recording::SessionRecorder>,
+    active_client: &mut Option<ActiveClient>,
+    detached_da: &mut Option<DeviceAttributeTracker>,
+    root: &Path,
+    id: &str,
+    vt_engine_kind: VtEngineKind,
+    epoch: Instant,
+    last_pty_output_at: &mut Option<Instant>,
+) -> Result<(), String> {
+    loop {
+        let mut buf = [0u8; PTY_READ_BUFFER_SIZE];
+        match pty_child.read_output(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                *last_pty_output_at = Some(Instant::now());
+                record_pty_output(vt_engine, &buf[..n])?;
+                if let Some(ref mut rec) = recorder {
+                    let elapsed = epoch.elapsed();
+                    rec.output(&buf[..n], elapsed);
+                    if rec.output_bytes_since_snapshot() >= 256 * 1024 {
+                        if let Ok(Some(payload)) = vt_engine.replay_payload(&vt::ClientCapabilities::conservative_fallback()) {
+                            let (cols, rows) = vt_engine.size();
+                            let state = String::from_utf8_lossy(&payload);
+                            rec.write_snapshot(&state, vt_engine_kind.as_str(), cols, rows, elapsed);
+                        } else {
+                            rec.reset_output_bytes_since_snapshot();
+                        }
+                    }
+                }
+
+                let engine_reply = vt_engine.drain_replies();
+                if active_client.is_none() {
+                    if let Some(ref mut tracker) = detached_da {
+                        for reply in tracker.push(&buf[..n]) {
+                            pty_child.write_all(&reply)?;
+                        }
+                    }
+                    if !engine_reply.is_empty() {
+                        pty_child.write_all(&engine_reply)?;
+                    }
+                }
+                if let Some(client) = active_client.as_mut() {
+                    if client.enqueue_frame(&Frame::Output(buf[..n].to_vec())).is_err() {
+                        let _ = fs::remove_file(foreground_path(root, id));
+                        if let Some(ref mut rec) = recorder {
+                            rec.event(crate::asciicast::EventCode::Custom('d'), r#"{"client":"foreground"}"#, epoch.elapsed());
+                        }
+                        *active_client = None;
+                    }
+                }
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(err) => return Err(format!("read pty output after exit: {err}")),
+        }
+    }
+    Ok(())
 }
 
 struct ActiveClient {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -21,7 +21,7 @@ use crate::{
             bind_session_listener, connect_session_stream, session_socket_path as platform_session_socket_path, set_listener_nonblocking,
             set_stream_nonblocking, set_stream_read_timeout, shutdown_stream, SessionStream,
         },
-        pty::{exit_code_from_wait_status, listener_fd, poll_session_ready, stream_fd, PtyChild},
+        pty::{exit_code_from_wait_status, poll_session_ready, PtyChild},
         terminal::{
             attach_signal_exit_requested, current_terminal_size, poll_stdin_readable, stdout_is_tty, AttachSignalHandlers,
             TerminalModeGuard,
@@ -422,10 +422,10 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
     let mut last_pty_output_at: Option<Instant> = None;
     loop {
         let poll_result = poll_session_ready(
-            listener_fd(&listener),
-            active_client.as_ref().map(|client| stream_fd(&client.stream)),
+            &listener,
+            active_client.as_ref().map(|client| &client.stream),
             active_client.as_ref().map(|client| !client.pending_output.is_empty()).unwrap_or(false),
-            pty_child.master_fd(),
+            &pty_child,
             100,
         )?;
 

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -707,8 +707,10 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
         if active_client.is_some() {
             let mut client_disconnected = false;
             let mut pending = VecDeque::new();
+            let client_read_timeout =
+                if poll_result.pty_readable || poll_result.client_writable { Duration::ZERO } else { Duration::from_millis(100) };
             if let Some(client) = active_client.as_mut() {
-                match client.drain_input_frames(&mut pending) {
+                match client.drain_input_frames(&mut pending, client_read_timeout) {
                     Ok(true) => {}
                     Ok(false) => client_disconnected = true,
                     Err(err) => return Err(format!("read client frame: {err}")),
@@ -1056,9 +1058,16 @@ impl ActiveClient {
         Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new() })
     }
 
-    fn drain_input_frames(&mut self, pending: &mut VecDeque<Frame>) -> Result<bool, std::io::Error> {
+    fn drain_input_frames(&mut self, pending: &mut VecDeque<Frame>, timeout: Duration) -> Result<bool, std::io::Error> {
+        let mut first_poll = true;
         loop {
-            match self.input_reader.poll()? {
+            let chunk = if first_poll {
+                first_poll = false;
+                self.input_reader.poll_timeout(timeout)?
+            } else {
+                self.input_reader.poll()?
+            };
+            match chunk {
                 Some(bytes) if bytes.is_empty() => return Ok(false),
                 Some(bytes) => self.input_buffer.extend_from_slice(&bytes),
                 None => break,

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -373,7 +373,7 @@ struct PendingExpect {
     registered_at: Instant,
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), String> {
     let id = &session.id;
     let session_dir = root.join(id);
@@ -434,8 +434,15 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                 Ok((mut stream, _)) => {
                     // Accepted sockets inherit nonblocking mode from the listener on macOS/BSD.
                     // Reset to blocking so the initial frame read works correctly.
-                    set_stream_nonblocking(&stream, false).map_err(|err| format!("set accepted stream blocking: {err}"))?;
-                    let _ = set_stream_read_timeout(&stream, Some(Duration::from_millis(100)));
+                    #[cfg(unix)]
+                    {
+                        set_stream_nonblocking(&stream, false).map_err(|err| format!("set accepted stream blocking: {err}"))?;
+                        let _ = set_stream_read_timeout(&stream, Some(Duration::from_millis(100)));
+                    }
+                    #[cfg(windows)]
+                    {
+                        set_stream_nonblocking(&stream, true).map_err(|err| format!("set accepted stream nonblocking: {err}"))?;
+                    }
                     match Frame::read(&mut stream) {
                         Ok(Frame::AttachInit { cols, rows, capabilities }) => {
                             if active_client.is_none() {
@@ -814,7 +821,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
         }
 
         if let Some(ref mut rec) = recorder {
-            if !poll_result.pty_readable && !poll_result.client_readable && !poll_result.listener_readable {
+            if !poll_result.pty_readable && !poll_result.client_readable {
                 rec.flush();
             }
         }
@@ -925,12 +932,12 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 pub fn run_session_daemon(_root: &Path, _session: &SessionMetadata) -> Result<(), String> {
     Err("session daemon is only supported on unix".into())
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn build_inspect_result(
     session: &SessionMetadata,
     vt_engine: &dyn VtEngine,

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::VecDeque,
     fs,
-    io::Write,
+    io::{Read, Write},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -452,6 +452,8 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                                 pty_child.resize(cols, rows)?;
                                 let replay = apply_attach_state(vt_engine.as_mut(), cols, rows, &capabilities)?;
                                 Frame::Ack.write(&mut stream).map_err(|err| format!("write attach ack: {err}"))?;
+                                #[cfg(unix)]
+                                set_stream_nonblocking(&stream, true).map_err(|err| format!("set client nonblocking: {err}"))?;
                                 let mut client = ActiveClient::new(stream)?;
                                 if let Some(payload) = replay {
                                     if !payload.is_empty() {
@@ -899,10 +901,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                 &mut recorder,
                 &mut active_client,
                 &mut detached_da,
-                root,
-                id,
-                session.vt_engine,
-                epoch,
+                DrainExitContext { root, id, vt_engine_kind: session.vt_engine, epoch },
                 &mut last_pty_output_at,
             )?;
             for mut wait in pending_waits.drain(..) {
@@ -990,10 +989,7 @@ fn drain_pty_output_after_exit(
     recorder: &mut Option<crate::recording::SessionRecorder>,
     active_client: &mut Option<ActiveClient>,
     detached_da: &mut Option<DeviceAttributeTracker>,
-    root: &Path,
-    id: &str,
-    vt_engine_kind: VtEngineKind,
-    epoch: Instant,
+    context: DrainExitContext<'_>,
     last_pty_output_at: &mut Option<Instant>,
 ) -> Result<(), String> {
     loop {
@@ -1004,13 +1000,13 @@ fn drain_pty_output_after_exit(
                 *last_pty_output_at = Some(Instant::now());
                 record_pty_output(vt_engine, &buf[..n])?;
                 if let Some(ref mut rec) = recorder {
-                    let elapsed = epoch.elapsed();
+                    let elapsed = context.epoch.elapsed();
                     rec.output(&buf[..n], elapsed);
                     if rec.output_bytes_since_snapshot() >= 256 * 1024 {
                         if let Ok(Some(payload)) = vt_engine.replay_payload(&vt::ClientCapabilities::conservative_fallback()) {
                             let (cols, rows) = vt_engine.size();
                             let state = String::from_utf8_lossy(&payload);
-                            rec.write_snapshot(&state, vt_engine_kind.as_str(), cols, rows, elapsed);
+                            rec.write_snapshot(&state, context.vt_engine_kind.as_str(), cols, rows, elapsed);
                         } else {
                             rec.reset_output_bytes_since_snapshot();
                         }
@@ -1030,9 +1026,9 @@ fn drain_pty_output_after_exit(
                 }
                 if let Some(client) = active_client.as_mut() {
                     if client.enqueue_frame(&Frame::Output(buf[..n].to_vec())).is_err() {
-                        let _ = fs::remove_file(foreground_path(root, id));
+                        let _ = fs::remove_file(foreground_path(context.root, context.id));
                         if let Some(ref mut rec) = recorder {
-                            rec.event(crate::asciicast::EventCode::Custom('d'), r#"{"client":"foreground"}"#, epoch.elapsed());
+                            rec.event(crate::asciicast::EventCode::Custom('d'), r#"{"client":"foreground"}"#, context.epoch.elapsed());
                         }
                         *active_client = None;
                     }
@@ -1045,16 +1041,23 @@ fn drain_pty_output_after_exit(
     Ok(())
 }
 
+struct DrainExitContext<'a> {
+    root: &'a Path,
+    id: &'a str,
+    vt_engine_kind: VtEngineKind,
+    epoch: Instant,
+}
+
 struct ActiveClient {
     stream: SessionStream,
     pending_output: Vec<u8>,
-    input_reader: crate::platform::ipc::OverlappedRead,
+    input_reader: ActiveClientReader,
     input_buffer: Vec<u8>,
 }
 
 impl ActiveClient {
     fn new(stream: SessionStream) -> Result<Self, String> {
-        let input_reader = stream.overlapped_reader(64 * 1024).map_err(|err| format!("create foreground client reader: {err}"))?;
+        let input_reader = ActiveClientReader::new(&stream)?;
         Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new() })
     }
 
@@ -1063,9 +1066,9 @@ impl ActiveClient {
         loop {
             let chunk = if first_poll {
                 first_poll = false;
-                self.input_reader.poll_timeout(timeout)?
+                self.input_reader.poll_timeout(&mut self.stream, timeout)?
             } else {
-                self.input_reader.poll()?
+                self.input_reader.poll(&mut self.stream)?
             };
             match chunk {
                 Some(bytes) if bytes.is_empty() => return Ok(false),
@@ -1103,6 +1106,54 @@ impl ActiveClient {
             }
         }
         Ok(true)
+    }
+}
+
+#[cfg(windows)]
+struct ActiveClientReader {
+    reader: crate::platform::ipc::OverlappedRead,
+}
+
+#[cfg(windows)]
+impl ActiveClientReader {
+    fn new(stream: &SessionStream) -> Result<Self, String> {
+        let reader = stream.overlapped_reader(64 * 1024).map_err(|err| format!("create foreground client reader: {err}"))?;
+        Ok(Self { reader })
+    }
+
+    fn poll(&mut self, _stream: &mut SessionStream) -> Result<Option<Vec<u8>>, std::io::Error> {
+        self.reader.poll()
+    }
+
+    fn poll_timeout(&mut self, _stream: &mut SessionStream, timeout: Duration) -> Result<Option<Vec<u8>>, std::io::Error> {
+        self.reader.poll_timeout(timeout)
+    }
+}
+
+#[cfg(not(windows))]
+struct ActiveClientReader;
+
+#[cfg(not(windows))]
+impl ActiveClientReader {
+    fn new(_stream: &SessionStream) -> Result<Self, String> {
+        Ok(Self)
+    }
+
+    fn poll(&mut self, stream: &mut SessionStream) -> Result<Option<Vec<u8>>, std::io::Error> {
+        self.poll_timeout(stream, Duration::ZERO)
+    }
+
+    fn poll_timeout(&mut self, stream: &mut SessionStream, _timeout: Duration) -> Result<Option<Vec<u8>>, std::io::Error> {
+        let mut buf = vec![0; 64 * 1024];
+        match stream.read(&mut buf) {
+            Ok(0) => Ok(Some(Vec::new())),
+            Ok(n) => {
+                buf.truncate(n);
+                Ok(Some(buf))
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 }
 
@@ -1174,7 +1225,8 @@ mod tests {
     #[test]
     fn active_client_rejects_unbounded_output_backlog() {
         let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
-        let mut client = super::ActiveClient { stream, pending_output: vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1] };
+        let mut client = super::ActiveClient::new(stream).expect("create active client");
+        client.pending_output = vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1];
 
         let err = client.enqueue_frame(&super::Frame::Output(vec![1])).expect_err("backlog should overflow");
 

--- a/crates/cleat/src/vt/ghostty_ffi.rs
+++ b/crates/cleat/src/vt/ghostty_ffi.rs
@@ -383,7 +383,6 @@ pub type GhosttyRenderState = *mut GhosttyRenderStateOpaque;
 pub type GhosttyRenderStateRowIterator = *mut GhosttyRowIteratorOpaque;
 pub type GhosttyRenderStateRowCells = *mut GhosttyRowCellsOpaque;
 
-#[link(name = "ghostty-vt")]
 unsafe extern "C" {
     fn ghostty_terminal_new(allocator: *const c_void, terminal: *mut GhosttyTerminal, options: GhosttyTerminalOptions) -> GhosttyResult;
     fn ghostty_terminal_free(terminal: GhosttyTerminal);

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -148,17 +148,14 @@ fn list_reports_existing_sessions() {
     let output = cli::execute(cli, &service).expect("execute list").expect("list output");
     let lines: Vec<_> = output.lines().collect();
 
-    assert_eq!(
-        lines,
-        vec![
-            format!(
-                "alpha\tdetached\t{} ({})\t/repo",
-                vt::default_vt_engine_kind().as_str(),
-                vt::vt_engine_status(vt::default_vt_engine_kind())
-            ),
-            format!("beta\tdetached\tpassthrough ({})\tzsh", vt::vt_engine_status(VtEngineKind::Passthrough)),
-        ]
-    );
+    assert_eq!(lines, vec![
+        format!(
+            "alpha\tdetached\t{} ({})\t/repo",
+            vt::default_vt_engine_kind().as_str(),
+            vt::vt_engine_status(vt::default_vt_engine_kind())
+        ),
+        format!("beta\tdetached\tpassthrough ({})\tzsh", vt::vt_engine_status(VtEngineKind::Passthrough)),
+    ]);
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -277,7 +277,7 @@ fn attach_creates_session_lazily_and_reuses_it_on_later_attach() {
     assert_eq!(second.vt_engine, vt::default_vt_engine_kind());
 }
 
-#[cfg(not(feature = "ghostty-vt"))]
+#[cfg(all(not(feature = "ghostty-vt"), not(windows)))]
 #[test]
 fn attach_rejects_lazy_create_in_nonfunctional_build() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -108,7 +108,7 @@ fn create_uses_requested_vt_engine() {
     assert_eq!(created.vt_engine, VtEngineKind::Passthrough);
 }
 
-#[cfg(not(feature = "ghostty-vt"))]
+#[cfg(all(not(feature = "ghostty-vt"), not(windows)))]
 #[test]
 fn create_rejects_unavailable_vt_engine() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
@@ -122,7 +122,7 @@ fn create_rejects_unavailable_vt_engine() {
     assert!(err.contains("ghostty-vt"));
 }
 
-#[cfg(not(feature = "ghostty-vt"))]
+#[cfg(all(not(feature = "ghostty-vt"), not(windows)))]
 #[test]
 fn create_rejects_default_nonfunctional_build() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
@@ -148,14 +148,17 @@ fn list_reports_existing_sessions() {
     let output = cli::execute(cli, &service).expect("execute list").expect("list output");
     let lines: Vec<_> = output.lines().collect();
 
-    assert_eq!(lines, vec![
-        format!(
-            "alpha\tdetached\t{} ({})\t/repo",
-            vt::default_vt_engine_kind().as_str(),
-            vt::vt_engine_status(vt::default_vt_engine_kind())
-        ),
-        format!("beta\tdetached\tpassthrough ({})\tzsh", vt::vt_engine_status(VtEngineKind::Passthrough)),
-    ]);
+    assert_eq!(
+        lines,
+        vec![
+            format!(
+                "alpha\tdetached\t{} ({})\t/repo",
+                vt::default_vt_engine_kind().as_str(),
+                vt::vt_engine_status(vt::default_vt_engine_kind())
+            ),
+            format!("beta\tdetached\tpassthrough ({})\tzsh", vt::vt_engine_status(VtEngineKind::Passthrough)),
+        ]
+    );
 }
 
 #[test]

--- a/crates/cleat/tests/vt.rs
+++ b/crates/cleat/tests/vt.rs
@@ -3,7 +3,9 @@ use cleat::vt::{passthrough::PassthroughVtEngine, ClientCapabilities, ColorLevel
 mod vt_contracts;
 
 #[cfg(feature = "ghostty-vt")]
-use std::{path::PathBuf, process::Command};
+use std::path::PathBuf;
+#[cfg(all(feature = "ghostty-vt", any(target_os = "linux", target_os = "macos")))]
+use std::process::Command;
 
 use vt_contracts::{assert_non_replay_contract, assert_replay_contract_placeholder, PassthroughFixture, PlaceholderReplayFixture};
 #[cfg(feature = "ghostty-vt")]
@@ -288,29 +290,59 @@ fn vt_ghostty_screen_grid_multi_codepoint_grapheme() {
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
-fn vt_ghostty_links_against_shared_library() {
+fn vt_ghostty_prepared_library_exists() {
     let prefix = PathBuf::from(env!("CLEAT_GHOSTTY_PREFIX"));
-    let lib_name = shared_library_filename();
-    let shared_library = prefix.join("lib").join(lib_name);
-    assert!(shared_library.exists(), "expected shared ghostty library at {}", shared_library.display());
+    #[cfg(target_os = "windows")]
+    {
+        let shared_library = shared_library_path(&prefix);
+        let import_library = prefix.join("lib").join("ghostty-vt.lib");
+        assert!(shared_library.exists(), "expected ghostty DLL at {}", shared_library.display());
+        assert!(import_library.exists(), "expected ghostty import library at {}", import_library.display());
+    }
 
-    let exe = std::env::current_exe().expect("current test binary");
-    let output = inspect_linkage(&exe);
-    let linkage = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "failed to inspect test binary linkage for {}\nstdout:\n{}\nstderr:\n{}",
-        exe.display(),
-        linkage,
-        stderr
-    );
-    assert!(
-        linkage.contains(lib_name),
-        "expected shared ghostty-vt linkage via {}, but test binary dependencies were:\n{}",
-        shared_library.display(),
-        linkage
-    );
+    #[cfg(not(target_os = "windows"))]
+    {
+        let static_library = prefix.join("lib").join(static_library_filename());
+        let shared_library = shared_library_path(&prefix);
+        assert!(
+            static_library.exists() || shared_library.exists(),
+            "expected static or shared ghostty library at {} or {}",
+            static_library.display(),
+            shared_library.display()
+        );
+
+        if static_library.exists() {
+            return;
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        let shared_library = shared_library_path(&prefix);
+        let lib_name = shared_library_filename();
+        let exe = std::env::current_exe().expect("current test binary");
+        let output = inspect_linkage(&exe);
+        let linkage = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "failed to inspect test binary linkage for {}\nstdout:\n{}\nstderr:\n{}",
+            exe.display(),
+            linkage,
+            stderr
+        );
+        assert!(
+            linkage.contains(lib_name),
+            "expected shared ghostty-vt linkage via {}, but test binary dependencies were:\n{}",
+            shared_library.display(),
+            linkage
+        );
+    }
+}
+
+#[cfg(all(feature = "ghostty-vt", not(target_os = "windows")))]
+fn static_library_filename() -> &'static str {
+    "libghostty-vt.a"
 }
 
 #[cfg(feature = "ghostty-vt")]
@@ -323,9 +355,25 @@ fn shared_library_filename() -> &'static str {
     {
         "libghostty-vt.dylib"
     }
+    #[cfg(target_os = "windows")]
+    {
+        "ghostty-vt.dll"
+    }
 }
 
 #[cfg(feature = "ghostty-vt")]
+fn shared_library_path(prefix: &std::path::Path) -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        let bin_path = prefix.join("bin").join(shared_library_filename());
+        if bin_path.exists() {
+            return bin_path;
+        }
+    }
+    prefix.join("lib").join(shared_library_filename())
+}
+
+#[cfg(all(feature = "ghostty-vt", any(target_os = "linux", target_os = "macos")))]
 fn inspect_linkage(exe: &std::path::Path) -> std::process::Output {
     #[cfg(target_os = "linux")]
     {

--- a/docs/specs/2026-06-02-windows-session-backend.md
+++ b/docs/specs/2026-06-02-windows-session-backend.md
@@ -1,0 +1,190 @@
+# Windows Session Backend Design
+
+Design sketch for adding a native Windows session backend to cleat after the
+platform-boundary refactor in PR #64.
+
+## Goal
+
+Support cleat sessions on Windows while preserving the daemon-per-session model:
+`cleat launch` starts a long-lived session daemon, clients communicate with that
+daemon, and the session continues after the foreground CLI exits.
+
+The first Windows milestone should make a narrow command-driven session work.
+Interactive attach parity can follow once the child PTY and IPC backend are
+proven.
+
+## Non-Goals
+
+- Do not implement full Ghostty app support. Cleat depends on `libghostty-vt`,
+  which is a separate lower-level library.
+- Do not redesign Unix sessions around Windows constraints.
+- Do not make Windows signals pretend to be POSIX. Expose compatible commands
+  where behavior is defensible, and document differences.
+- Do not start with async unless a concrete Windows API forces it.
+
+## Existing Shape
+
+The shared runtime now has platform seams under `crates/cleat/src/platform/`:
+
+- `ipc`: session stream/listener/connect helpers
+- `terminal`: foreground terminal mode, size, stdin polling, attach signal exit
+- `daemon`: daemon process spawn, pid file, liveness, termination
+- `process`: executable naming, executable detection, process termination
+- `signals`: CLI signal-name parsing to platform signal values
+- `pty`: PTY child facade, currently backed by the Unix module
+
+The shared session loop still owns:
+
+- protocol frame dispatch
+- VT engine feed/replay/capture
+- recorder, markers, waits, expects
+- foreground attachment state
+- cleanup and session lifecycle
+
+## Backend Choices
+
+### IPC
+
+Use Windows named pipes for session IPC.
+
+Rationale:
+- Named pipes match the local daemon/control-plane shape better than TCP.
+- They avoid port allocation, firewall, and localhost binding ambiguity.
+- They support multiple client connections and blocking stream IO.
+
+Open questions:
+- Pipe name format should be derived from the runtime root and session id but
+  sanitized for Windows pipe namespace constraints.
+- The session directory still needs a liveness indicator. The existing `socket`
+  path can remain as a marker file, but the actual transport will be a named
+  pipe.
+
+Alternative: localhost TCP. This is simpler to prototype but creates port
+management and security questions. Keep it as a fallback if named pipes become
+too awkward.
+
+### PTY
+
+Use Windows ConPTY (`CreatePseudoConsole`) for the child terminal.
+
+Rationale:
+- It is the native Windows pseudo-terminal API.
+- It provides byte-stream pipes that map naturally to cleat's VT feed and
+  recording model.
+- It supports resize through `ResizePseudoConsole`.
+
+First spike should prove:
+- spawn `powershell.exe` or `cmd.exe`
+- read PTY output
+- write input
+- resize
+- detect child exit
+- close handles without leaking the pseudoconsole
+
+Implementation choice:
+- Prefer a small direct Windows API wrapper or a narrow existing crate if it
+  exposes the exact needed handles and lifecycle.
+- Avoid committing to a broad terminal crate until the cleat-specific contract
+  is clear.
+
+### Shell and Command Semantics
+
+Unix currently runs `$SHELL` or `$SHELL -lc <cmd>`.
+
+Windows should default to `pwsh.exe` if available, then `powershell.exe`, then
+`cmd.exe`. For `--cmd`, use shell-specific command execution:
+
+- PowerShell: `-NoLogo -NoProfile -Command <cmd>`
+- cmd: `/C <cmd>`
+
+Open question:
+- Whether `--cmd` should keep the shell alive after command completion. Unix
+  exits when the command exits today; preserve that behavior initially.
+
+### Process Control
+
+Map existing control commands conservatively:
+
+- `kill`: terminate the daemon if it is still a cleat process; daemon cleanup
+  should terminate the child process/pseudoconsole.
+- `signal INT`: send Ctrl-C to the console process group if possible.
+- `signal TERM` / `KILL`: terminate the child process or process tree.
+- `signal HUP`, `QUIT`, `USR1`, `USR2`, `STOP`, `TSTP`, `CONT`: unsupported on
+  Windows unless a specific mapping is later justified.
+
+Foreground-process-group semantics do not directly exist on Windows. `inspect`
+should not fabricate `foreground_pgid`. Add platform-specific fields later if
+needed, or report `None` with clear state.
+
+Open questions:
+- Whether ConPTY plus process creation can reliably send Ctrl-C only to the
+  session child and not the cleat daemon.
+- Whether process tree termination should use Job Objects from the start.
+
+### Foreground Attach
+
+Defer full interactive attach until the ConPTY backend works for command-driven
+sessions.
+
+Initial attach support can remain unsupported on Windows, or it can use the same
+byte relay once these are solved:
+
+- Windows console raw-ish mode for stdin
+- terminal size detection from Windows console APIs
+- Ctrl-C handling without killing the cleat client itself
+- resize event propagation
+
+OpenSSH-on-Windows is a real target: attach behavior should be tested from an
+SSH session as well as Windows Terminal.
+
+### VT Engine
+
+Treat `libghostty-vt` as potentially portable to Windows, independent of the
+full Ghostty app.
+
+Follow-up work:
+- add a Windows prepare script or cross-platform tool for pinned Ghostty VT
+- support `.dll`/import `.lib` or static `ghostty-vt-static.lib`
+- adjust runtime library lookup (`PATH`) if dynamically linked
+
+This is separate from the session backend. A passthrough/nonfunctional default
+Windows build should remain possible while the Ghostty VT path is explored.
+
+## Proposed Milestones
+
+1. Keep Windows default build green in CI.
+2. ConPTY spike outside the shared daemon loop.
+3. Named-pipe IPC spike with `Frame` read/write round trips.
+4. Minimal backend integration:
+   - `launch --cmd`
+   - `send` / `send-keys`
+   - `record`, `transcript`, `expect --since`
+   - `kill`
+   - no interactive `attach` yet
+5. Add `capture` once a functional VT engine is available on Windows.
+6. Add interactive `attach` after terminal-mode and Ctrl-C behavior are proven.
+
+## Risks
+
+- Ctrl-C and process-tree behavior may not map cleanly to Unix signal targets.
+- Named pipe path/lifetime behavior may need a marker file distinct from the
+  actual transport endpoint.
+- ConPTY EOF and process-exit ordering may differ from Unix PTY behavior.
+- Dynamic `libghostty-vt` loading on Windows may complicate distribution.
+
+## Validation
+
+Baseline Windows checks:
+
+```powershell
+cargo check --locked
+cargo test --workspace --locked
+```
+
+Unix parity checks remain:
+
+```bash
+cargo +nightly-2026-03-12 fmt --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --locked
+```

--- a/tools/install-zig.ps1
+++ b/tools/install-zig.ps1
@@ -1,0 +1,52 @@
+param(
+    [string]$Version = '0.15.2',
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    'ARM64' { 'aarch64' }
+    default { 'x86_64' }
+}
+
+$toolsDir = Join-Path $RepoRoot '.tools'
+$installDir = Join-Path $toolsDir "zig-$Version"
+$zipName = "zig-$arch-windows-$Version.zip"
+$zipPath = Join-Path $toolsDir $zipName
+$url = "https://ziglang.org/download/$Version/$zipName"
+
+New-Item -ItemType Directory -Force -Path $toolsDir | Out-Null
+
+if (!(Test-Path (Join-Path $installDir 'zig.exe'))) {
+    if (!(Test-Path $zipPath)) {
+        Write-Host "Downloading $url"
+        Invoke-WebRequest -Uri $url -OutFile $zipPath
+    }
+
+    $extractDir = Join-Path $toolsDir "zig-extract-$Version"
+    if (Test-Path $extractDir) {
+        Remove-Item -Recurse -Force $extractDir
+    }
+    New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+    Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+    $expanded = Get-ChildItem -Path $extractDir -Directory | Select-Object -First 1
+    if ($null -eq $expanded) {
+        throw "Unable to find expanded Zig directory in $extractDir"
+    }
+
+    if (Test-Path $installDir) {
+        Remove-Item -Recurse -Force $installDir
+    }
+    Move-Item -Path $expanded.FullName -Destination $installDir
+    Remove-Item -Recurse -Force $extractDir
+}
+
+$zig = Join-Path $installDir 'zig.exe'
+$actualVersion = (& $zig version).Trim()
+if ($actualVersion -ne $Version) {
+    throw "Expected Zig $Version at $zig, found $actualVersion"
+}
+
+Write-Output $zig

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -17,24 +17,26 @@ echo "Building cleat..."
   CLEAT_GHOSTTY_PREFIX="$GHOSTTY_PREFIX" \
   cargo build -p cleat --locked --features ghostty-vt --release)
 
-# Install binary and dylib
+# Install binary and, if dynamic Ghostty linkage is used, the dylib
 mkdir -p "$BIN_DIR" "$LIB_DIR"
 
 cp "$REPO_ROOT/target/release/cleat" "$BIN_DIR/cleat"
 
-# Copy ghostty-vt dylib
-case "$(uname -s)" in
-  Darwin) DYLIB="libghostty-vt.dylib" ;;
-  Linux)  DYLIB="libghostty-vt.so" ;;
-  *)      echo "Unsupported OS" >&2; exit 1 ;;
-esac
+if [[ ! -f "$GHOSTTY_PREFIX/lib/libghostty-vt.a" ]]; then
+  case "$(uname -s)" in
+    Darwin) DYLIB="libghostty-vt.dylib" ;;
+    Linux)  DYLIB="libghostty-vt.so" ;;
+    *)      echo "Unsupported OS" >&2; exit 1 ;;
+  esac
 
-cp "$GHOSTTY_PREFIX/lib/$DYLIB" "$LIB_DIR/$DYLIB"
+  cp "$GHOSTTY_PREFIX/lib/$DYLIB" "$LIB_DIR/$DYLIB"
 
-# On macOS, add rpath so the binary finds the dylib in ../lib relative to itself
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  install_name_tool -add_rpath "@executable_path/../lib" "$BIN_DIR/cleat" 2>/dev/null || true
+  # On macOS, add rpath so the binary finds the dylib in ../lib relative to itself
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    install_name_tool -add_rpath "@executable_path/../lib" "$BIN_DIR/cleat" 2>/dev/null || true
+  fi
+
+  echo "Installed $DYLIB to $LIB_DIR/$DYLIB"
 fi
 
 echo "Installed cleat to $BIN_DIR/cleat"
-echo "Installed $DYLIB to $LIB_DIR/$DYLIB"

--- a/tools/prepare-ghostty-vt.ps1
+++ b/tools/prepare-ghostty-vt.ps1
@@ -1,0 +1,91 @@
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ToolchainFile = Join-Path $RepoRoot 'tools\ghostty-toolchain.toml'
+$SourceDir = Join-Path $RepoRoot '.tools\ghostty-src'
+$InstallDir = Join-Path $RepoRoot '.tools\ghostty-install'
+
+function Get-TomlValue {
+    param(
+        [string]$Section,
+        [string]$Key,
+        [string]$Path
+    )
+
+    $current = ''
+    foreach ($line in Get-Content $Path) {
+        $trimmed = ($line -replace '#.*$', '').Trim()
+        if ($trimmed -match '^\[(.+)\]$') {
+            $current = $Matches[1]
+            continue
+        }
+        if ($current -eq $Section -and $trimmed -match "^$([regex]::Escape($Key))\s*=\s*`"(.+)`"\s*$") {
+            return $Matches[1]
+        }
+    }
+
+    throw "Missing [$Section].$Key in $Path"
+}
+
+$requiredZigVersion = Get-TomlValue -Section 'zig' -Key 'version' -Path $ToolchainFile
+$zig = (Get-Command zig -ErrorAction SilentlyContinue).Source
+if ($null -eq $zig -or ((& $zig version).Trim()) -ne $requiredZigVersion) {
+    $zig = (& (Join-Path $RepoRoot 'tools\install-zig.ps1') -Version $requiredZigVersion -RepoRoot $RepoRoot | Select-Object -Last 1).Trim()
+}
+
+$zigVersion = (& $zig version).Trim()
+if ($zigVersion -ne $requiredZigVersion) {
+    throw "Expected zig version $requiredZigVersion, found $zigVersion"
+}
+
+$ghosttyRepo = Get-TomlValue -Section 'ghostty' -Key 'repo' -Path $ToolchainFile
+$ghosttyRef = Get-TomlValue -Section 'ghostty' -Key 'ref' -Path $ToolchainFile
+$buildStep = Get-TomlValue -Section 'ghostty' -Key 'build_step' -Path $ToolchainFile
+$buildArgs = @()
+if ($buildStep.Trim().Length -gt 0) {
+    $buildArgs = $buildStep -split '\s+'
+}
+
+New-Item -ItemType Directory -Force -Path (Join-Path $RepoRoot '.tools') | Out-Null
+
+if (Test-Path (Join-Path $SourceDir '.git')) {
+    git -C $SourceDir remote set-url origin $ghosttyRepo
+    git -C $SourceDir fetch origin --prune --tags --force
+} else {
+    if (Test-Path $SourceDir) {
+        Remove-Item -Recurse -Force $SourceDir
+    }
+    git clone $ghosttyRepo $SourceDir
+}
+
+git -C $SourceDir checkout --force $ghosttyRef
+git -C $SourceDir reset --hard $ghosttyRef
+
+if (Test-Path $InstallDir) {
+    Remove-Item -Recurse -Force $InstallDir
+}
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+Push-Location $SourceDir
+try {
+    & $zig build @buildArgs --prefix $InstallDir
+} finally {
+    Pop-Location
+}
+
+$header = Join-Path $InstallDir 'include\ghostty\vt.h'
+if (!(Test-Path $header)) {
+    throw "Missing Ghostty VT header at $header"
+}
+
+$staticLib = Join-Path $InstallDir 'lib\ghostty-vt-static.lib'
+$sharedLib = Join-Path $InstallDir 'bin\ghostty-vt.dll'
+$sharedLibAlt = Join-Path $InstallDir 'lib\ghostty-vt.dll'
+$importLib = Join-Path $InstallDir 'lib\ghostty-vt.lib'
+
+if (!(Test-Path $staticLib) -and !((Test-Path $importLib) -and ((Test-Path $sharedLib) -or (Test-Path $sharedLibAlt)))) {
+    throw "Missing Ghostty VT library; expected $staticLib or $importLib plus ghostty-vt.dll"
+}

--- a/tools/prepare-ghostty-vt.sh
+++ b/tools/prepare-ghostty-vt.sh
@@ -68,9 +68,13 @@ mkdir -p "$INSTALL_DIR"
 (cd "$SOURCE_DIR" && zig build $build_step --prefix "$INSTALL_DIR")
 
 test -f "$INSTALL_DIR/include/ghostty/vt.h"
-test -f "$INSTALL_DIR/lib/libghostty-vt.a"
 
 case "$(uname -s)" in
-  Darwin) test -f "$INSTALL_DIR/lib/libghostty-vt.dylib" ;;
-  *)      test -f "$INSTALL_DIR/lib/libghostty-vt.so" ;;
+  Darwin) shared_lib="$INSTALL_DIR/lib/libghostty-vt.dylib" ;;
+  *)      shared_lib="$INSTALL_DIR/lib/libghostty-vt.so" ;;
 esac
+static_lib="$INSTALL_DIR/lib/libghostty-vt.a"
+if [ ! -f "$static_lib" ] && [ ! -f "$shared_lib" ]; then
+  echo "missing Ghostty VT library: expected $static_lib or $shared_lib" >&2
+  exit 1
+fi

--- a/tools/prepare-ghostty-vt.sh
+++ b/tools/prepare-ghostty-vt.sh
@@ -68,6 +68,7 @@ mkdir -p "$INSTALL_DIR"
 (cd "$SOURCE_DIR" && zig build $build_step --prefix "$INSTALL_DIR")
 
 test -f "$INSTALL_DIR/include/ghostty/vt.h"
+test -f "$INSTALL_DIR/lib/libghostty-vt.a"
 
 case "$(uname -s)" in
   Darwin) test -f "$INSTALL_DIR/lib/libghostty-vt.dylib" ;;


### PR DESCRIPTION
## Summary

- add a foreground terminal abstraction so attach owns stable terminal handles while it is active
- implement Windows console input for attach via `ReadConsoleInputW`, including VT-input mode and fallback key translation for common navigation keys
- rework Windows session IPC to use overlapped named-pipe operations and buffered frame decoding instead of `PIPE_NOWAIT` polling
- close ConPTY-side pipe handles after process creation and improve detach cleanup so the caller's terminal is reset, cleared, and homed

## Verification

- `cargo check -p cleat --locked --features ghostty-vt`
- `cargo test -p cleat --locked --features ghostty-vt`
- manual Windows Terminal smoke test: attach, detach, reattach from another terminal, start `codex`, detach, and reattach again