### PR TITLE
Enable Ghostty SIMD VT on Windows

### DIFF
--- a/crates/cleat/build.rs
+++ b/crates/cleat/build.rs
@@ -38,8 +38,20 @@ fn main() {
         LinkMode::Static => println!("cargo:rustc-link-lib=static={}", static_link_name()),
         LinkMode::Dynamic => println!("cargo:rustc-link-lib=dylib=ghostty-vt"),
     }
+    if cfg!(all(target_os = "windows", target_env = "msvc")) && install.link_mode == LinkMode::Dynamic {
+        link_msvc_runtime_libs();
+    }
     if install.link_mode == LinkMode::Dynamic && cfg!(any(target_os = "linux", target_os = "macos")) {
         println!("cargo:rustc-link-arg=-Wl,-rpath,{}", install.lib_dir.display());
+    }
+}
+
+fn link_msvc_runtime_libs() {
+    // Windows uses Ghostty's import library, but enabling Ghostty SIMD pulls in
+    // UCRT/VCRuntime/C++ EH symbols that Rust's DLL link does not otherwise
+    // resolve reliably.
+    for lib in ["ucrt", "vcruntime", "msvcprt"] {
+        println!("cargo:rustc-link-arg=/defaultlib:{lib}");
     }
 }
 

--- a/tools/ghostty-toolchain.toml
+++ b/tools/ghostty-toolchain.toml
@@ -14,5 +14,5 @@ version = "0.15.2"
 # libvt branches upstream, retire this fork and re-pin to ghostty-org/ghostty.
 [ghostty]
 repo = "https://github.com/rjwittams/ghostty.git"
-ref = "5ac386088664b2209c0e0f8fce161977d2b1d31c"
-build_step = "-Demit-lib-vt=true"
+ref = "4951a2b2b4b18e1d627550c26fb0018cd915afbd"
+build_step = "-Demit-lib-vt=true -Dsimd=true"


### PR DESCRIPTION
## Summary
- pin Ghostty VT to the cleat-integration commit with the in-tree MSVC simdutf static-init fix
- enable Ghostty VT SIMD globally for the prepared toolchain
- make Cleat's Windows/MSVC dynamic Ghostty link explicitly include UCRT/VCRuntime/C++ runtime default libraries

## Notes
-Dsimd=true is intentionally enabled for the prepared Ghostty VT build on every supported platform, not just Windows. The Windows-specific part of this PR is the Cleat/MSVC link fix required for the SIMD Ghostty import library.

## Verification
- cargo build -p cleat --locked --features ghostty-vt
- C:\dev\build-uishell.cmd
- standalone Cleat launched/captured PowerShell output through the SIMD Ghostty provider
- uild\uishell.exe stayed alive for 8 seconds with no new crash dump
- after review cleanup, rebuilt Cleat without msvcrt in the explicit runtime list; no LNK4098 warning appeared
