### PR TITLE
[codex] kill preserves recordings; --purge deletes; stale sweep claims husks

### DIFF
--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -229,7 +229,12 @@ resolved through the live daemon socket. \n\
     /// Detach from a session
     Detach { id: String },
     /// Terminate a session
-    Kill { id: String },
+    Kill {
+        #[arg(value_name = "ID")]
+        id: String,
+        #[arg(long, help = "Delete any preserved recording for the session")]
+        purge: bool,
+    },
     /// Send key sequences using tmux-style names
     #[command(
         after_long_help = "Key names: Enter, Escape (Esc), Tab, BSpace, Space,\n           Up, Down, Left, Right, Home, End,\n           PgUp (PageUp), PgDn (PageDown),\n           IC (Insert), DC (Delete),\n           F1-F12, BTab (Shift-Tab)\n\nModifiers:  C-x (Ctrl), M-x (Meta/Alt), S-x (Shift)\n            ^x  (Ctrl, alternative syntax)\n\nExamples:   cleat send-keys myapp Enter\n            cleat send-keys myapp C-c\n            cleat send-keys myapp -l 'literal text'\n            cleat send-keys myapp -H 1b5b41"
@@ -613,7 +618,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Ok(()) => ExecResult::Ok(None),
             Err(e) => ExecResult::Err(e),
         },
-        Command::Kill { id } => match service.kill(&id) {
+        Command::Kill { id, purge } => match service.kill_with_purge(&id, purge) {
             Ok(()) => ExecResult::Ok(None),
             Err(e) => ExecResult::Err(e),
         },

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -16,8 +16,8 @@ use crate::{
     protocol::{SessionInfo, SessionStatus},
     runtime::{RuntimeLayout, TerminalSize},
     session::{
-        attach_foreground, ensure_session_started, run_session_daemon, session_socket_path, watch_foreground, ForegroundAttach,
-        SessionStartOptions,
+        attach_foreground, ensure_session_started, foreground_path, run_session_daemon, session_socket_path, watch_foreground,
+        ForegroundAttach, SessionStartOptions,
     },
     vt::VtEngineKind,
 };
@@ -138,6 +138,16 @@ impl SessionService {
             };
             let socket_path = session_socket_path(self.layout.root(), &id);
             if !socket_path.exists() {
+                if session_dir_is_empty(&path) {
+                    let _ = self.layout.remove_session(&id);
+                }
+                continue;
+            }
+            if !daemon_pid_path(self.layout.root(), &id).exists()
+                && !crate::recreate::session_is_recreatable(&path)
+                && session_dir_contains_only(&path, &socket_path)
+            {
+                let _ = self.layout.remove_session(&id);
                 continue;
             }
             if !is_session_daemon_alive(self.layout.root(), &id) {
@@ -183,25 +193,51 @@ impl SessionService {
     }
 
     pub fn kill(&self, id: &str) -> Result<(), String> {
+        self.kill_with_purge(id, false)
+    }
+
+    pub fn kill_with_purge(&self, id: &str, purge: bool) -> Result<(), String> {
         if !self.layout.root().join(id).exists() {
             return Err(format!("missing session {id}"));
         }
         let pid_path = daemon_pid_path(self.layout.root(), id);
         if self.http_no_content(id, Method::DELETE, &format!("/sessions/{id}"), &()).is_ok() {
             if pid_path.exists() {
-                for _ in 0..50 {
-                    if !self.layout.root().join(id).exists() || !pid_path.exists() || !is_session_daemon_alive(self.layout.root(), id) {
-                        break;
-                    }
-                    thread::sleep(Duration::from_millis(20));
-                }
+                self.wait_for_session_shutdown(id);
             }
             if !self.layout.root().join(id).exists() {
                 return Ok(());
             }
         }
         terminate_session_daemon_if_expected(self.layout.root(), id);
-        self.layout.remove_session(id)
+        self.wait_for_session_shutdown(id);
+        if !self.layout.root().join(id).exists() {
+            return Ok(());
+        }
+        if purge || !crate::recreate::session_is_recreatable(&self.layout.root().join(id)) {
+            self.layout.remove_session(id)
+        } else {
+            self.remove_volatile_session_files(id);
+            Ok(())
+        }
+    }
+
+    fn wait_for_session_shutdown(&self, id: &str) {
+        for _ in 0..50 {
+            if !self.layout.root().join(id).exists()
+                || !daemon_pid_path(self.layout.root(), id).exists()
+                || !is_session_daemon_alive(self.layout.root(), id)
+            {
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    fn remove_volatile_session_files(&self, id: &str) {
+        let _ = std::fs::remove_file(session_socket_path(self.layout.root(), id));
+        let _ = std::fs::remove_file(daemon_pid_path(self.layout.root(), id));
+        let _ = std::fs::remove_file(foreground_path(self.layout.root(), id));
     }
 
     pub fn detach(&self, id: &str) -> Result<(), String> {
@@ -539,6 +575,27 @@ impl SessionService {
     }
 }
 
+fn session_dir_is_empty(path: &Path) -> bool {
+    std::fs::read_dir(path).map(|mut entries| entries.next().is_none()).unwrap_or(false)
+}
+
+fn session_dir_contains_only(path: &Path, expected: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return false;
+    };
+    let mut count = 0;
+    for entry in entries {
+        let Ok(entry) = entry else {
+            return false;
+        };
+        count += 1;
+        if entry.path() != expected {
+            return false;
+        }
+    }
+    count == 1
+}
+
 /// Resolve start and end bounds into byte offsets against a cast file without
 /// going through the daemon. Marker-based bounds are rejected; the CLI is
 /// expected to prevent these combinations via clap's `conflicts_with = "path"`
@@ -851,7 +908,7 @@ mod tests {
                 drop(stream);
             }
         });
-        // No PID file means is_session_daemon_alive returns true (assumes starting up).
+        fs::write(daemon_pid_path(temp.path(), "broken-session"), std::process::id().to_string()).expect("write pid");
 
         let sessions = service.list().expect("list sessions");
         assert_eq!(sessions.len(), 1, "broken session should appear in list");
@@ -877,6 +934,35 @@ mod tests {
         let sessions = service.list().expect("list sessions");
         assert!(sessions.is_empty(), "stale session should not appear in list");
         assert!(!session_dir.exists(), "stale session directory should be cleaned up");
+    }
+
+    #[test]
+    fn list_cleans_up_socket_only_session_without_pid_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+
+        let session_dir = temp.path().join("socket-only");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        let socket_path = session_socket_path(temp.path(), "socket-only");
+        let listener = UnixListener::bind(&socket_path).expect("bind socket");
+        drop(listener);
+
+        let sessions = service.list().expect("list sessions");
+        assert!(sessions.is_empty(), "socket-only husk should not appear in list");
+        assert!(!session_dir.exists(), "socket-only husk should be cleaned up");
+    }
+
+    #[test]
+    fn list_cleans_up_empty_session_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+
+        let session_dir = temp.path().join("empty-session");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+
+        let sessions = service.list().expect("list sessions");
+        assert!(sessions.is_empty(), "empty session dir should not appear in list");
+        assert!(!session_dir.exists(), "empty session dir should be cleaned up");
     }
 
     #[test]

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -146,6 +146,7 @@ impl SessionService {
             if !daemon_pid_path(self.layout.root(), &id).exists()
                 && !crate::recreate::session_is_recreatable(&path)
                 && session_dir_contains_only(&path, &socket_path)
+                && session_socket_is_stale(&socket_path)
             {
                 let _ = self.layout.remove_session(&id);
                 continue;
@@ -597,6 +598,10 @@ fn session_dir_contains_only(path: &Path, expected: &Path) -> bool {
     count == 1
 }
 
+fn session_socket_is_stale(socket_path: &Path) -> bool {
+    try_connect_session_stream(socket_path).is_err()
+}
+
 /// Resolve start and end bounds into byte offsets against a cast file without
 /// going through the daemon. Marker-based bounds are rejected; the CLI is
 /// expected to prevent these combinations via clap's `conflicts_with = "path"`
@@ -967,12 +972,38 @@ mod tests {
         let session_dir = temp.path().join("socket-only");
         fs::create_dir_all(&session_dir).expect("create session dir");
         let socket_path = session_socket_path(temp.path(), "socket-only");
-        let listener = UnixListener::bind(&socket_path).expect("bind socket");
-        drop(listener);
+        fs::write(&socket_path, b"stale socket placeholder").expect("write stale socket placeholder");
 
         let sessions = service.list().expect("list sessions");
         assert!(sessions.is_empty(), "socket-only husk should not appear in list");
         assert!(!session_dir.exists(), "socket-only husk should be cleaned up");
+    }
+
+    #[test]
+    fn list_preserves_socket_only_session_when_socket_is_connectable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+
+        let session_dir = temp.path().join("starting-session");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        let socket_path = session_socket_path(temp.path(), "starting-session");
+        let listener = UnixListener::bind(&socket_path).expect("bind socket");
+        let reader = thread::spawn(move || {
+            for _ in 0..2 {
+                let Ok((stream, _)) = listener.accept() else {
+                    break;
+                };
+                drop(stream);
+            }
+        });
+
+        let sessions = service.list().expect("list sessions");
+        assert_eq!(sessions.len(), 1, "connectable no-pid socket should be treated as starting");
+        assert_eq!(sessions[0].id, "starting-session");
+        assert!(sessions[0].error.is_some(), "inspect failure should be reported while preserving the directory");
+        assert!(session_dir.exists(), "connectable no-pid socket should not be cleaned up as a husk");
+
+        reader.join().expect("join reader");
     }
 
     #[test]

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -1,11 +1,13 @@
 use std::{
     path::Path,
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use http::{Method, StatusCode};
 use serde::de::DeserializeOwned;
+
+const EMPTY_SESSION_DIR_GRACE: Duration = Duration::from_secs(2);
 
 use crate::{
     http_uds,
@@ -138,7 +140,7 @@ impl SessionService {
             };
             let socket_path = session_socket_path(self.layout.root(), &id);
             if !socket_path.exists() {
-                if session_dir_is_empty(&path) {
+                if session_dir_is_stale_empty(&path, EMPTY_SESSION_DIR_GRACE) {
                     let _ = self.layout.remove_session(&id);
                 }
                 continue;
@@ -581,6 +583,17 @@ fn session_dir_is_empty(path: &Path) -> bool {
     std::fs::read_dir(path).map(|mut entries| entries.next().is_none()).unwrap_or(false)
 }
 
+fn session_dir_is_stale_empty(path: &Path, grace: Duration) -> bool {
+    if !session_dir_is_empty(path) {
+        return false;
+    }
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age >= grace)
+}
+
 fn session_dir_contains_only(path: &Path, expected: &Path) -> bool {
     let Ok(entries) = std::fs::read_dir(path) else {
         return false;
@@ -715,15 +728,17 @@ fn connect_session_socket(socket_path: &Path) -> Result<SessionStream, String> {
 #[cfg(all(test, unix))]
 mod tests {
     use std::{
+        ffi::CString,
         fs,
-        os::unix::net::UnixListener,
+        os::unix::{ffi::OsStrExt, net::UnixListener},
+        path::Path,
         process::Command,
         sync::mpsc,
         thread,
-        time::{Duration, Instant},
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
     };
 
-    use super::SessionService;
+    use super::{SessionService, EMPTY_SESSION_DIR_GRACE};
     use crate::{
         http_uds::read_http_request_for_test,
         protocol::{WaitCondition, WaitStatus},
@@ -1013,10 +1028,24 @@ mod tests {
 
         let session_dir = temp.path().join("empty-session");
         fs::create_dir_all(&session_dir).expect("create session dir");
+        set_mtime_ago(&session_dir, EMPTY_SESSION_DIR_GRACE + Duration::from_secs(1));
 
         let sessions = service.list().expect("list sessions");
         assert!(sessions.is_empty(), "empty session dir should not appear in list");
         assert!(!session_dir.exists(), "empty session dir should be cleaned up");
+    }
+
+    #[test]
+    fn list_preserves_young_empty_session_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+
+        let session_dir = temp.path().join("starting-empty-session");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+
+        let sessions = service.list().expect("list sessions");
+        assert!(sessions.is_empty(), "young empty session dir should not appear in list");
+        assert!(session_dir.exists(), "young empty session dir should be allowed to finish starting");
     }
 
     #[test]
@@ -1036,5 +1065,15 @@ mod tests {
         let sessions = service.list().expect("list sessions");
         assert!(sessions.is_empty(), "stale session should not appear in list");
         assert!(session_dir.exists(), "a recreatable session directory must survive the stale sweep");
+    }
+
+    fn set_mtime_ago(path: &Path, age: Duration) {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("system time after epoch");
+        let target = now.checked_sub(age).expect("age before now");
+        let timeval = libc::timeval { tv_sec: target.as_secs() as libc::time_t, tv_usec: target.subsec_micros() as libc::suseconds_t };
+        let times = [timeval, timeval];
+        let c_path = CString::new(path.as_os_str().as_bytes()).expect("path without nul");
+        let rc = unsafe { libc::utimes(c_path.as_ptr(), times.as_ptr()) };
+        assert_eq!(rc, 0, "set mtime for {}", path.display());
     }
 }

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -201,7 +201,8 @@ impl SessionService {
             return Err(format!("missing session {id}"));
         }
         let pid_path = daemon_pid_path(self.layout.root(), id);
-        if self.http_no_content(id, Method::DELETE, &format!("/sessions/{id}"), &()).is_ok() {
+        let socket_path = session_socket_path(self.layout.root(), id);
+        if socket_path.exists() && self.http_no_content(id, Method::DELETE, &format!("/sessions/{id}"), &()).is_ok() {
             if pid_path.exists() {
                 self.wait_for_session_shutdown(id);
             }
@@ -708,7 +709,14 @@ fn connect_session_socket(socket_path: &Path) -> Result<SessionStream, String> {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use std::{fs, os::unix::net::UnixListener, process::Command, sync::mpsc, thread, time::Duration};
+    use std::{
+        fs,
+        os::unix::net::UnixListener,
+        process::Command,
+        sync::mpsc,
+        thread,
+        time::{Duration, Instant},
+    };
 
     use super::SessionService;
     use crate::{
@@ -799,6 +807,21 @@ mod tests {
         reader.join().expect("join reader");
         assert!(request.starts_with("DELETE /sessions/alpha HTTP/1.1\r\n"), "{request}");
         assert!(!session_dir.exists(), "kill should remove the local session directory");
+    }
+
+    #[test]
+    fn kill_purge_preserved_recording_without_socket_returns_promptly() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+        let session_dir = temp.path().join("alpha");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        fs::write(session_dir.join(crate::recording::CAST_FILE_NAME), b"{\"version\":3}\n").expect("write cast");
+
+        let started = Instant::now();
+        service.kill_with_purge("alpha", true).expect("purge preserved recording");
+
+        assert!(started.elapsed() < Duration::from_secs(1), "purge should not wait for a missing socket");
+        assert!(!session_dir.exists(), "purge should remove the preserved recording directory");
     }
 
     #[test]

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -213,7 +213,13 @@ fn detach_command_parses() {
 #[test]
 fn kill_command_parses() {
     let cli = Cli::try_parse_from(["cleat", "kill", "session-1"]).expect("kill parses");
-    assert_eq!(cli.command, Command::Kill { id: "session-1".into() });
+    assert_eq!(cli.command, Command::Kill { id: "session-1".into(), purge: false });
+}
+
+#[test]
+fn kill_purge_command_parses() {
+    let cli = Cli::try_parse_from(["cleat", "kill", "session-1", "--purge"]).expect("kill --purge parses");
+    assert_eq!(cli.command, Command::Kill { id: "session-1".into(), purge: true });
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -575,6 +575,53 @@ fn kill_removes_session_directory() {
 }
 
 #[test]
+fn kill_preserves_session_directory_with_recording() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sh -c 'printf preserved; sleep 30'".into()), true)
+        .expect("create alpha");
+
+    let cast_path = temp.path().join("alpha").join(CAST_FILE_NAME);
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !cast_path.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(cast_path.exists(), "recording should exist before kill");
+
+    let cli = Cli::try_parse_from(["cleat", "kill", "alpha"]).expect("parse kill");
+    cli::execute(cli, &service).expect("execute kill");
+
+    assert!(temp.path().join("alpha").exists(), "recording-bearing session directory should be preserved");
+    assert!(cast_path.exists(), "recording should survive kill");
+    assert!(!session_socket_path(temp.path(), "alpha").exists(), "socket should not survive kill");
+    assert!(!daemon_pid_path(temp.path(), "alpha").exists(), "pid file should not survive kill");
+}
+
+#[test]
+fn kill_purge_removes_session_directory_with_recording() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sh -c 'printf purged; sleep 30'".into()), true)
+        .expect("create alpha");
+
+    let cast_path = temp.path().join("alpha").join(CAST_FILE_NAME);
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !cast_path.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(cast_path.exists(), "recording should exist before purge");
+
+    let cli = Cli::try_parse_from(["cleat", "kill", "alpha", "--purge"]).expect("parse kill --purge");
+    cli::execute(cli, &service).expect("execute kill --purge");
+
+    assert!(!temp.path().join("alpha").exists(), "purge should delete the recording-bearing session directory");
+}
+
+#[test]
 fn kill_missing_session_is_an_error() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Fixes #92.

Fleet-dogfood output: one of four codex sessions hosted in cleat working friction issues in parallel (run log: `docs/dogfood/2026-07-03-codex-hosts-issue-78.md`). This one is the **retirement gate** for the fleet itself — the previous run's recording was destroyed by `cleat kill`, and this fix is what lets the current four sessions be retired without losing theirs.

## What

- `kill` waits for daemon shutdown, then preserves the session dir when it is recreatable (`session_is_recreatable` — the same predicate the stale sweep and attach recreation use), restoring ADR 0001's recreation floor for deliberately-ended sessions.
- `kill --purge` explicitly deletes, recording and all.
- Stale sweep now also claims socket-only husks with no pid file (previously error-listed forever) and empty session dirs (~30 had accumulated in the runtime root).
- Regression tests: kill preserves `session.cast`; purge deletes it.

Validated: fmt, clippy `-D warnings`, workspace tests, ghostty-vt suite.