### PR TITLE
[codex] wait --screen-stable: grid-level stability condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Three layers cooperate during a session. Knowing which layer is authoritative fo
 | `record`, `mark` | recording | Mutates recording state |
 | `wait --idle-time` | daemon | PTY-output idle timer |
 | `wait --text` | VT engine | Consults the rendered screen grid |
+| `wait --screen-stable` | VT engine | Waits for the rendered screen grid to stop changing |
 
 ### Queries and capabilities
 

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -311,8 +311,9 @@ resolved through the live daemon socket. \n\
     #[command(after_long_help = "Conditions (OR semantics — any match wins):\n\
                            \x20 --idle-time N  Wait until no PTY output for N seconds\n\
                            \x20 --text STR     Wait until STR appears on the VT screen\n\
+                           \x20 --screen-stable N  Wait until the rendered screen is stable for N\n\
                            \n\
-                           At least one of --idle-time or --text is required.\n\
+                           At least one condition is required.\n\
                            \n\
                            NOTE: --text matches against the current VT screen state. If the\n\
                            text is already visible when wait is called, it returns immediately.\n\
@@ -332,6 +333,9 @@ resolved through the live daemon socket. \n\
         idle_time: Option<std::time::Duration>,
         #[arg(long, help = "Wait until this text appears on screen")]
         text: Option<String>,
+        /// Wait until the rendered screen is stable for this duration (e.g., 500ms, 2s, or plain seconds).
+        #[arg(long, value_parser = crate::duration_parser::parse_humantime_or_seconds)]
+        screen_stable: Option<std::time::Duration>,
         #[arg(long, default_value_t = 30.0, help = "Maximum seconds to wait (default: 30)")]
         timeout: f64,
         #[arg(long, help = "Output as JSON")]
@@ -701,7 +705,9 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Ok(()) => ExecResult::Ok(None),
             Err(e) => ExecResult::Err(e),
         },
-        Command::Wait { id, idle_time, text, timeout, json } => execute_wait(service, id, idle_time, text, timeout, json),
+        Command::Wait { id, idle_time, text, screen_stable, timeout, json } => {
+            execute_wait(service, id, idle_time, text, screen_stable, timeout, json)
+        }
         Command::Expect { id, text, since, since_marker, timeout, json } => {
             execute_expect(service, id, text, since, since_marker, timeout, json)
         }
@@ -732,13 +738,14 @@ fn execute_wait(
     id: String,
     idle_time: Option<std::time::Duration>,
     text: Option<String>,
+    screen_stable: Option<std::time::Duration>,
     timeout: f64,
     json: bool,
 ) -> ExecResult {
-    if idle_time.is_none() && text.is_none() {
+    if idle_time.is_none() && text.is_none() && screen_stable.is_none() {
         return ExecResult::Exit {
             code: 2,
-            message: Some("wait requires at least one of --idle-time or --text".to_string()),
+            message: Some("wait requires at least one of --idle-time, --text, or --screen-stable".to_string()),
             output: None,
         };
     }
@@ -757,6 +764,13 @@ fn execute_wait(
     }
     if let Some(pattern) = text {
         conditions.push(WaitCondition::TextMatch { text: pattern });
+    }
+    if let Some(dur) = screen_stable {
+        let secs = dur.as_secs_f64();
+        if !(0.0..=86_400.0).contains(&secs) {
+            return ExecResult::Exit { code: 2, message: Some(format!("invalid screen-stable: {secs} (max 86400)")), output: None };
+        }
+        conditions.push(WaitCondition::ScreenStable { stable_ms: (secs * 1000.0) as u64 });
     }
     let timeout_ms = (timeout * 1000.0) as u64;
 

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -311,7 +311,7 @@ resolved through the live daemon socket. \n\
     #[command(after_long_help = "Conditions (OR semantics — any match wins):\n\
                            \x20 --idle-time N  Wait until no PTY output for N seconds\n\
                            \x20 --text STR     Wait until STR appears on the VT screen\n\
-                           \x20 --screen-stable N  Wait until the rendered screen is stable for N\n\
+                           \x20 --screen-stable N  Wait until the rendered screen is stable for N (e.g., 500ms, 2s)\n\
                            \n\
                            At least one condition is required.\n\
                            \n\

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -155,6 +155,7 @@ pub(crate) struct WaitRequest {
 pub(crate) enum WaitConditionRequest {
     OutputIdle { quiet_ms: u64 },
     TextMatch { text: String },
+    ScreenStable { stable_ms: u64 },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -92,6 +92,7 @@ const TAG_ERROR: u8 = 9;
 pub enum WaitCondition {
     OutputIdle { quiet_ms: u64 },
     TextMatch { text: String },
+    ScreenStable { stable_ms: u64 },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -615,6 +615,7 @@ fn wait_condition_to_http(condition: crate::protocol::WaitCondition) -> http_uds
     match condition {
         crate::protocol::WaitCondition::OutputIdle { quiet_ms } => http_uds::WaitConditionRequest::OutputIdle { quiet_ms },
         crate::protocol::WaitCondition::TextMatch { text } => http_uds::WaitConditionRequest::TextMatch { text },
+        crate::protocol::WaitCondition::ScreenStable { stable_ms } => http_uds::WaitConditionRequest::ScreenStable { stable_ms },
     }
 }
 
@@ -793,13 +794,20 @@ mod tests {
                 .expect("write response");
         });
 
-        let result = service.wait("alpha", vec![WaitCondition::OutputIdle { quiet_ms: 250 }], 5000).expect("wait");
+        let result = service
+            .wait("alpha", vec![WaitCondition::OutputIdle { quiet_ms: 250 }, WaitCondition::ScreenStable { stable_ms: 750 }], 5000)
+            .expect("wait");
         let request = rx.recv_timeout(Duration::from_secs(1)).expect("receive request");
 
         reader.join().expect("join reader");
         assert_eq!(result, (WaitStatus::Ready, 42));
         assert!(request.starts_with("POST /sessions/alpha/wait HTTP/1.1\r\n"), "{request}");
-        assert!(request.ends_with(r#"{"conditions":[{"kind":"output_idle","quiet_ms":250}],"timeout_ms":5000}"#), "{request}");
+        assert!(
+            request.ends_with(
+                r#"{"conditions":[{"kind":"output_idle","quiet_ms":250},{"kind":"screen_stable","stable_ms":750}],"timeout_ms":5000}"#
+            ),
+            "{request}"
+        );
     }
 
     #[test]

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -38,6 +38,7 @@ const DETACH_CLEANUP_SEQUENCE: &[u8] =
 const REATTACH_CLEAR_SEQUENCE: &[u8] = b"\x1b[2J\x1b[H";
 const MAX_PENDING_CLIENT_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 const TERMINATE_SIGNAL: i32 = 15;
+const SCREEN_STABLE_CHANGED_CELL_TOLERANCE: usize = 16;
 
 #[derive(Debug)]
 pub struct ForegroundAttach {
@@ -433,8 +434,62 @@ fn apply_attach_state(
 struct PendingWait {
     stream: SessionStream,
     conditions: Vec<crate::protocol::WaitCondition>,
+    screen_stable: Option<ScreenStableState>,
     timeout_ms: u64,
     registered_at: Instant,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct ScreenStableFingerprint {
+    cols: u16,
+    rows: u16,
+    viewport_kind: crate::provider::TerminalViewportKind,
+    scrollback_offset_rows: u64,
+    cells: Vec<crate::provider::TerminalCell>,
+}
+
+impl ScreenStableFingerprint {
+    fn from_snapshot(snapshot: crate::provider::TerminalSnapshot) -> Self {
+        Self {
+            cols: snapshot.cols,
+            rows: snapshot.rows,
+            viewport_kind: snapshot.viewport_kind,
+            scrollback_offset_rows: snapshot.scrollback_offset_rows,
+            cells: snapshot.cells,
+        }
+    }
+
+    fn significant_change_from(&self, other: &Self) -> bool {
+        if self.cols != other.cols
+            || self.rows != other.rows
+            || self.viewport_kind != other.viewport_kind
+            || self.scrollback_offset_rows != other.scrollback_offset_rows
+            || self.cells.len() != other.cells.len()
+        {
+            return true;
+        }
+
+        self.cells.iter().zip(&other.cells).filter(|(left, right)| left != right).count() > SCREEN_STABLE_CHANGED_CELL_TOLERANCE
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ScreenStableState {
+    fingerprint: ScreenStableFingerprint,
+    stable_since: Instant,
+}
+
+impl ScreenStableState {
+    fn new(fingerprint: ScreenStableFingerprint, stable_since: Instant) -> Self {
+        Self { fingerprint, stable_since }
+    }
+
+    fn observe(&mut self, fingerprint: ScreenStableFingerprint, observed_at: Instant) {
+        if self.fingerprint.significant_change_from(&fingerprint) {
+            self.fingerprint = fingerprint;
+            self.stable_since = observed_at;
+        }
+    }
 }
 
 struct PendingExpect {
@@ -609,6 +664,12 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
 
         // Evaluate pending waits on each loop tick.
         // Write errors are intentionally discarded — the client may have disconnected.
+        let screen_stable_fingerprint = if pending_waits.iter().any(|wait| wait.screen_stable.is_some()) {
+            runtime.snapshot(crate::provider::DirtyState::Full).ok().map(ScreenStableFingerprint::from_snapshot)
+        } else {
+            None
+        };
+        let now = Instant::now();
         pending_waits.retain_mut(|wait| {
             let elapsed = wait.registered_at.elapsed();
             let elapsed_ms = elapsed.as_millis() as u64;
@@ -617,6 +678,10 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
             if elapsed_ms >= wait.timeout_ms {
                 let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Timeout, elapsed_ms);
                 return false;
+            }
+
+            if let (Some(state), Some(fingerprint)) = (wait.screen_stable.as_mut(), screen_stable_fingerprint.as_ref()) {
+                state.observe(fingerprint.clone(), now);
             }
 
             // Check conditions (OR semantics — any match wins)
@@ -638,6 +703,15 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                         if runtime.screen_contains(text.as_str()) {
                             let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
                             return false;
+                        }
+                    }
+                    crate::protocol::WaitCondition::ScreenStable { stable_ms } => {
+                        if let Some(state) = wait.screen_stable.as_ref() {
+                            let stable_duration_ms = state.stable_since.elapsed().as_millis() as u64;
+                            if stable_duration_ms >= *stable_ms {
+                                let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
+                                return false;
+                            }
                         }
                     }
                 }
@@ -961,6 +1035,8 @@ fn handle_http_request(
             }
 
             let has_text_match = conditions.iter().any(|condition| matches!(condition, crate::protocol::WaitCondition::TextMatch { .. }));
+            let has_screen_stable =
+                conditions.iter().any(|condition| matches!(condition, crate::protocol::WaitCondition::ScreenStable { .. }));
             if has_text_match {
                 if let Err(err) = state.runtime.validate_text_matching() {
                     http_uds::write_error(stream, StatusCode::CONFLICT, &format!("text matching not supported: {err}"))
@@ -968,6 +1044,19 @@ fn handle_http_request(
                     break 'wait Ok(());
                 }
             }
+            let registered_at = Instant::now();
+            let screen_stable = if has_screen_stable {
+                match state.runtime.snapshot(crate::provider::DirtyState::Full) {
+                    Ok(snapshot) => Some(ScreenStableState::new(ScreenStableFingerprint::from_snapshot(snapshot), registered_at)),
+                    Err(err) => {
+                        http_uds::write_error(stream, StatusCode::CONFLICT, &format!("screen stability not supported: {err}"))
+                            .map_err(|err| format!("write HTTP wait error: {err}"))?;
+                        break 'wait Ok(());
+                    }
+                }
+            } else {
+                None
+            };
 
             if has_text_match {
                 for condition in &conditions {
@@ -993,8 +1082,9 @@ fn handle_http_request(
             state.pending_waits.push(PendingWait {
                 stream: pending_stream,
                 conditions,
+                screen_stable,
                 timeout_ms: body.timeout_ms,
-                registered_at: Instant::now(),
+                registered_at,
             });
             Ok(())
         }
@@ -1016,6 +1106,7 @@ fn wait_condition_from_http(condition: http_uds::WaitConditionRequest) -> crate:
     match condition {
         http_uds::WaitConditionRequest::OutputIdle { quiet_ms } => crate::protocol::WaitCondition::OutputIdle { quiet_ms },
         http_uds::WaitConditionRequest::TextMatch { text } => crate::protocol::WaitCondition::TextMatch { text },
+        http_uds::WaitConditionRequest::ScreenStable { stable_ms } => crate::protocol::WaitCondition::ScreenStable { stable_ms },
     }
 }
 
@@ -1173,11 +1264,14 @@ fn wait_for_socket(path: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::{
+        sync::{Arc, Mutex},
+        time::{Duration, Instant},
+    };
 
     use super::{
         apply_attach_state, attach_foreground, attach_init_capabilities, default_vt_engine, record_pty_output, session_socket_path,
-        AttachCleanupGuard, TestReplayProbeVtEngine,
+        AttachCleanupGuard, ScreenStableFingerprint, ScreenStableState, TestReplayProbeVtEngine, SCREEN_STABLE_CHANGED_CELL_TOLERANCE,
     };
     use crate::{
         http_uds::read_http_request_for_test,
@@ -1324,6 +1418,61 @@ mod tests {
     #[test]
     fn lifecycle_attach_init_capabilities_use_conservative_terminal_assumptions() {
         assert_eq!(attach_init_capabilities(), vt::ClientCapabilities::conservative_fallback());
+    }
+
+    fn screen_stable_fingerprint_with_cells(cell_count: usize, changed_prefix: usize) -> ScreenStableFingerprint {
+        let cells = (0..cell_count)
+            .map(|index| crate::provider::TerminalCell {
+                graphemes: vec![if index < changed_prefix { 'x' as u32 } else { 'a' as u32 }],
+                ..crate::provider::TerminalCell::default()
+            })
+            .collect();
+        ScreenStableFingerprint {
+            cols: cell_count as u16,
+            rows: 1,
+            viewport_kind: crate::provider::TerminalViewportKind::LiveNormal,
+            scrollback_offset_rows: 0,
+            cells,
+        }
+    }
+
+    #[test]
+    fn screen_stable_tolerates_small_rendered_cell_churn() {
+        let baseline = screen_stable_fingerprint_with_cells(80, 0);
+        let spinner_tick = screen_stable_fingerprint_with_cells(80, SCREEN_STABLE_CHANGED_CELL_TOLERANCE);
+
+        assert!(!baseline.significant_change_from(&spinner_tick));
+    }
+
+    #[test]
+    fn screen_stable_resets_on_large_rendered_cell_change() {
+        let baseline = screen_stable_fingerprint_with_cells(80, 0);
+        let changed = screen_stable_fingerprint_with_cells(80, SCREEN_STABLE_CHANGED_CELL_TOLERANCE + 1);
+
+        assert!(baseline.significant_change_from(&changed));
+    }
+
+    #[test]
+    fn screen_stable_resets_on_geometry_change() {
+        let baseline = screen_stable_fingerprint_with_cells(80, 0);
+        let mut resized = baseline.clone();
+        resized.cols = 40;
+
+        assert!(baseline.significant_change_from(&resized));
+    }
+
+    #[test]
+    fn screen_stable_observe_only_resets_timestamp_for_significant_changes() {
+        let baseline = screen_stable_fingerprint_with_cells(80, 0);
+        let mut state = ScreenStableState::new(baseline, Instant::now());
+        let original_stable_since = state.stable_since;
+
+        state.observe(screen_stable_fingerprint_with_cells(80, 1), original_stable_since + Duration::from_millis(100));
+        assert_eq!(state.stable_since, original_stable_since);
+
+        let reset_at = original_stable_since + Duration::from_millis(200);
+        state.observe(screen_stable_fingerprint_with_cells(80, SCREEN_STABLE_CHANGED_CELL_TOLERANCE + 1), reset_at);
+        assert_eq!(state.stable_since, reset_at);
     }
 
     #[test]

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -607,10 +607,21 @@ fn wait_text_parses() {
 }
 
 #[test]
+fn wait_screen_stable_parses() {
+    let cli = Cli::try_parse_from(["cleat", "wait", "sess", "--screen-stable", "750ms"]).expect("parse");
+    assert!(matches!(
+        cli.command,
+        Command::Wait { screen_stable: Some(t), idle_time: None, text: None, .. } if t == std::time::Duration::from_millis(750)
+    ));
+}
+
+#[test]
 fn wait_combined_parses() {
-    let cli = Cli::try_parse_from(["cleat", "wait", "sess", "--idle-time", "1.0", "--text", "ready", "--timeout", "10"]).expect("parse");
+    let cli =
+        Cli::try_parse_from(["cleat", "wait", "sess", "--idle-time", "1.0", "--text", "ready", "--screen-stable", "2s", "--timeout", "10"])
+            .expect("parse");
     assert!(
-        matches!(cli.command, Command::Wait { idle_time: Some(_), text: Some(_), timeout, .. } if (timeout - 10.0).abs() < f64::EPSILON)
+        matches!(cli.command, Command::Wait { idle_time: Some(_), text: Some(_), screen_stable: Some(_), timeout, .. } if (timeout - 10.0).abs() < f64::EPSILON)
     );
 }
 
@@ -628,7 +639,7 @@ fn wait_execute_rejects_no_conditions() {
     let result = execute(cli, &service);
     match result {
         ExecResult::Exit { code: 2, message: Some(msg), .. } => {
-            assert!(msg.contains("at least one of --idle-time or --text"));
+            assert!(msg.contains("at least one of --idle-time, --text, or --screen-stable"));
         }
         other => panic!("wait without conditions should exit 2, got: {other:?}"),
     }

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -646,6 +646,21 @@ fn wait_execute_rejects_no_conditions() {
 }
 
 #[test]
+fn wait_execute_rejects_screen_stable_above_maximum() {
+    let temp = tempfile::tempdir().unwrap();
+    let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+    let cli = Cli::try_parse_from(["cleat", "wait", "sess", "--screen-stable", "86401s"]).expect("parse");
+    let result = execute(cli, &service);
+    match result {
+        ExecResult::Exit { code: 2, message: Some(msg), .. } => {
+            assert!(msg.contains("invalid screen-stable"));
+            assert!(msg.contains("max 86400"));
+        }
+        other => panic!("screen-stable above maximum should exit 2, got: {other:?}"),
+    }
+}
+
+#[test]
 fn wait_idle_time_accepts_humantime_and_seconds() {
     // Both forms parse to the same Duration.
     let humantime_form = Cli::try_parse_from(["cleat", "wait", "x", "--idle-time", "500ms"]).expect("humantime parse");


### PR DESCRIPTION
Fixes #90 (the `--screen-stable` MVP; `--at-prompt` deliberately not included — no Ghostty FFI changes, per issue scoping).

Fleet-dogfood output: one of four codex sessions hosted in cleat working friction issues in parallel (run log: `docs/dogfood/2026-07-03-codex-hosts-issue-78.md`).

## What

- `cleat wait --screen-stable <duration>`: satisfied when the **rendered grid** (not the byte stream) has been unchanged for the duration, with a small changed-cell tolerance so TUI spinner/timer redraws don't reset the stability clock. Composes with existing OR semantics (`--text`, `--idle-time`).
- Fingerprint = dims + viewport kind + scrollback offset + cells; resize/viewport changes are always significant.
- Tests at CLI parse, HTTP serialization, and daemon stability/tolerance layers.

## Motivation

Direct fix for the fleet-driving blindspot found in the dogfood run: codex's per-second "Working (Nm Ns)" redraw defeats `--idle-time`, and a 45 s idle monitor sat blind for 40 minutes through an approval prompt.

Validated: fmt, clippy `-D warnings`, workspace tests, ghostty-vt suite.