### PR TITLE
docs: multi-client, never-hang, and M:N daemon design session

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,13 +34,54 @@ session's recording directory. There is no separate ephemeral handle.
 _Avoid_: name (a human-friendly display alias is a deferred nicety, not a second
 identity).
 
+**Host** (hosting):
+A process that owns the VT + PTY for one *or more* sessions, running each session's
+runtime actor. The two hostings below are the same host shape differing only in
+whether it carries the UI and a socket; a session can move between them by Transfer.
+Per-session faults are contained inside a host (a panicking VT engine unwinds its
+own session without killing siblings; the PTY fd survives in-process).
+
 **Embedded** (hosting):
-The session's VT runs inside the client's own process (e.g. uishell). Lowest
-latency; ends with the client unless the session is recovered from its recording.
+A host running inside the client's own process (e.g. uishell), which may hold many
+sessions. Lowest latency; a session ends with the client unless recovered from its
+recording.
 
 **Daemon** (hosting):
-The session's VT and PTY run in a separate cleat process; clients reach it over a
-socket. Survives client restarts.
+A standalone host process — an embedded host minus the UI, reachable over a socket.
+Owns one *or more* sessions and **outlives any single session** (lifetime is no
+longer pinned to one child process). Survives client restarts.
+_Avoid_: "one daemon per session" (the historical 1:1 model; a daemon now hosts a
+set of sessions).
+
+Daemons are **named** (default: `default`); the socket derives from the name. A
+daemon auto-starts on first use of its name and, when it hosts no sessions, lingers
+for a grace period before exiting (kills the empty-teardown race without leaving a
+resident process forever). A daemon is an **isolation boundary** — analogous to a
+k8s namespace: separate project checkouts, an agent loop's process backing, test
+scratch space. It is *not* an organizational grouping mechanism.
+
+**Tag**:
+A flat label on a session, used to organize and select sessions *within* a daemon —
+analogous to k8s labels inside a namespace. A session may carry many tags; clients
+select subsets by tag. Tags are the answer to grouping; daemons are the answer to
+isolation.
+_Avoid_: hierarchical groups / paths (a hierarchy forces each session into exactly
+one grouping; sessions legitimately belong to several).
+
+**Directory**:
+The live set of sessions a daemon hosts, with their metadata (tags, liveness,
+control state, recreatability). Frontend-relevant state like any other: a
+multi-pane client **subscribes** to it (optionally through a tag selector) and
+receives the current set plus pushed changes; a one-shot listing is a single read
+of the same state, never a separate polling mechanism. A session's address is
+`(daemon, id)` — unqualified means the default daemon; tag selectors select *sets*,
+never address a single session.
+
+**Client connection shapes**: a multi-pane client (e.g. uishell) holds one
+multiplexed connection to a daemon carrying the directory subscription and its
+session streams; single-session tools (`cleat attach`, `cleat watch`, one-shot CLI
+commands) keep their simple per-session surface. Both are first-class; the
+single-session shape is not collapsed into the multiplexed one.
 
 **Attach**:
 A client resuming a session that already exists — the program is still running,
@@ -58,6 +99,75 @@ A client's live reference to a session returned by Ensure Session. Multiple
 clients may hold handles to the same session; the handle is not the session's
 identity and does not determine where the session is hosted.
 _Avoid_: session id, attach.
+
+**Update Packet**:
+The single self-contained, serializable unit by which a session surfaces its
+current state to a client: cell/cursor deltas, scrollback extent, images and
+placements, and every frontend-relevant scalar (modes, title, cwd, palette,
+selection). It is the *one* attach transport — the same unit whether it crosses a
+thread, a socket, or an ssh tunnel. There is no separate "raw byte-stream" attach;
+a thin client that paints to a dumb terminal is just the simplest renderer of this
+stream.
+_Avoid_: frame, render frame (a packet is state, not a video frame), side-channel
+query (frontend-relevant state rides the packet, never a query).
+
+**Capability-complete packet**:
+The Update Packet carries everything the VT engine knows at full fidelity. Each
+client **downsamples** the packet to what its own renderer can express, so a weak
+host terminal never limits what a richer client attached to the same session can
+render. Client capability is therefore a one-way client-side concern, not a
+negotiation.
+_Avoid_: capability negotiation (it is downsampling, not negotiation).
+
+**Capability policy** (what the child sees):
+What the session advertises *to the PTY child* in answer to its capability queries
+(DA/DSR/kitty/XTGETTCAP/…) is not fixed:
+- **Default**: the engine answers with full (ghostty) capabilities.
+- **Passthrough**: the child's queries pass through to the real attached terminal,
+  so a recording faithfully reproduces what the program does in that emulator (e.g.
+  xterm). This is the capability-policy sense of "passthrough" — distinct from the
+  test-only placeholder VT engine of the same name. Passthrough binds to the
+  **primary controller** (below); with no controller it falls back to the default.
+
+**Controller**:
+An attachment allowed to drive the session — its input reaches the PTY. A session
+may have more than one; interference between concurrent controllers is the
+controllers' own responsibility, not cleat's.
+
+**Watcher**:
+An attachment that consumes the Update Packet read-only. It renders the session
+but its input does not reach the PTY. The basis for "you are not in control"
+indication.
+
+**Primary controller**:
+The first-attached controller. The query target for Passthrough capability policy.
+The primary is the *query target*, which is independent of which controller's input
+is currently reaching the PTY.
+
+**Grid geometry** (what size the child sees):
+The PTY grid is one `(rows, cols)` the child lays out to. Who decides it:
+- **Control-driven** (default): the grid is sized by control. With one controller
+  the grid is that controller's size; with concurrent co-controllers (deferred) it
+  is the **intersection** (min rows, min cols) of the controllers' sizes, so every
+  driver can see and type into every cell.
+- **Watchers never vote.** A watcher reconciles its own window against the grid
+  client-side from the full grid in the Update Packet — letterbox/center if larger,
+  pan a viewport or show a "too small" indicator if smaller.
+- **Pinned** (optional): an explicit fixed geometry set at launch or by resize;
+  overrides control, so the child never reflows just because someone attached.
+  Intended for headless/agent sessions that want a deterministic layout.
+Taking control resizes the grid to the new controller (unless pinned).
+_Avoid_: "smallest client wins" across *all* attachments — a watcher must never
+shrink the grid the controller is driving.
+
+**Take control**:
+A watcher promoting itself to controller. In the first cut a session has at most
+one controller, so taking control is a **forced handoff**: the requester becomes
+controller and the previous controller is **demoted to watcher** (not detached),
+which it learns from its own control state. Concurrent co-controllers are a
+deferred extension; until then, interference is impossible because control is
+exclusive. Control state (own role, who holds control) rides the Update Packet
+like any other frontend-relevant state — never a side-channel query.
 
 **Recording**:
 The append-only log of a session's output (asciicast v3), optionally with VT

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -130,9 +130,10 @@ What the session advertises *to the PTY child* in answer to its capability queri
   **primary controller** (below); with no controller it falls back to the default.
 
 **Controller**:
-An attachment allowed to drive the session — its input reaches the PTY. A session
-may have more than one; interference between concurrent controllers is the
-controllers' own responsibility, not cleat's.
+An attachment allowed to drive the session — its input reaches the PTY. In the
+first cut a session has at most one controller (see Take control); concurrent
+co-controllers are a **deferred** extension, and when they arrive, interference
+between them is the controllers' own responsibility, not cleat's.
 
 **Watcher**:
 An attachment that consumes the Update Packet read-only. It renders the session
@@ -140,9 +141,14 @@ but its input does not reach the PTY. The basis for "you are not in control"
 indication.
 
 **Primary controller**:
-The first-attached controller. The query target for Passthrough capability policy.
-The primary is the *query target*, which is independent of which controller's input
-is currently reaching the PTY.
+The first controller to attach in an activation. The query target for Passthrough
+capability policy, independent of which attachment's input is currently reaching
+the PTY. The designation is **sticky**: it does not move when control is taken —
+the demoted attachment remains the query target as a watcher, because Passthrough
+exists to give the child coherent capability answers from *one* emulator across
+the session (launch in xterm, drive from a remote attachment, xterm still answers
+queries), not from whoever currently drives. Only if the primary's attachment
+detaches entirely does Passthrough fall back to the default (engine) policy.
 
 **Grid geometry** (what size the child sees):
 The PTY grid is one `(rows, cols)` the child lays out to. Who decides it:
@@ -162,12 +168,15 @@ shrink the grid the controller is driving.
 
 **Take control**:
 A watcher promoting itself to controller. In the first cut a session has at most
-one controller, so taking control is a **forced handoff**: the requester becomes
-controller and the previous controller is **demoted to watcher** (not detached),
-which it learns from its own control state. Concurrent co-controllers are a
-deferred extension; until then, interference is impossible because control is
-exclusive. Control state (own role, who holds control) rides the Update Packet
+one controller, so taking control is a **forced reassignment**: the requester
+becomes controller and the previous controller is **demoted to watcher** (not
+detached), which it learns from its own control state. Concurrent co-controllers
+are a deferred extension; until then, interference is impossible because control
+is exclusive. Control state (own role, who holds control) rides the Update Packet
 like any other frontend-relevant state — never a side-channel query.
+_Avoid_: handoff (reserved as Transfer's alias — moving a session's PTY between
+hostings; taking control reassigns a *role between attachments* on the same
+hosting).
 
 **Recording**:
 The append-only log of a session's output (asciicast v3), optionally with VT

--- a/docs/adr/0004-daemon-hosts-a-set-of-sessions.md
+++ b/docs/adr/0004-daemon-hosts-a-set-of-sessions.md
@@ -1,0 +1,70 @@
+# A daemon hosts a set of sessions; isolation comes from named daemons, not one process per session
+
+Cleat began with an emphatic 1:1 model: **one daemon per session**, the daemon's
+lifetime pinned to its one child process, and the per-session socket file doubling
+as liveness indicator and discovery mechanism. This ADR retires that model.
+
+A [daemon](../../CONTEXT.md) is now a **host for a set of sessions** — structurally
+the same thing as the embedded uishell host (which already runs many sessions'
+runtime actors in one process), minus the UI and plus a socket. Daemons are
+**named** (default: `default`), auto-start on first use of their name, and when
+empty linger for a grace period before exiting. A daemon is an **isolation
+boundary** (a k8s-namespace analogue: separate project checkouts, an agent loop's
+process backing, test scratch space); flat **tags** on sessions handle grouping
+*within* a daemon. Session address is `(daemon, id)`, unqualified id meaning the
+default daemon.
+
+The pivotal realization: the codebase already trusts many-sessions-per-process —
+embedded uishell runs exactly that. Keeping the daemon 1:1 wasn't buying safety;
+it was a historical artifact of the daemon predating the shared host shape.
+
+## Considered options
+
+- **Keep 1:1 hosting, add a "hub" directory/router in front.** A client-facing
+  process that enumerates per-session daemons and fans their streams in, preserving
+  per-process crash isolation. Rejected: strictly more moving parts for a model we
+  already run in-process, and the isolation it preserves is largely illusory — the
+  VT engine is not assumed unstable, per-session faults can be contained with a
+  `catch_unwind` boundary around each session's work (the PTY fd survives in the
+  process, so a panicked session rebuilds rather than dies), and true process death
+  is already covered by recreation-from-recording (ADR 0001) with FD transfer as the
+  lossless upgrade path.
+- **One resident daemon, always running.** No teardown race, warm forever.
+  Rejected as the default: leaves an idle process behind and adds a step to "fully
+  reset cleat." The grace-period linger captures the benefit (no race between
+  last-session-exit and an incoming launch) without permanent residency.
+- **Exit immediately when empty (tmux-server-like).** Honest process table, but
+  "empty" is mushier for cleat than for tmux — a session with a recording remains
+  recreatable after its child dies, serial agent workloads would bounce the daemon
+  per session, and last-exit vs. incoming-launch is a genuine race. Rejected in
+  favor of the linger.
+- **Hierarchical session groups inside a daemon (attach-by-path).** Rejected: a
+  hierarchy forces each session into exactly one grouping; sessions legitimately
+  belong to several. Flat tags + selectors (the k8s labels move) compose; daemons
+  cover the case that actually needs a hard boundary.
+
+## Consequences
+
+- **Liveness and discovery reroute.** Today socket-per-session = liveness =
+  discovery via filesystem stat. With socket-per-daemon, session liveness and
+  enumeration become daemon queries; `list`, stale-cleanup,
+  `is_session_daemon_alive`, and kill fallbacks all move onto the daemon protocol.
+  This is the largest mechanical chunk of the change, and it depends on the
+  progress/servicing split (the daemon answering these queries must be the
+  never-blocked servicing side — see the provider threading spec).
+- **The directory is a subscription.** The daemon's session set + metadata is
+  frontend-relevant state: multi-pane clients subscribe (optionally via tag
+  selector) over one multiplexed connection that also carries their session
+  streams; `cleat list` is a one-shot read of the same state. The single-session
+  surfaces (`attach`, `watch`, one-shot CLI ops) remain first-class alongside —
+  the CLI is not collapsed into the uishell model.
+- **Blast radius is managed, not eliminated.** A daemon crash now takes down every
+  session it hosts. Mitigations, in order: per-session `catch_unwind` containment,
+  FD transfer for planned handoff/upgrade, recreation-from-recording as the
+  always-works floor (ADR 0001). Users who want hard isolation put sessions in
+  different named daemons — that is what daemon names are *for*.
+- **Auto-start needs bind-is-the-lock.** Two concurrent commands naming the same
+  daemon race to start it; first to bind the socket wins, the loser connects.
+- **Docs debt:** the README's "One daemon per session" section and the runtime
+  directory layout description are superseded and must be rewritten when this
+  lands.

--- a/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
+++ b/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
@@ -81,6 +81,19 @@ Check off as confirmed/refuted; surprises go in the friction log.
   distinct Enter; consider a `send --submit` that does text-as-paste + delayed
   Enter.
 
+- **2026-07-04 (run live, watcher report)** Watch initially "over drew" the
+  watcher's terminal: the watch handler sends the replay payload with no
+  clear+home first (the reattach path has `REATTACH_CLEAR_SEQUENCE`; watch skips
+  it), and the payload assumes a 200×50 canvas the watcher may not have. Cheap
+  scaffolding fix: always prepend clear+home for watchers. The real fix is the
+  packet-based watcher — a byte-tee paints someone else's escape stream into the
+  watcher's current screen state and can never own cursor/alt-screen/viewport
+  reconciliation. First concrete evidence for the Update Packet destination.
+- **2026-07-04 (run live, watcher report)** Prediction 1 counter-evidence: watch
+  is *not* perceptibly laggy while codex streams. The #78 staleness may be
+  conditional (controller-attach path? specific load shapes?) rather than
+  constant — matches the decision to instrument before fixing.
+
 ## Issues spawned
 
 *(label: `dogfood`)*

--- a/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
+++ b/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
@@ -1,0 +1,78 @@
+# Dogfood run: cleat hosts codex working on #78
+
+Cleat hosts the agent that fixes cleat's staleness bug
+([#78](https://github.com/flotilla-org/cleat/issues/78)). The driver (human or
+Claude) supervises through the control plane; a human terminal watches the TUI
+live once MVP watch lands.
+
+## Shape
+
+- One session per work item: `cleat launch codex-78 --record --size <cols>x<rows> --cmd "codex ..."`
+- Supervision without attaching: `capture`, `wait --idle-time`, `expect`,
+  `inspect` (foreground_pgid != leader_pgid = "codex is running something"),
+  `send` / `send-keys` for prompts.
+- Human check-ins: `cleat watch` (byte-tee MVP) from any terminal, incl. ssh.
+
+## Prep (blocking, in order)
+
+1. **`launch --size`** — initial grid geometry at launch. Blocking because at the
+   default 80×24 a modern TUI doesn't just look cramped, it *behaves* differently
+   (collapsed panels, different wrap points), which contaminates `expect` matching
+   and the recording. Distinct from *pinned* geometry (freeze), which is not
+   needed to start: nothing attaches as controller while driving via the control
+   plane.
+2. **Byte-tee MVP watch** — read-only attachments: replay payload on attach + the
+   same output chunks the controller gets; input frames dropped. Known wart,
+   accepted: a watcher terminal smaller than the session grid sees wrap artifacts
+   (no client-side letterbox until the Update Packet transport). Scaffolding;
+   will be replaced by the packet-based watcher.
+3. Smoke test: codex under the ghostty engine, detached — launch, wait, capture,
+   see a sane prompt.
+
+## Pre-registered predictions
+
+Check off as confirmed/refuted; surprises go in the friction log.
+
+- [ ] **#78 staleness** felt constantly on attach/watch with a chatty codex TUI
+  (macOS).
+- [ ] **Second-attach 409** hit the first time someone peeks while attached
+  elsewhere — measures the real value of watch/take-control. (Partially
+  pre-empted by prep item 2.)
+- [ ] **Dropped `CSI ? u` (kitty keyboard) queries while detached** cause codex to
+  behave differently detached vs attached — the README's known asymmetry biting a
+  real workload.
+- [ ] **Geometry churn**: reflow on each differently-sized attach is the first
+  annoyance felt; argues pinned geometry earlier than planned.
+- [ ] **`cleat list` across many codex sessions** is where the flat
+  one-daemon-per-session model hurts first — the concrete pull toward tags +
+  directory (ADR 0004 world).
+
+## Friction log
+
+*(append during the run: timestamp, what happened, what it implies)*
+
+- **2026-07-04** Prep 1 and 2 merged (#81 → `78cba35`, #82 → `ae135c6`, both
+  codex-authored). Reviewed: `--size` plumbs coherently to PTY winsize, VT engine
+  creation, ConPTY, and both provider FFI paths; watch matches the issue spec
+  (replay without resize, watcher input/resize ignored, drop-on-backlog,
+  inspect roles, list status counts controllers only). Verified live:
+  `launch --size 120x40` → `inspect` reports `terminal 120x40`; watcher receives
+  replay payload; `attachments: watcher` in inspect.
+- **2026-07-04** `wait --timeout 5s` rejected — timeout is a bare float (seconds),
+  while transcript's `--until-idle` accepts humane durations. Agents *will* type
+  `5s`. Small CLI inconsistency worth unifying.
+- **2026-07-04** `recreation_seeds_scrollback_from_prior_recording` is flaky under
+  parallel test load (times out spawning a real PTY; passes 3/3 in isolation).
+  Pre-existing, not a #81/#82 regression.
+- **2026-07-04** Byte-tee watch nits (acceptable scaffolding, all subsumed by the
+  progress/servicing split): watchers are not in the poll fd set, so disconnect
+  and backlog detection ride the ≤100 ms tick; the watch upgrade handler can
+  attempt to write an HTTP 500 onto an already-upgraded stream on enqueue error;
+  `--size` on an already-running session id is silently ignored (reuse path).
+
+## Issues spawned
+
+*(label: `dogfood`)*
+
+- [#79](https://github.com/flotilla-org/cleat/issues/79) — `launch --size` (prep 1)
+- [#80](https://github.com/flotilla-org/cleat/issues/80) — `cleat watch` byte-tee MVP (prep 2)

--- a/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
+++ b/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
@@ -94,6 +94,16 @@ Check off as confirmed/refuted; surprises go in the friction log.
   conditional (controller-attach path? specific load shapes?) rather than
   constant — matches the decision to instrument before fixing.
 
+- **2026-07-04 (run live)** `wait --idle-time` is defeated by TUI spinners: codex
+  redraws its "Working (Nm Ns)" timer every second, so PTY output never goes
+  quiet and a 45 s idle monitor sat blind for 40 minutes *through an approval
+  prompt*. Also `inspect`'s `foreground_pgid != leader_pgid` signal is useless
+  for TUI agents (the TUI is always the foreground process). Workaround today:
+  `wait --text "Press enter to confirm" --idle-time 60` (OR semantics) to catch
+  approval prompts by text. Real need: a "screen stable" / semantic-prompt wait
+  condition -- the VT engine already has row-level dirty tracking and ghostty
+  exposes semantic prompt state per row, so both are buildable.
+
 ## Issues spawned
 
 *(label: `dogfood`)*

--- a/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
+++ b/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
@@ -70,6 +70,17 @@ Check off as confirmed/refuted; surprises go in the friction log.
   attempt to write an HTTP 500 onto an already-upgraded stream on enqueue error;
   `--size` on an already-running session id is silently ignored (reuse path).
 
+- **2026-07-04 (run live)** Codex TUI renders cleanly detached under the ghostty
+  engine at 200×50; recording active; human watching via `cleat watch` while the
+  driver supervises through the control plane. The multi-client shape works.
+- **2026-07-04 (run live)** `cleat send codex-78 "<task>"` left the text sitting
+  in codex's composer unsubmitted — the trailing Enter was swallowed (likely
+  codex's paste heuristic treating fast text+newline as one paste). A separate
+  `send-keys codex-78 Enter` submitted it. Driving modern TUI composers needs
+  either a delay between text and Enter or a paste-encoded send followed by a
+  distinct Enter; consider a `send --submit` that does text-as-paste + delayed
+  Enter.
+
 ## Issues spawned
 
 *(label: `dogfood`)*

--- a/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
+++ b/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
@@ -104,9 +104,25 @@ Check off as confirmed/refuted; surprises go in the friction log.
   condition -- the VT engine already has row-level dirty tracking and ghostty
   exposes semantic prompt state per row, so both are buildable.
 
+- **2026-07-04 (run complete)** Codex finished #78: instrumented first as asked,
+  **could not reproduce a Darwin poll() miss** (burst, paced, and
+  watcher-attached workloads) — prediction/hypothesis 1 unconfirmed. Landed the
+  kqueue/epoll readiness primitive anyway (the split needs it) as PR #88, honest
+  commit message, all four validation gates green on macOS. #78 stays open; the
+  staleness may live in the attach path or a load shape not reproduced.
+- **2026-07-04 (run complete)** Driving-codex friction summary: composer swallows
+  fast text+Enter (use send --no-enter, pause, send-keys Enter); TUI spinner
+  defeats wait --idle-time (use wait --text on the approval-prompt string, OR'd
+  with idle); worktrees don't share .tools so agents try to rebuild ghostty
+  (point CLEAT_GHOSTTY_PREFIX at the main checkout); codex sandbox blocks UDS
+  binds in tests (needs an unsandboxed approval). All workable today; the first
+  two argue for a send --submit flag and a screen-stable/semantic-prompt wait
+  condition.
+
 ## Issues spawned
 
 *(label: `dogfood`)*
 
 - [#79](https://github.com/flotilla-org/cleat/issues/79) — `launch --size` (prep 1)
 - [#80](https://github.com/flotilla-org/cleat/issues/80) — `cleat watch` byte-tee MVP (prep 2)
+- [#88](https://github.com/flotilla-org/cleat/pull/88) — kqueue/epoll readiness (the run's output; #78 stays open)

--- a/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
+++ b/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
@@ -126,3 +126,5 @@ Check off as confirmed/refuted; surprises go in the friction log.
 - [#79](https://github.com/flotilla-org/cleat/issues/79) — `launch --size` (prep 1)
 - [#80](https://github.com/flotilla-org/cleat/issues/80) — `cleat watch` byte-tee MVP (prep 2)
 - [#88](https://github.com/flotilla-org/cleat/pull/88) — kqueue/epoll readiness (the run's output; #78 stays open)
+- [#89](https://github.com/flotilla-org/cleat/issues/89) — `send --submit` (composer swallows fast text+Enter)
+- [#90](https://github.com/flotilla-org/cleat/issues/90) — `wait --screen-stable` / `--at-prompt` (spinners defeat idle)

--- a/docs/specs/2026-06-06-provider-threading-progress.md
+++ b/docs/specs/2026-06-06-provider-threading-progress.md
@@ -72,6 +72,37 @@ wake subscription. Until that exists, daemon-backed embeddings should treat wake
 as a local provider notification facility, not a complete cross-process event
 stream.
 
+### Daemon Progress And Servicing Split (direction)
+
+The in-process provider already separates progress from rendering via a per-session
+runtime actor. The daemon must reach the same invariant: **terminal progress is
+never blocked by client rendering or by control-plane servicing.** Today's daemon
+is a single event loop (`run_session_daemon`) where PTY read + VT feed, connection
+accept, control-request handling, and client output flushing all run on one thread.
+That fuses progress with servicing, so a slow control connection or an expensive
+`feed()` (e.g. image decode) delays delivery of up-to-date screen state to every
+client.
+
+The direction:
+
+- A dedicated **VT-feed owner** (thread/actor) owns PTY read, VT feed, and the
+  dirty generation. It is never blocked by connection or client I/O.
+- **Connection and control servicing move off** the feed path (thread-per-connection
+  or a non-blocking request state machine), so a client that dribbles a partial
+  request cannot stall feed. (The accepted-stream blocking read with a 100 ms
+  timeout in the current inline handler is exactly the stall to remove.)
+- The feed owner needs a **reliable readiness primitive on the PTY master**. `poll()`
+  on a PTY device is unreliable on macOS/Darwin; the owner should use the platform
+  edge/readiness mechanism (kqueue/epoll) rather than `poll()` so readability is not
+  capped at the idle tick. This is also the leading hypothesis for observed
+  "attach updates only after a long delay" latency and is tracked as its own bug.
+- A **dirty/wake subscription** crosses the socket so structured clients are pushed
+  updates (the generation model above, now cross-process) instead of polling. This
+  also serves multiple attached clients fanning in from one feed.
+
+This decouples the daemon's PTY host role from its client-facing role, which is the
+same separation the M:N hub direction relies on.
+
 ## Target Model
 
 The intended provider contract is:


### PR DESCRIPTION
Design-session output covering three roadmap areas: multiple attached clients per session, the never-hang survey of the daemon loop, and the M:N daemon↔session model.

## What's in here

- **CONTEXT.md** — new domain language: Update Packet as the single attach transport (thin terminal clients are just its simplest renderer); capability-complete packets with client-side downsampling; capability policy toward the child (engine-full default vs **passthrough** bound to the primary controller); **controller / watcher / take control** roles (single controller with forced handoff first, co-controllers deferred); grid geometry rules (control-driven, intersection across co-controllers, watchers never vote, optional pinned); multi-session **Host/Daemon** (named, default `default`, grace-period linger when empty); **tags** for grouping vs daemons for isolation (k8s namespace/label analogy); **directory** as a subscription.
- **ADR 0004** — a daemon hosts a *set* of sessions; retires the 1:1 daemon-per-session model; isolation comes from named daemons, recovery from catch_unwind + FD transfer + recreation (ADR 0001 floor).
- **provider-threading spec** — daemon progress/servicing split direction: dedicated VT-feed owner, off-loop connection servicing, kqueue/epoll PTY readiness (relates to #78), cross-socket dirty/wake push.
- **docs/dogfood/** — first dogfood run doc: cleat hosts codex working on #78, with pre-registered predictions and a friction log already seeded from the #79/#81 and #80/#82 review.

Refs #78 #79 #80, builds on #81 #82.