### PR TITLE
[codex] launch --size sets initial geometry

### DIFF
--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use crate::{
     keys::encode_send_keys,
     protocol::{WaitCondition, WaitStatus},
-    runtime::SessionMetadata,
+    runtime::{SessionMetadata, TerminalSize},
     server::{EndBound, FallbackReason, SessionService, StartBound},
     vt::{Rgb, TerminalColors, VtEngineKind},
 };
@@ -113,6 +113,8 @@ pub enum Command {
         id: Option<String>,
         #[arg(long, help = "Output as JSON")]
         json: bool,
+        #[arg(long, value_name = "COLSxROWS", value_parser = parse_terminal_size, help = "Initial terminal size, e.g. 120x40")]
+        size: Option<TerminalSize>,
         #[arg(long, value_enum, help = crate::vt::VT_ENGINE_HELP)]
         vt: Option<VtEngineKind>,
         #[arg(long, help = "Working directory for the session")]
@@ -374,6 +376,8 @@ resolved through the live daemon socket. \n\
         cmd: Option<String>,
         #[arg(long)]
         cwd: Option<PathBuf>,
+        #[arg(long, value_name = "COLSxROWS", value_parser = parse_terminal_size)]
+        size: Option<TerminalSize>,
         // Internal: the daemon spawner passes the already-resolved value as a
         // presence flag, so there is no default-on / env handling here.
         #[arg(long)]
@@ -457,14 +461,14 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 Err(e) => ExecResult::Err(e),
             }
         }
-        Command::Launch { id, json, vt, cwd, cmd, record } => {
+        Command::Launch { id, json, size, vt, cwd, cmd, record } => {
             // Windows can provide basic sessions through ConPTY plus the
             // passthrough engine while Ghostty VT support is still optional.
             #[cfg(not(windows))]
             if !crate::vt::functional_vt_available() {
                 return ExecResult::Err(crate::vt::nonfunctional_build_error());
             }
-            let created = match service.create(id, vt, cwd, cmd, record.enabled()) {
+            let created = match service.create_with_size(id, vt, cwd, cmd, record.enabled(), size.unwrap_or_default()) {
                 Ok(v) => v,
                 Err(e) => return ExecResult::Err(e),
             };
@@ -684,13 +688,14 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
         Command::Expect { id, text, since, since_marker, timeout, json } => {
             execute_expect(service, id, text, since, since_marker, timeout, json)
         }
-        Command::Serve { id, vt, cmd, cwd, record, color_foreground, color_background, color_cursor } => {
+        Command::Serve { id, vt, cmd, cwd, size, record, color_foreground, color_background, color_cursor } => {
             let session = SessionMetadata {
                 id,
                 vt_engine: vt,
                 cwd,
                 cmd,
                 record,
+                initial_size: size.unwrap_or_default(),
                 colors: TerminalColors {
                     default_foreground: color_foreground,
                     default_background: color_background,
@@ -908,6 +913,17 @@ fn parse_rgb(value: &str) -> Result<Rgb, String> {
     let g = u8::from_str_radix(&value[2..4], 16).map_err(|err| format!("parse green channel: {err}"))?;
     let b = u8::from_str_radix(&value[4..6], 16).map_err(|err| format!("parse blue channel: {err}"))?;
     Ok(Rgb { r, g, b })
+}
+
+fn parse_terminal_size(value: &str) -> Result<TerminalSize, String> {
+    let (cols, rows) =
+        value.split_once('x').or_else(|| value.split_once('X')).ok_or_else(|| "size must be formatted as COLSxROWS".to_string())?;
+    let cols = cols.parse::<u16>().map_err(|_| "columns must be a positive integer up to 65535".to_string())?;
+    let rows = rows.parse::<u16>().map_err(|_| "rows must be a positive integer up to 65535".to_string())?;
+    if cols == 0 || rows == 0 {
+        return Err("size dimensions must be greater than zero".to_string());
+    }
+    Ok(TerminalSize { cols, rows })
 }
 
 fn parse_repeat(value: &str) -> Result<usize, String> {

--- a/crates/cleat/src/platform/daemon.rs
+++ b/crates/cleat/src/platform/daemon.rs
@@ -22,6 +22,7 @@ pub fn spawn_daemon_process(root: &Path, session: &SessionMetadata) -> Result<()
     let exe = resolve_cleat_executable()?;
     let mut command = Command::new(exe);
     command.arg("--runtime-root").arg(root).arg("serve").arg("--id").arg(&session.id).arg("--vt").arg(session.vt_engine.as_str());
+    command.arg("--size").arg(session.initial_size.to_string());
     if let Some(cmd) = &session.cmd {
         command.arg("--cmd").arg(cmd);
     }

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -45,7 +45,7 @@ pub struct PtyChild {
 impl PtyChild {
     pub fn spawn(session: &SessionMetadata) -> Result<Self, String> {
         let pipes = Pipes::new()?;
-        let conpty = create_pseudo_console(80, 24, pipes.input_read, pipes.output_write)?;
+        let conpty = create_pseudo_console(session.initial_size.cols, session.initial_size.rows, pipes.input_read, pipes.output_write)?;
         let process = spawn_with_conpty(&windows_shell_command(session), conpty, session.cwd.as_ref())?;
         unsafe {
             CloseHandle(pipes.input_read);
@@ -391,7 +391,10 @@ fn last_error(operation: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{quote_windows_arg, windows_shell_command};
-    use crate::{runtime::SessionMetadata, vt::VtEngineKind};
+    use crate::{
+        runtime::{SessionMetadata, TerminalSize},
+        vt::VtEngineKind,
+    };
 
     #[test]
     fn quotes_empty_argument() {
@@ -424,6 +427,7 @@ mod tests {
             cwd: None,
             cmd: Some("echo ready".into()),
             record: false,
+            initial_size: TerminalSize::default(),
             colors: crate::vt::TerminalColors::default(),
         };
 

--- a/crates/cleat/src/platform/unix.rs
+++ b/crates/cleat/src/platform/unix.rs
@@ -9,7 +9,7 @@ use nix::{
     errno::Errno,
     fcntl::{fcntl, FcntlArg, OFlag},
     poll::{poll, PollFd, PollFlags, PollTimeout},
-    pty::{forkpty, ForkptyResult},
+    pty::{forkpty, ForkptyResult, Winsize},
     sys::{
         signal::{killpg, Signal},
         wait::{waitpid, WaitPidFlag, WaitStatus},
@@ -32,8 +32,9 @@ pub struct PtyChild {
 
 impl PtyChild {
     pub fn spawn(session: &SessionMetadata) -> Result<Self, String> {
+        let winsize = Winsize { ws_row: session.initial_size.rows, ws_col: session.initial_size.cols, ws_xpixel: 0, ws_ypixel: 0 };
         // SAFETY: `forkpty` creates a child attached to a new PTY; parent receives the owned master fd.
-        let result = unsafe { forkpty(None, None) }.map_err(|err| format!("forkpty failed: {err}"))?;
+        let result = unsafe { forkpty(&winsize, None) }.map_err(|err| format!("forkpty failed: {err}"))?;
         match result {
             ForkptyResult::Parent { master, child } => Ok(Self { master_fd: master.into_raw_fd(), pid: child }),
             ForkptyResult::Child => {

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -23,8 +23,8 @@ use crate::{
         TerminalScrollbackExtent, TerminalScrollbarState, TerminalSnapshot, TerminalStyleColor, TerminalStyleColorTag,
         TerminalViewportKind, ViewportCommand, ViewportCommandOutcome, TERMINAL_IMAGE_PLACEMENT_VIRTUAL,
     },
-    runtime::RuntimeLayout,
-    session::{ensure_session_started, session_socket_path},
+    runtime::{RuntimeLayout, TerminalSize},
+    session::{ensure_session_started, session_socket_path, SessionStartOptions},
     session_runtime::{PtyOutput, SessionRuntime},
     vt::{self, Rgb, TerminalColors, VtEngineKind},
 };
@@ -2372,9 +2372,10 @@ fn create_in_process_session(provider: &CleatProvider, desc: CleatSessionDesc) -
     let id = read_optional_utf8(desc.id, desc.id_len).map_err(|err| format!("id is not valid UTF-8: {err}"))?;
     let mut metadata = layout.create_session(id, vt_engine, cwd, cmd)?;
     metadata.record = desc.record;
-    let session_dir = layout.root().join(&metadata.id);
     let cols = desc.cols.max(1);
     let rows = desc.rows.max(1);
+    metadata.initial_size = TerminalSize { cols, rows };
+    let session_dir = layout.root().join(&metadata.id);
     let initial_geometry = TerminalGeometry::from_cell_size(cols, rows, desc.cell_width_px, desc.cell_height_px);
     let (cell_width_px, cell_height_px) = geometry_cell_size_to_backend(initial_geometry);
     let wake = provider.wake.clone();
@@ -2413,14 +2414,16 @@ fn create_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Re
     let cmd = read_optional_utf8(desc.command, desc.command_len).map_err(|err| format!("command is not valid UTF-8: {err}"))?;
     let cwd = read_optional_utf8(desc.cwd, desc.cwd_len).map_err(|err| format!("cwd is not valid UTF-8: {err}"))?.map(PathBuf::from);
     let id = read_optional_utf8(desc.id, desc.id_len).map_err(|err| format!("id is not valid UTF-8: {err}"))?;
-    let metadata = ensure_session_started(&layout, id, Some(vt_engine), cwd, cmd, desc.record, colors)?;
-    let mut session = DaemonSession {
-        id: metadata.id,
-        runtime_root: provider.runtime_root.clone(),
-        rows: desc.rows.max(1),
-        observation: ObservationState::new(desc.rows.max(1)),
-    };
-    daemon_resize(&mut session, desc.cols.max(1), desc.rows.max(1))?;
+    let cols = desc.cols.max(1);
+    let rows = desc.rows.max(1);
+    let metadata = ensure_session_started(&layout, id, Some(vt_engine), cwd, cmd, SessionStartOptions {
+        record: desc.record,
+        initial_size: TerminalSize { cols, rows },
+        colors,
+    })?;
+    let mut session =
+        DaemonSession { id: metadata.id, runtime_root: provider.runtime_root.clone(), rows, observation: ObservationState::new(rows) };
+    daemon_resize(&mut session, cols, rows)?;
     Ok(session)
 }
 

--- a/crates/cleat/src/runtime.rs
+++ b/crates/cleat/src/runtime.rs
@@ -1,5 +1,5 @@
 use std::{
-    env, fs,
+    env, fmt, fs,
     path::{Path, PathBuf},
 };
 
@@ -8,6 +8,26 @@ use uuid::Uuid;
 use crate::vt::{TerminalColors, VtEngineKind};
 
 const SESSION_ROOT_DIR: &str = "cleat";
+pub const DEFAULT_TERMINAL_COLS: u16 = 80;
+pub const DEFAULT_TERMINAL_ROWS: u16 = 24;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerminalSize {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+impl Default for TerminalSize {
+    fn default() -> Self {
+        Self { cols: DEFAULT_TERMINAL_COLS, rows: DEFAULT_TERMINAL_ROWS }
+    }
+}
+
+impl fmt::Display for TerminalSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}x{}", self.cols, self.rows)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionMetadata {
@@ -16,6 +36,7 @@ pub struct SessionMetadata {
     pub cwd: Option<PathBuf>,
     pub cmd: Option<String>,
     pub record: bool,
+    pub initial_size: TerminalSize,
     pub colors: TerminalColors,
 }
 
@@ -60,7 +81,15 @@ impl RuntimeLayout {
         let id = id.unwrap_or_else(|| format!("session-{}", Uuid::new_v4()));
         let dir = self.root.join(&id);
         fs::create_dir_all(&dir).map_err(|err| format!("create session dir {}: {err}", dir.display()))?;
-        Ok(SessionMetadata { id, vt_engine, cwd, cmd, record: false, colors: TerminalColors::default() })
+        Ok(SessionMetadata {
+            id,
+            vt_engine,
+            cwd,
+            cmd,
+            record: false,
+            initial_size: TerminalSize::default(),
+            colors: TerminalColors::default(),
+        })
     }
 
     pub fn remove_session(&self, id: &str) -> Result<(), String> {

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -14,8 +14,8 @@ use crate::{
         ipc::{set_stream_read_timeout, try_connect_session_stream, SessionStream},
     },
     protocol::{SessionInfo, SessionStatus},
-    runtime::RuntimeLayout,
-    session::{attach_foreground, ensure_session_started, run_session_daemon, session_socket_path, ForegroundAttach},
+    runtime::{RuntimeLayout, TerminalSize},
+    session::{attach_foreground, ensure_session_started, run_session_daemon, session_socket_path, ForegroundAttach, SessionStartOptions},
     vt::VtEngineKind,
 };
 
@@ -81,7 +81,23 @@ impl SessionService {
         cmd: Option<String>,
         record: bool,
     ) -> Result<SessionInfo, String> {
-        let session = ensure_session_started(&self.layout, name, vt_engine, cwd, cmd, record, crate::vt::TerminalColors::default())?;
+        self.create_with_size(name, vt_engine, cwd, cmd, record, TerminalSize::default())
+    }
+
+    pub fn create_with_size(
+        &self,
+        name: Option<String>,
+        vt_engine: Option<VtEngineKind>,
+        cwd: Option<std::path::PathBuf>,
+        cmd: Option<String>,
+        record: bool,
+        initial_size: TerminalSize,
+    ) -> Result<SessionInfo, String> {
+        let session = ensure_session_started(&self.layout, name, vt_engine, cwd, cmd, SessionStartOptions {
+            record,
+            initial_size,
+            colors: crate::vt::TerminalColors::default(),
+        })?;
         // If the daemon was already running, get real config via inspect.
         if let Ok(result) = self.inspect(&session.id) {
             return Ok(session_info_from_inspect(result, SessionStatus::Detached));
@@ -321,9 +337,17 @@ impl SessionService {
                 return Err(format!("session {id} has a stale daemon (cleaned up)"));
             }
             let vt_engine = vt_engine.unwrap_or_else(crate::vt::default_vt_engine_kind);
-            crate::runtime::SessionMetadata { id, vt_engine, cwd, cmd, record: false, colors: crate::vt::TerminalColors::default() }
+            crate::runtime::SessionMetadata {
+                id,
+                vt_engine,
+                cwd,
+                cmd,
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: crate::vt::TerminalColors::default(),
+            }
         } else {
-            ensure_session_started(&self.layout, name, vt_engine, cwd, cmd, false, crate::vt::TerminalColors::default())?
+            ensure_session_started(&self.layout, name, vt_engine, cwd, cmd, SessionStartOptions::default())?
         };
         // Get real config from the daemon before attaching (which takes the foreground slot).
         let info = if let Ok(result) = self.inspect(&session.id) {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -27,14 +27,12 @@ use crate::{
         terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
     protocol::Frame,
-    runtime::{RuntimeLayout, SessionMetadata},
+    runtime::{RuntimeLayout, SessionMetadata, TerminalSize},
     session_runtime::SessionRuntime,
     vt::{self, ScreenGrid, VtEngine, VtEngineKind},
 };
 
 const FOREGROUND_NAME: &str = "foreground";
-const DEFAULT_TERMINAL_COLS: u16 = 80;
-const DEFAULT_TERMINAL_ROWS: u16 = 24;
 const DETACH_CLEANUP_SEQUENCE: &[u8] =
     b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[<u\x1b[r\x1b[0m\x1b[?25h\x1b[2J\x1b[H\x1b[?1049l";
 const REATTACH_CLEAR_SEQUENCE: &[u8] = b"\x1b[2J\x1b[H";
@@ -44,6 +42,13 @@ const TERMINATE_SIGNAL: i32 = 15;
 #[derive(Debug)]
 pub struct ForegroundAttach {
     stream: Arc<Mutex<SessionStream>>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SessionStartOptions {
+    pub record: bool,
+    pub initial_size: TerminalSize,
+    pub colors: vt::TerminalColors,
 }
 
 impl ForegroundAttach {
@@ -223,8 +228,7 @@ pub fn ensure_session_started(
     vt_engine: Option<VtEngineKind>,
     cwd: Option<PathBuf>,
     cmd: Option<String>,
-    record: bool,
-    colors: vt::TerminalColors,
+    options: SessionStartOptions,
 ) -> Result<SessionMetadata, String> {
     // If a named session directory already exists with a live socket, reuse it.
     if let Some(ref id_str) = id {
@@ -234,7 +238,15 @@ pub fn ensure_session_started(
                 // Daemon is running — return the id. The caller should use inspect()
                 // if it needs the session's actual config.
                 let vt_engine = vt_engine.unwrap_or_else(vt::default_vt_engine_kind);
-                return Ok(SessionMetadata { id: id_str.clone(), vt_engine, cwd, cmd, record, colors });
+                return Ok(SessionMetadata {
+                    id: id_str.clone(),
+                    vt_engine,
+                    cwd,
+                    cmd,
+                    record: options.record,
+                    initial_size: options.initial_size,
+                    colors: options.colors,
+                });
             }
             // Stale socket from a crashed daemon. Remove it so the respawned daemon
             // binds cleanly and wait_for_socket waits for the new listener rather
@@ -257,8 +269,9 @@ pub fn ensure_session_started(
     let vt_engine = vt_engine.unwrap_or_else(vt::default_vt_engine_kind);
     vt_engine.ensure_available()?;
     let mut session = layout.create_session(id, vt_engine, cwd, cmd)?;
-    session.record = record;
-    session.colors = colors;
+    session.record = options.record;
+    session.initial_size = options.initial_size;
+    session.colors = options.colors;
 
     let socket_path = session_socket_path(layout.root(), &session.id);
     spawn_daemon_process(layout.root(), &session)?;
@@ -309,15 +322,15 @@ pub fn foreground_path(root: &Path, id: &str) -> PathBuf {
 fn default_vt_engine(session: &SessionMetadata) -> Result<Box<dyn VtEngine>, String> {
     #[cfg(test)]
     if session.vt_engine == VtEngineKind::Ghostty {
-        return Ok(Box::new(TestReplayProbeVtEngine::new(DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS)));
+        return Ok(Box::new(TestReplayProbeVtEngine::new(session.initial_size.cols, session.initial_size.rows)));
     }
 
     if std::env::var_os("CARGO_BIN_EXE_cleat").is_some()
         && std::env::var_os("CLEAT_TEST_VT_ENGINE").as_deref() == Some(std::ffi::OsStr::new("replay-probe"))
     {
-        return Ok(Box::new(TestReplayProbeVtEngine::new(DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS)));
+        return Ok(Box::new(TestReplayProbeVtEngine::new(session.initial_size.cols, session.initial_size.rows)));
     }
-    vt::make_vt_engine_with_colors(session.vt_engine, DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS, session.colors)
+    vt::make_vt_engine_with_colors(session.vt_engine, session.initial_size.cols, session.initial_size.rows, session.colors)
 }
 
 #[derive(Debug)]
@@ -1125,7 +1138,7 @@ mod tests {
     };
     use crate::{
         http_uds::read_http_request_for_test,
-        runtime::{RuntimeLayout, SessionMetadata},
+        runtime::{RuntimeLayout, SessionMetadata, TerminalSize},
         vt::{self, VtEngine},
     };
 
@@ -1226,10 +1239,11 @@ mod tests {
             cwd: None,
             cmd: None,
             record: false,
+            initial_size: TerminalSize::default(),
             colors: vt::TerminalColors::default(),
         };
         let engine = default_vt_engine(&session).expect("create default vt engine");
-        assert_eq!(engine.size(), (super::DEFAULT_TERMINAL_COLS, super::DEFAULT_TERMINAL_ROWS));
+        assert_eq!(engine.size(), (crate::runtime::DEFAULT_TERMINAL_COLS, crate::runtime::DEFAULT_TERMINAL_ROWS));
         #[cfg(feature = "ghostty-vt")]
         assert!(engine.supports_replay());
         #[cfg(not(feature = "ghostty-vt"))]
@@ -1248,9 +1262,11 @@ mod tests {
             cwd: None,
             cmd: None,
             record: false,
+            initial_size: TerminalSize { cols: 120, rows: 40 },
             colors: vt::TerminalColors::default(),
         };
         let mut engine = default_vt_engine(&session).expect("create default vt engine");
+        assert_eq!(engine.size(), (120, 40));
         record_pty_output(engine.as_mut(), b"hello").expect("feed output");
         let replay =
             apply_attach_state(engine.as_mut(), 132, 40, &vt::ClientCapabilities::conservative_fallback()).expect("apply attach state");

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -534,6 +534,7 @@ mod tests {
             cwd: None,
             cmd: Some("true".to_string()),
             record: true,
+            initial_size: crate::runtime::TerminalSize::default(),
             colors: crate::vt::TerminalColors::default(),
         };
 
@@ -573,6 +574,7 @@ mod tests {
             cwd: None,
             cmd: Some("sh -c 'printf RECREATE_MARKER; sleep 30'".to_string()),
             record: true,
+            initial_size: crate::runtime::TerminalSize::default(),
             colors,
         };
         let engine1 = crate::vt::make_vt_engine_with_colors(VtEngineKind::Ghostty, 80, 24, colors).expect("engine 1");

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -1,7 +1,7 @@
 use clap::{CommandFactory, Parser};
 use cleat::{
     cli::{self, execute, Cli, Command, ExecResult, RecordFlags},
-    runtime::RuntimeLayout,
+    runtime::{RuntimeLayout, TerminalSize},
     server::SessionService,
     vt::{self, Rgb, VtEngineKind},
 };
@@ -96,6 +96,7 @@ fn launch_command_parses() {
     assert_eq!(cli.command, Command::Launch {
         id: None,
         json: false,
+        size: None,
         vt: None,
         cwd: None,
         cmd: Some("bash".into()),
@@ -104,11 +105,31 @@ fn launch_command_parses() {
 }
 
 #[test]
+fn launch_command_parses_size() {
+    let cli = Cli::try_parse_from(["cleat", "launch", "demo", "--size", "120x40"]).expect("launch --size parses");
+    assert!(matches!(
+        cli.command,
+        Command::Launch {
+            id: Some(ref id),
+            size: Some(TerminalSize { cols: 120, rows: 40 }),
+            ..
+        } if id == "demo"
+    ));
+}
+
+#[test]
+fn launch_command_rejects_invalid_size() {
+    assert!(Cli::try_parse_from(["cleat", "launch", "demo", "--size", "120"]).is_err());
+    assert!(Cli::try_parse_from(["cleat", "launch", "demo", "--size", "0x40"]).is_err());
+}
+
+#[test]
 fn launch_command_parses_positional_name() {
     let cli = Cli::try_parse_from(["cleat", "launch", "demo", "--cmd", "bash"]).expect("launch positional parses");
     assert_eq!(cli.command, Command::Launch {
         id: Some("demo".into()),
         json: false,
+        size: None,
         vt: None,
         cwd: None,
         cmd: Some("bash".into()),
@@ -122,6 +143,7 @@ fn launch_command_parses_json() {
     assert_eq!(cli.command, Command::Launch {
         id: Some("demo".into()),
         json: true,
+        size: None,
         vt: None,
         cwd: None,
         cmd: None,
@@ -135,6 +157,7 @@ fn launch_command_parses_vt() {
     assert_eq!(cli.command, Command::Launch {
         id: Some("demo".into()),
         json: false,
+        size: None,
         vt: Some(VtEngineKind::Ghostty),
         cwd: None,
         cmd: None,
@@ -148,6 +171,7 @@ fn create_alias_still_parses_as_launch() {
     assert_eq!(cli.command, Command::Launch {
         id: None,
         json: false,
+        size: None,
         vt: None,
         cwd: None,
         cmd: Some("bash".into()),
@@ -328,6 +352,8 @@ fn serve_parses_all_flags() {
         "bash",
         "--cwd",
         "/tmp",
+        "--size",
+        "132x43",
         "--record",
         "--color-foreground",
         "123456",
@@ -341,6 +367,7 @@ fn serve_parses_all_flags() {
         cli.command,
         Command::Serve {
             ref id,
+            size: Some(TerminalSize { cols: 132, rows: 43 }),
             record: true,
             color_foreground: Some(Rgb { r: 0x12, g: 0x34, b: 0x56 }),
             color_background: Some(Rgb { r: 0xab, g: 0xcd, b: 0xef }),

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -22,7 +22,7 @@ use cleat::{
         CleatProviderDesc, CleatSessionDesc, CLEAT_PROVIDER_ABI_VERSION, CLEAT_PROVIDER_BACKEND_DAEMON, CLEAT_PROVIDER_VT_PASSTHROUGH,
     },
     recording::{SessionRecorder, CAST_FILE_NAME},
-    runtime::RuntimeLayout,
+    runtime::{RuntimeLayout, TerminalSize},
     server::{EndBound, SessionService, StartBound},
     session::{daemon_pid_path, session_socket_path},
     vt::{self, ClientCapabilities, ColorLevel, VtEngineKind},
@@ -1104,6 +1104,38 @@ fn inspect_returns_structured_session_state() {
     assert_eq!(result.terminal.cols, 80);
     assert_eq!(result.terminal.rows, 24);
     assert!(!result.recording.active);
+
+    service.kill(&info.id).expect("kill session");
+}
+
+#[test]
+fn create_with_size_sets_initial_terminal_geometry() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let info = service
+        .create_with_size(Some("sized".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false, TerminalSize {
+            cols: 120,
+            rows: 40,
+        })
+        .expect("create session");
+
+    let socket_path = session_socket_path(temp.path(), &info.id);
+    wait_for_socket(&socket_path);
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let result = loop {
+        match service.inspect(&info.id) {
+            Ok(result) => break result,
+            Err(_) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(err) => panic!("inspect sized session: {err}"),
+        }
+    };
+
+    assert_eq!(result.terminal.cols, 120);
+    assert_eq!(result.terminal.rows, 40);
 
     service.kill(&info.id).expect("kill session");
 }


### PR DESCRIPTION
## What changed

Adds `cleat launch --size COLSxROWS` and forwards the same value through the hidden `serve` daemon path so detached sessions can start with a caller-specified terminal grid.

The requested size is stored in `SessionMetadata`, used when constructing the initial VT engine, and passed into Unix `forkpty` / Windows `CreatePseudoConsole` so headless sessions do not begin at the hardcoded 80x24 default.

## Why

Fixes #79. Headless control-plane sessions never receive a foreground controller attach, so TUIs were running indefinitely at 80x24 unless something later resized them.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`