### PR TITLE
[codex] Fix in-process dirty state queries

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,10 +20,10 @@ _Avoid_: mode, backend (the code-level term, not the domain concept).
 
 **Placement**:
 A client's requested hosting target or policy for a session, such as embedded,
-daemon, or a remote target. A placement request may be exact, or may allow Cleat
-to fall back to a different hosting when policy, capability, or availability
-requires it at Ensure Session time. Both the requested placement and the actual hosting are
-discoverable by clients.
+daemon, or a remote target. A placement request may be exact or advisory. When
+advisory, Cleat may fall back to a different hosting when policy, capability, or
+availability requires it at Ensure Session time. Both the requested placement
+and the actual hosting are discoverable by clients.
 _Avoid_: backend, provider mode.
 
 **Id**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,14 @@ Where a session's VT engine currently runs. A property *of the session* that can
 change over its life — not a global mode of the client or provider.
 _Avoid_: mode, backend (the code-level term, not the domain concept).
 
+**Placement**:
+A client's requested hosting target or policy for a session, such as embedded,
+daemon, or a remote target. A placement request may be exact, or may allow Cleat
+to fall back to a different hosting when policy, capability, or availability
+requires it at Ensure Session time. Both the requested placement and the actual hosting are
+discoverable by clients.
+_Avoid_: backend, provider mode.
+
 **Id**:
 A session's single durable identity. Client-assignable at create (cleat
 generates a uuid only as a fallback) and **reused across recreations** — so it is
@@ -38,6 +46,18 @@ socket. Survives client restarts.
 A client resuming a session that already exists — the program is still running,
 so it is lossless and live. Distinct from recreation.
 _Avoid_: connect, open.
+
+**Ensure Session**:
+Making a durable session id usable for a client by attaching to the live session,
+recreating it from recording, or creating it fresh. Attach is one possible
+outcome; it is not the umbrella term for the whole operation.
+_Avoid_: ensure attached, attach-or-create.
+
+**Session Handle**:
+A client's live reference to a session returned by Ensure Session. Multiple
+clients may hold handles to the same session; the handle is not the session's
+identity and does not determine where the session is hosted.
+_Avoid_: session id, attach.
 
 **Recording**:
 The append-only log of a session's output (asciicast v3), optionally with VT

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -3,7 +3,10 @@ use std::{
     path::PathBuf,
     ptr, slice,
     str::Utf8Error,
-    sync::{mpsc, Arc, Mutex},
+    sync::{
+        atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering},
+        mpsc, Arc, Mutex,
+    },
     thread,
     time::Duration,
 };
@@ -536,6 +539,7 @@ struct MockSession {
 
 struct InProcessSession {
     tx: mpsc::Sender<InProcessCommand>,
+    observation: Arc<ObservationMirror>,
     worker: Option<thread::JoinHandle<()>>,
 }
 
@@ -562,12 +566,23 @@ struct ObservationState {
     dirty: DirtyState,
     dirty_rows: Vec<u16>,
     terminal_modes: Option<vt::TerminalModeState>,
+    mirror: Option<Arc<ObservationMirror>>,
 }
 
 impl ObservationState {
     fn new(rows: u16) -> Self {
-        let mut state =
-            Self { render_generation: 0, observed_generation: 0, dirty: DirtyState::Clean, dirty_rows: Vec::new(), terminal_modes: None };
+        Self::new_with_mirror(rows, None)
+    }
+
+    fn new_with_mirror(rows: u16, mirror: Option<Arc<ObservationMirror>>) -> Self {
+        let mut state = Self {
+            render_generation: 0,
+            observed_generation: 0,
+            dirty: DirtyState::Clean,
+            dirty_rows: Vec::new(),
+            terminal_modes: None,
+            mirror,
+        };
         state.mark_full(rows);
         state
     }
@@ -585,6 +600,7 @@ impl ObservationState {
         self.render_generation = self.render_generation.saturating_add(1);
         self.dirty = DirtyState::Full;
         self.dirty_rows.clear();
+        self.publish_mirror();
         was_clean
     }
 
@@ -600,6 +616,7 @@ impl ObservationState {
             }
             self.dirty_rows.sort_unstable();
         }
+        self.publish_mirror();
         was_clean
     }
 
@@ -610,6 +627,7 @@ impl ObservationState {
             self.dirty = DirtyState::Partial;
             self.dirty_rows.clear();
         }
+        self.publish_mirror();
         was_clean
     }
 
@@ -631,6 +649,7 @@ impl ObservationState {
             self.dirty = DirtyState::Clean;
             self.dirty_rows.clear();
         }
+        self.publish_mirror();
         true
     }
 
@@ -657,6 +676,61 @@ impl ObservationState {
         } else if update.dirty == DirtyState::Clean {
             update.dirty = dirty;
         }
+    }
+
+    fn publish_mirror(&self) {
+        if let Some(mirror) = &self.mirror {
+            mirror.store(self.render_generation, self.observed_generation, self.dirty);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ObservationMirror {
+    render_generation: AtomicU64,
+    observed_generation: AtomicU64,
+    dirty: AtomicU8,
+}
+
+impl ObservationMirror {
+    fn new() -> Self {
+        Self {
+            render_generation: AtomicU64::new(0),
+            observed_generation: AtomicU64::new(0),
+            dirty: AtomicU8::new(dirty_state_to_u8(DirtyState::Clean)),
+        }
+    }
+
+    fn store(&self, render_generation: u64, observed_generation: u64, dirty: DirtyState) {
+        self.dirty.store(dirty_state_to_u8(dirty), AtomicOrdering::SeqCst);
+        self.observed_generation.store(observed_generation, AtomicOrdering::SeqCst);
+        self.render_generation.store(render_generation, AtomicOrdering::SeqCst);
+    }
+
+    fn dirty(&self) -> DirtyState {
+        let render_generation = self.render_generation.load(AtomicOrdering::SeqCst);
+        let observed_generation = self.observed_generation.load(AtomicOrdering::SeqCst);
+        if render_generation > observed_generation {
+            dirty_state_from_u8(self.dirty.load(AtomicOrdering::SeqCst))
+        } else {
+            DirtyState::Clean
+        }
+    }
+}
+
+fn dirty_state_to_u8(dirty: DirtyState) -> u8 {
+    match dirty {
+        DirtyState::Clean => 0,
+        DirtyState::Partial => 1,
+        DirtyState::Full => 2,
+    }
+}
+
+fn dirty_state_from_u8(value: u8) -> DirtyState {
+    match value {
+        1 => DirtyState::Partial,
+        2 => DirtyState::Full,
+        _ => DirtyState::Clean,
     }
 }
 
@@ -733,9 +807,6 @@ enum InProcessCommand {
         callback: CleatImageResourceDataFn,
         user_data: usize,
         reply: mpsc::Sender<Result<bool, String>>,
-    },
-    Dirty {
-        reply: mpsc::Sender<DirtyState>,
     },
     MarkObserved {
         generation: u64,
@@ -1724,9 +1795,7 @@ pub unsafe extern "C" fn cleat_session_poll(session: *mut CleatSession) -> Cleat
     };
     match &mut session.backend {
         SessionBackend::Mock(mock) => mock.observation.dirty().into(),
-        SessionBackend::InProcess(in_process) => {
-            in_process_request(in_process, |reply| InProcessCommand::Dirty { reply }, DirtyState::Full).into()
-        }
+        SessionBackend::InProcess(in_process) => in_process.observation.dirty().into(),
         SessionBackend::Daemon(daemon) => daemon.observation.dirty().into(),
     }
 }
@@ -1741,9 +1810,7 @@ pub unsafe extern "C" fn cleat_session_dirty(session: *const CleatSession) -> Cl
     unsafe { session.as_ref() }
         .map(|session| match &session.backend {
             SessionBackend::Mock(mock) => mock.observation.dirty().into(),
-            SessionBackend::InProcess(in_process) => {
-                in_process_request(in_process, |reply| InProcessCommand::Dirty { reply }, DirtyState::Full).into()
-            }
+            SessionBackend::InProcess(in_process) => in_process.observation.dirty().into(),
             SessionBackend::Daemon(daemon) => daemon.observation.dirty().into(),
         })
         .unwrap_or(CleatDirtyState::Full)
@@ -2117,10 +2184,11 @@ fn in_process_actor_loop(
     mut runtime: SessionRuntime,
     wake: Arc<Mutex<WakeCallback>>,
     rows: u16,
+    mirror: Arc<ObservationMirror>,
     ready: mpsc::Sender<Result<(), String>>,
     rx: mpsc::Receiver<InProcessCommand>,
 ) {
-    let mut observation = ObservationState::new(rows);
+    let mut observation = ObservationState::new_with_mirror(rows, Some(mirror));
     let mut exited = false;
     let _ = ready.send(Ok(()));
     loop {
@@ -2212,10 +2280,6 @@ fn in_process_actor_handle_command(
                 None => Ok(false),
             };
             let _ = reply.send(result);
-        }
-        InProcessCommand::Dirty { reply } => {
-            sync_terminal_modes_and_wake(runtime, observation, wake);
-            let _ = reply.send(observation.dirty());
         }
         InProcessCommand::MarkObserved { generation, reply } => {
             let _ = reply.send(observation.mark_observed(generation));
@@ -2311,6 +2375,8 @@ fn create_in_process_session(provider: &CleatProvider, desc: CleatSessionDesc) -
     let initial_geometry = TerminalGeometry::from_cell_size(cols, rows, desc.cell_width_px, desc.cell_height_px);
     let (cell_width_px, cell_height_px) = geometry_cell_size_to_backend(initial_geometry);
     let wake = provider.wake.clone();
+    let observation = Arc::new(ObservationMirror::new());
+    let actor_observation = observation.clone();
     let (tx, rx) = mpsc::channel();
     let (ready_tx, ready_rx) = mpsc::channel();
     let worker = thread::spawn(move || {
@@ -2322,14 +2388,14 @@ fn create_in_process_session(provider: &CleatProvider, desc: CleatSessionDesc) -
             Ok(runtime)
         })();
         match result {
-            Ok(runtime) => in_process_actor_loop(runtime, wake, rows, ready_tx, rx),
+            Ok(runtime) => in_process_actor_loop(runtime, wake, rows, actor_observation, ready_tx, rx),
             Err(err) => {
                 let _ = ready_tx.send(Err(err));
             }
         }
     });
     match ready_rx.recv().map_err(|_| "in-process session actor did not report startup".to_string())? {
-        Ok(()) => Ok(InProcessSession { tx, worker: Some(worker) }),
+        Ok(()) => Ok(InProcessSession { tx, observation, worker: Some(worker) }),
         Err(err) => {
             let _ = worker.join();
             Err(err)
@@ -3005,6 +3071,58 @@ mod tests {
 
             cleat_session_destroy(session);
             cleat_provider_close(provider);
+        }
+    }
+
+    #[test]
+    fn in_process_dirty_queries_do_not_wait_for_actor_replies() {
+        let (tx, _rx) = mpsc::channel::<InProcessCommand>();
+        let observation = Arc::new(ObservationMirror::new());
+        observation.store(1, 0, DirtyState::Full);
+        let session = Box::into_raw(Box::new(CleatSession {
+            backend: SessionBackend::InProcess(Box::new(InProcessSession { tx, observation, worker: None })),
+            geometry: TerminalGeometry::default(),
+            next_input_sequence: 1,
+            wake: Arc::new(Mutex::new(WakeCallback::default())),
+            last_snapshot: None,
+            last_render_update: None,
+        }));
+
+        let session_addr = session as usize;
+        let (done_tx, done_rx) = mpsc::channel();
+        std::thread::spawn(move || unsafe {
+            let dirty = cleat_session_dirty(session_addr as *const CleatSession);
+            let poll = cleat_session_poll(session_addr as *mut CleatSession);
+            let _ = done_tx.send((dirty, poll));
+        });
+        let result = done_rx.recv_timeout(Duration::from_millis(100)).expect("dirty queries blocked waiting for actor replies");
+        assert_eq!(result, (CleatDirtyState::Full, CleatDirtyState::Full));
+
+        unsafe {
+            cleat_session_destroy(session);
+        }
+    }
+
+    #[test]
+    fn in_process_dirty_queries_read_clean_mirror_state() {
+        let (tx, _rx) = mpsc::channel::<InProcessCommand>();
+        let observation = Arc::new(ObservationMirror::new());
+        observation.store(1, 1, DirtyState::Full);
+        let session = Box::into_raw(Box::new(CleatSession {
+            backend: SessionBackend::InProcess(Box::new(InProcessSession { tx, observation, worker: None })),
+            geometry: TerminalGeometry::default(),
+            next_input_sequence: 1,
+            wake: Arc::new(Mutex::new(WakeCallback::default())),
+            last_snapshot: None,
+            last_render_update: None,
+        }));
+
+        unsafe {
+            let dirty = cleat_session_dirty(session);
+            let poll = cleat_session_poll(session);
+            assert_eq!((dirty, poll), (CleatDirtyState::Clean, CleatDirtyState::Clean));
+
+            cleat_session_destroy(session);
         }
     }
 

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -730,7 +730,10 @@ fn dirty_state_from_u8(value: u8) -> DirtyState {
     match value {
         1 => DirtyState::Partial,
         2 => DirtyState::Full,
-        _ => DirtyState::Clean,
+        _ => {
+            debug_assert_eq!(value, 0, "unexpected DirtyState byte");
+            DirtyState::Clean
+        }
     }
 }
 
@@ -3121,6 +3124,29 @@ mod tests {
             let dirty = cleat_session_dirty(session);
             let poll = cleat_session_poll(session);
             assert_eq!((dirty, poll), (CleatDirtyState::Clean, CleatDirtyState::Clean));
+
+            cleat_session_destroy(session);
+        }
+    }
+
+    #[test]
+    fn in_process_dirty_queries_read_partial_mirror_state() {
+        let (tx, _rx) = mpsc::channel::<InProcessCommand>();
+        let observation = Arc::new(ObservationMirror::new());
+        observation.store(2, 1, DirtyState::Partial);
+        let session = Box::into_raw(Box::new(CleatSession {
+            backend: SessionBackend::InProcess(Box::new(InProcessSession { tx, observation, worker: None })),
+            geometry: TerminalGeometry::default(),
+            next_input_sequence: 1,
+            wake: Arc::new(Mutex::new(WakeCallback::default())),
+            last_snapshot: None,
+            last_render_update: None,
+        }));
+
+        unsafe {
+            let dirty = cleat_session_dirty(session);
+            let poll = cleat_session_poll(session);
+            assert_eq!((dirty, poll), (CleatDirtyState::Partial, CleatDirtyState::Partial));
 
             cleat_session_destroy(session);
         }


### PR DESCRIPTION
## Summary

- Mirror in-process observation state into atomics owned by `InProcessSession`.
- Make `cleat_session_dirty` and `cleat_session_poll` read that mirror directly instead of synchronously round-tripping through the actor.
- Remove the in-process `Dirty` actor command and add regression tests for nonblocking dirty reads.
- Include `CONTEXT.md` glossary additions for placement, ensure session, and session handle terminology.

## Root Cause

The in-process provider contract says dirty-state queries return already-known state and do not pump or wait on provider IO. The implementation still sent `InProcessCommand::Dirty` to the actor and blocked on the reply. That made UI frame construction vulnerable to actor latency or actor work such as terminal-mode sync.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo build -p cleat --locked --features ghostty-vt`
- `cargo test -p cleat --locked --features ghostty-vt provider_ffi -- --nocapture`
- `cargo test -p cleat --locked --features ghostty-vt`

Note: one initial full Ghostty feature run hit a transient timeout in `session_runtime::tests::recreation_seeds_scrollback_from_prior_recording`; the exact test passed on rerun, and the full Ghostty feature suite passed on the next full run.