### PR TITLE
dogfood: shepherding-phase closing note

### DIFF
--- a/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
+++ b/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
@@ -119,6 +119,18 @@ Check off as confirmed/refuted; surprises go in the friction log.
   two argue for a send --submit flag and a screen-stable/semantic-prompt wait
   condition.
 
+- **2026-07-04 (shepherding phase)** Codex shepherded its own PR #88 from inside
+  the cleat session ($pr-shepherd): investigated Linux CI failures it could not
+  reproduce locally and fixed **three real epoll bugs** (EINTR from SIGCHLD
+  interrupting epoll_wait, HUP/ERR misreported as PTY read readiness, client
+  writability semantics), de-flaked its own regression test, rode out an
+  unrelated Ghostty VT flake with a rerun, and reported merge-readiness without
+  merging. The review-loop pattern (bot review -> fix -> re-verify) also worked
+  on the docs PR #87: three real CONTEXT.md ambiguities found and resolved, with
+  one reviewer inference correctly pushed back on (sticky primary). Strongest
+  datapoint of the run: the full author->CI->review->merge-ready loop is
+  workable with the agent hosted in a cleat session.
+
 ## Issues spawned
 
 *(label: `dogfood`)*

--- a/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
+++ b/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
@@ -131,6 +131,15 @@ Check off as confirmed/refuted; surprises go in the friction log.
   datapoint of the run: the full author->CI->review->merge-ready loop is
   workable with the agent hosted in a cleat session.
 
+- **2026-07-04 (retirement)** `cleat kill codex-78` **deleted the active
+  recording** — the daemon preserved the session dir (recorder present) but
+  `SessionService::kill` unconditionally `remove_session`s it afterwards. The
+  full record of the run is gone; filed as #92. Also found ~30 empty
+  `session-<uuid>` husks and a crashed session dir (stale socket, no pid file)
+  that `list` reports as an error forever. Painful but exactly the kind of
+  lifecycle hole dogfooding exists to find: the run's most valuable artifact was
+  destroyed by the run's final command.
+
 ## Issues spawned
 
 *(label: `dogfood`)*
@@ -140,3 +149,4 @@ Check off as confirmed/refuted; surprises go in the friction log.
 - [#88](https://github.com/flotilla-org/cleat/pull/88) — kqueue/epoll readiness (the run's output; #78 stays open)
 - [#89](https://github.com/flotilla-org/cleat/issues/89) — `send --submit` (composer swallows fast text+Enter)
 - [#90](https://github.com/flotilla-org/cleat/issues/90) — `wait --screen-stable` / `--at-prompt` (spinners defeat idle)
+- [#92](https://github.com/flotilla-org/cleat/issues/92) — `kill` deletes active recordings (found at retirement; the run's recording is lost)

--- a/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
+++ b/docs/dogfood/2026-07-03-codex-hosts-issue-78.md
@@ -140,6 +140,20 @@ Check off as confirmed/refuted; surprises go in the friction log.
   lifecycle hole dogfooding exists to find: the run's most valuable artifact was
   destroyed by the run's final command.
 
+- **2026-07-04 (fleet phase)** Four codexes launched in parallel worktrees to fix
+  the run's own friction (#89 send --submit, #90 wait --screen-stable, #92 kill
+  preserves recordings, #93 test flake), ordered to de-sabotage first. Implementation
+  took 4-9 min each; every codex then self-shepherded its PR ($pr-shepherd) —
+  handling CI flake reruns, review pushback (tolerance defense on #95), and one
+  network-approval loop. All four merged (#94-#97) with zero rebase conflicts.
+  Biggest catch: #93's "flake" was a real **fork-safety bug** — exec_child
+  allocated after forkpty from a multithreaded parent (deadlock risk for embedded
+  hosts, not just tests); found because the deadline bump failed on its own PR's
+  CI. Retirement validated #96 in anger: all four recordings (85 MB) survived
+  kill. Remaining friction: monitors still need per-TUI prompt strings until
+  --screen-stable is in the driving binary; pr-shepherd.py re-flags addressed bot
+  comments (plugin-repo issue, not cleat).
+
 ## Issues spawned
 
 *(label: `dogfood`)*
@@ -149,4 +163,5 @@ Check off as confirmed/refuted; surprises go in the friction log.
 - [#88](https://github.com/flotilla-org/cleat/pull/88) — kqueue/epoll readiness (the run's output; #78 stays open)
 - [#89](https://github.com/flotilla-org/cleat/issues/89) — `send --submit` (composer swallows fast text+Enter)
 - [#90](https://github.com/flotilla-org/cleat/issues/90) — `wait --screen-stable` / `--at-prompt` (spinners defeat idle)
+- [#93](https://github.com/flotilla-org/cleat/issues/93) + fleet PRs [#94](https://github.com/flotilla-org/cleat/pull/94) [#95](https://github.com/flotilla-org/cleat/pull/95) [#96](https://github.com/flotilla-org/cleat/pull/96) [#97](https://github.com/flotilla-org/cleat/pull/97) — all merged 2026-07-04
 - [#92](https://github.com/flotilla-org/cleat/issues/92) — `kill` deletes active recordings (found at retirement; the run's recording is lost)


### PR DESCRIPTION
Closes out the run log from #87 with the shepherding-phase datapoint: codex shepherded its own PR #88 from inside the cleat session, fixing three real Linux epoll bugs via CI it couldn't reproduce locally. One-file docs append.