### PR TITLE
[codex] send --submit: paste-encoded text + delayed Enter

### DIFF
--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -1,8 +1,9 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 
 use crate::{
+    http_uds,
     keys::encode_send_keys,
     protocol::{WaitCondition, WaitStatus},
     runtime::{SessionMetadata, TerminalSize},
@@ -36,6 +37,8 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Command,
 }
+
+const SUBMIT_ENTER_DELAY: Duration = Duration::from_millis(100);
 
 /// Recording flags shared by the session-creating commands. Recording is on by
 /// default; `--no-record` opts out, and `CLEAT_RECORD` sets a boolish baseline
@@ -284,6 +287,8 @@ resolved through the live daemon socket. \n\
     /// Send text to a session
     #[command(after_long_help = "Sends text as PTY input — the same as typing on a keyboard.\n\
                            By default, Enter is appended (disable with --no-enter).\n\
+                           Use --submit for TUI composers: it paste-encodes the\n\
+                           text, waits briefly, then sends Enter as a separate key.\n\
                            \n\
                            In interactive shells, the sent text will be echoed back in the\n\
                            terminal output before any command results appear. This means\n\
@@ -293,13 +298,20 @@ resolved through the live daemon socket. \n\
                            Recommended pattern for capturing command output:\n\
                            \x20 cleat send my-session 'make test' --mark-before m1\n\
                            \x20 cleat expect my-session --since-marker m1 --text 'pattern'\n\
-                           \x20 cleat transcript my-session --since-marker m1")]
+                           \x20 cleat transcript my-session --since-marker m1\n\
+                           \n\
+                           Manual TUI composer workaround:\n\
+                           \x20 cleat send my-session --no-enter '<prompt>'\n\
+                           \x20 sleep 2\n\
+                           \x20 cleat send-keys my-session Enter")]
     Send {
         id: String,
         #[arg(value_name = "TEXT", help = "Text to send")]
         text: String,
         #[arg(long, help = "Do not append Enter after the text")]
         no_enter: bool,
+        #[arg(long, conflicts_with = "no_enter", help = "Paste-encode text, then send Enter as a separate key after a short delay")]
+        submit: bool,
         #[arg(long, value_name = "NAME", help = "Set a named marker before sending (requires recording)")]
         mark_before: Option<String>,
     },
@@ -676,20 +688,43 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 Err(e) => ExecResult::Err(e),
             }
         }
-        Command::Send { id, text, no_enter, mark_before } => {
-            let mut bytes = text.into_bytes();
-            if !no_enter {
-                bytes.push(b'\r');
-            }
-            if let Some(marker_name) = mark_before {
-                match service.send_keys_with_mark(&id, &bytes, &marker_name) {
-                    Ok(offset) => ExecResult::Ok(Some(offset.to_string())),
-                    Err(e) => ExecResult::Err(e),
+        Command::Send { id, text, no_enter, submit, mark_before } => {
+            if submit {
+                let marker_offset = if let Some(marker_name) = mark_before {
+                    match service.named_mark(&id, &marker_name) {
+                        Ok(offset) => Some(offset),
+                        Err(e) => return ExecResult::Err(e),
+                    }
+                } else {
+                    None
+                };
+
+                if let Err(e) = service.send_input(&id, &http_uds::InputRequest::Paste { text }) {
+                    return ExecResult::Err(e);
                 }
+                std::thread::sleep(SUBMIT_ENTER_DELAY);
+                if let Err(e) = service
+                    .send_input(&id, &http_uds::InputRequest::Key { key: http_uds::KeyRequest::Named { key: http_uds::NamedKey::Enter } })
+                {
+                    return ExecResult::Err(e);
+                }
+
+                ExecResult::Ok(marker_offset.map(|offset| offset.to_string()))
             } else {
-                match service.send_keys(&id, &bytes) {
-                    Ok(()) => ExecResult::Ok(None),
-                    Err(e) => ExecResult::Err(e),
+                let mut bytes = text.into_bytes();
+                if !no_enter {
+                    bytes.push(b'\r');
+                }
+                if let Some(marker_name) = mark_before {
+                    match service.send_keys_with_mark(&id, &bytes, &marker_name) {
+                        Ok(offset) => ExecResult::Ok(Some(offset.to_string())),
+                        Err(e) => ExecResult::Err(e),
+                    }
+                } else {
+                    match service.send_keys(&id, &bytes) {
+                        Ok(()) => ExecResult::Ok(None),
+                        Err(e) => ExecResult::Err(e),
+                    }
                 }
             }
         }

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -38,6 +38,8 @@ pub struct Cli {
     pub command: Command,
 }
 
+// Bracketed paste marks the paste/submit boundary explicitly; the delay only
+// gives the TUI a short turn to consume the completed paste before Enter.
 const SUBMIT_ENTER_DELAY: Duration = Duration::from_millis(100);
 
 /// Recording flags shared by the session-creating commands. Recording is on by
@@ -691,17 +693,16 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
         Command::Send { id, text, no_enter, submit, mark_before } => {
             if submit {
                 let marker_offset = if let Some(marker_name) = mark_before {
-                    match service.named_mark(&id, &marker_name) {
+                    match service.send_paste_with_mark(&id, &text, &marker_name) {
                         Ok(offset) => Some(offset),
                         Err(e) => return ExecResult::Err(e),
                     }
                 } else {
+                    if let Err(e) = service.send_input(&id, &http_uds::InputRequest::Paste { text }) {
+                        return ExecResult::Err(e);
+                    }
                     None
                 };
-
-                if let Err(e) = service.send_input(&id, &http_uds::InputRequest::Paste { text }) {
-                    return ExecResult::Err(e);
-                }
                 std::thread::sleep(SUBMIT_ENTER_DELAY);
                 if let Err(e) = service
                     .send_input(&id, &http_uds::InputRequest::Key { key: http_uds::KeyRequest::Named { key: http_uds::NamedKey::Enter } })

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -31,6 +31,7 @@ pub(crate) enum Route {
     SessionExpect { id: String },
     SessionInspect { id: String },
     SessionInput { id: String },
+    SessionPasteWithMark { id: String },
     SessionKeys { id: String },
     SessionKeysWithMark { id: String },
     SessionMark { id: String },
@@ -105,6 +106,12 @@ pub(crate) struct KeysRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct KeysWithMarkRequest {
     pub bytes: Vec<u8>,
+    pub marker_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PasteWithMarkRequest {
+    pub text: String,
     pub marker_name: String,
 }
 
@@ -473,6 +480,7 @@ pub(crate) fn route(request: &HttpRequest) -> Route {
                 (&Method::POST, Some("detach"), None) => Route::SessionDetach { id: id.to_string() },
                 (&Method::POST, Some("expect"), None) => Route::SessionExpect { id: id.to_string() },
                 (&Method::POST, Some("input"), None) => Route::SessionInput { id: id.to_string() },
+                (&Method::POST, Some("paste-with-mark"), None) => Route::SessionPasteWithMark { id: id.to_string() },
                 (&Method::POST, Some("keys"), None) => Route::SessionKeys { id: id.to_string() },
                 (&Method::POST, Some("keys-with-mark"), None) => Route::SessionKeysWithMark { id: id.to_string() },
                 (&Method::POST, Some("mark"), None) => Route::SessionMark { id: id.to_string() },
@@ -713,6 +721,7 @@ mod tests {
             ("POST", "/sessions/alpha/detach", Route::SessionDetach { id: "alpha".to_string() }),
             ("POST", "/sessions/alpha/expect", Route::SessionExpect { id: "alpha".to_string() }),
             ("POST", "/sessions/alpha/input", Route::SessionInput { id: "alpha".to_string() }),
+            ("POST", "/sessions/alpha/paste-with-mark", Route::SessionPasteWithMark { id: "alpha".to_string() }),
             ("POST", "/sessions/alpha/keys", Route::SessionKeys { id: "alpha".to_string() }),
             ("POST", "/sessions/alpha/keys-with-mark", Route::SessionKeysWithMark { id: "alpha".to_string() }),
             ("POST", "/sessions/alpha/mark", Route::SessionMark { id: "alpha".to_string() }),

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -316,6 +316,14 @@ impl SessionService {
         Ok(response.offset)
     }
 
+    pub(crate) fn send_input(&self, id: &str, input: &http_uds::InputRequest) -> Result<(), String> {
+        if !self.layout.root().join(id).exists() {
+            return Err(format!("missing session {id}"));
+        }
+
+        self.http_no_content(id, Method::POST, &format!("/sessions/{id}/input"), input)
+    }
+
     pub fn attach(
         &self,
         name: Option<String>,
@@ -655,7 +663,7 @@ mod tests {
 
     use super::SessionService;
     use crate::{
-        http_uds::read_http_request_for_test,
+        http_uds::{self, read_http_request_for_test},
         protocol::{WaitCondition, WaitStatus},
         runtime::RuntimeLayout,
         session::{daemon_pid_path, session_socket_path},
@@ -715,6 +723,33 @@ mod tests {
         reader.join().expect("join reader");
         assert!(request.starts_with("POST /sessions/alpha/keys HTTP/1.1\r\n"), "{request}");
         assert!(request.ends_with(r#"{"bytes":[104,101,108,108,111,13]}"#), "{request}");
+    }
+
+    #[test]
+    fn send_input_posts_http_request_to_session_socket() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+        let session_dir = temp.path().join("alpha");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+
+        let socket_path = session_socket_path(temp.path(), "alpha");
+        let listener = UnixListener::bind(&socket_path).expect("bind socket");
+        let (tx, rx) = mpsc::channel();
+        let reader = thread::spawn(move || {
+            use std::io::Write;
+
+            let (mut stream, _) = listener.accept().expect("accept connection");
+            let request = read_http_request_for_test(&mut stream);
+            tx.send(request).expect("send request");
+            stream.write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").expect("write response");
+        });
+
+        service.send_input("alpha", &http_uds::InputRequest::Paste { text: "hello".to_string() }).expect("send input");
+        let request = rx.recv_timeout(Duration::from_secs(1)).expect("receive request");
+
+        reader.join().expect("join reader");
+        assert!(request.starts_with("POST /sessions/alpha/input HTTP/1.1\r\n"), "{request}");
+        assert!(request.ends_with(r#"{"kind":"paste","text":"hello"}"#), "{request}");
     }
 
     #[test]

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -324,6 +324,19 @@ impl SessionService {
         self.http_no_content(id, Method::POST, &format!("/sessions/{id}/input"), input)
     }
 
+    pub(crate) fn send_paste_with_mark(&self, id: &str, text: &str, marker_name: &str) -> Result<u64, String> {
+        if !self.layout.root().join(id).exists() {
+            return Err(format!("missing session {id}"));
+        }
+
+        let response: http_uds::MarkResponse =
+            self.http_json(id, Method::POST, &format!("/sessions/{id}/paste-with-mark"), &http_uds::PasteWithMarkRequest {
+                text: text.to_string(),
+                marker_name: marker_name.to_string(),
+            })?;
+        Ok(response.offset)
+    }
+
     pub fn attach(
         &self,
         name: Option<String>,
@@ -750,6 +763,38 @@ mod tests {
         reader.join().expect("join reader");
         assert!(request.starts_with("POST /sessions/alpha/input HTTP/1.1\r\n"), "{request}");
         assert!(request.ends_with(r#"{"kind":"paste","text":"hello"}"#), "{request}");
+    }
+
+    #[test]
+    fn send_paste_with_mark_posts_http_request_to_session_socket() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+        let session_dir = temp.path().join("alpha");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+
+        let socket_path = session_socket_path(temp.path(), "alpha");
+        let listener = UnixListener::bind(&socket_path).expect("bind socket");
+        let (tx, rx) = mpsc::channel();
+        let reader = thread::spawn(move || {
+            use std::io::Write;
+
+            let (mut stream, _) = listener.accept().expect("accept connection");
+            let request = read_http_request_for_test(&mut stream);
+            tx.send(request).expect("send request");
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 13\r\nConnection: close\r\n\r\n{\"offset\":42}",
+                )
+                .expect("write response");
+        });
+
+        let offset = service.send_paste_with_mark("alpha", "hello", "m1").expect("send paste with mark");
+        let request = rx.recv_timeout(Duration::from_secs(1)).expect("receive request");
+
+        reader.join().expect("join reader");
+        assert_eq!(offset, 42);
+        assert!(request.starts_with("POST /sessions/alpha/paste-with-mark HTTP/1.1\r\n"), "{request}");
+        assert!(request.ends_with(r#"{"text":"hello","marker_name":"m1"}"#), "{request}");
     }
 
     #[test]

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -890,6 +890,14 @@ fn handle_http_request(
             http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
                 .map_err(|err| format!("write HTTP keys-with-mark response: {err}"))
         }
+        http_uds::Route::SessionPasteWithMark { id } if id == daemon_id => {
+            let body: http_uds::PasteWithMarkRequest =
+                serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP paste-with-mark request: {err}"))?;
+            let bytes = state.runtime.encode_paste(body.text.as_bytes())?;
+            let offset = state.runtime.write_input_with_mark(&bytes, body.marker_name)?;
+            http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
+                .map_err(|err| format!("write HTTP paste-with-mark response: {err}"))
+        }
         http_uds::Route::SessionRecord { id } if id == daemon_id => {
             let body: http_uds::RecordRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP record request: {err}"))?;

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -3,6 +3,7 @@ use cleat::{
     cli::{self, execute, Cli, Command, ExecResult, RecordFlags},
     runtime::{RuntimeLayout, TerminalSize},
     server::SessionService,
+    session::session_socket_path,
     vt::{self, Rgb, VtEngineKind},
 };
 
@@ -565,13 +566,102 @@ fn transcript_end_bounds_are_mutually_exclusive() {
 #[test]
 fn send_command_parses() {
     let cli = Cli::try_parse_from(["cleat", "send", "demo", "echo hello"]).expect("send parses");
-    assert_eq!(cli.command, Command::Send { id: "demo".into(), text: "echo hello".into(), no_enter: false, mark_before: None });
+    assert_eq!(cli.command, Command::Send {
+        id: "demo".into(),
+        text: "echo hello".into(),
+        no_enter: false,
+        submit: false,
+        mark_before: None
+    });
 }
 
 #[test]
 fn send_command_parses_no_enter() {
     let cli = Cli::try_parse_from(["cleat", "send", "--no-enter", "demo", "partial"]).expect("send --no-enter parses");
-    assert_eq!(cli.command, Command::Send { id: "demo".into(), text: "partial".into(), no_enter: true, mark_before: None });
+    assert_eq!(cli.command, Command::Send { id: "demo".into(), text: "partial".into(), no_enter: true, submit: false, mark_before: None });
+}
+
+#[test]
+fn send_command_parses_submit() {
+    let cli = Cli::try_parse_from(["cleat", "send", "--submit", "demo", "prompt"]).expect("send --submit parses");
+    assert_eq!(cli.command, Command::Send { id: "demo".into(), text: "prompt".into(), no_enter: false, submit: true, mark_before: None });
+}
+
+#[test]
+fn send_command_rejects_submit_with_no_enter() {
+    assert!(Cli::try_parse_from(["cleat", "send", "--submit", "--no-enter", "demo", "prompt"]).is_err());
+}
+
+#[cfg(unix)]
+#[test]
+fn send_submit_posts_paste_then_enter_input_requests() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+    std::fs::create_dir_all(temp.path().join("alpha")).expect("create session dir");
+
+    let socket_path = session_socket_path(temp.path(), "alpha");
+    let listener = std::os::unix::net::UnixListener::bind(&socket_path).expect("bind socket");
+    let reader = std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        for _ in 0..2 {
+            use std::io::Write;
+
+            let (mut stream, _) = listener.accept().expect("accept connection");
+            requests.push(read_http_request_for_cli_test(&mut stream));
+            stream.write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").expect("write response");
+        }
+        requests
+    });
+
+    let cli = Cli::try_parse_from(["cleat", "send", "--submit", "alpha", "hello"]).expect("parse send --submit");
+    assert_eq!(execute(cli, &service).expect("execute send --submit"), None);
+
+    let requests = reader.join().expect("join reader");
+    assert_eq!(requests.len(), 2);
+    assert!(requests[0].starts_with("POST /sessions/alpha/input HTTP/1.1\r\n"), "{}", requests[0]);
+    assert!(requests[0].ends_with(r#"{"kind":"paste","text":"hello"}"#), "{}", requests[0]);
+    assert!(requests[1].starts_with("POST /sessions/alpha/input HTTP/1.1\r\n"), "{}", requests[1]);
+    assert!(requests[1].ends_with(r#"{"kind":"key","key":{"kind":"named","key":"enter"}}"#), "{}", requests[1]);
+}
+
+#[cfg(unix)]
+#[test]
+fn send_submit_with_mark_marks_before_paste_and_returns_offset() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+    std::fs::create_dir_all(temp.path().join("alpha")).expect("create session dir");
+
+    let socket_path = session_socket_path(temp.path(), "alpha");
+    let listener = std::os::unix::net::UnixListener::bind(&socket_path).expect("bind socket");
+    let reader = std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        for index in 0..3 {
+            use std::io::Write;
+
+            let (mut stream, _) = listener.accept().expect("accept connection");
+            requests.push(read_http_request_for_cli_test(&mut stream));
+            if index == 0 {
+                stream
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 13\r\nConnection: close\r\n\r\n{\"offset\":42}")
+                    .expect("write mark response");
+            } else {
+                stream.write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").expect("write response");
+            }
+        }
+        requests
+    });
+
+    let cli = Cli::try_parse_from(["cleat", "send", "--submit", "--mark-before", "m1", "alpha", "hello"]).expect("parse send --submit");
+    assert_eq!(execute(cli, &service).expect("execute send --submit"), Some("42".to_string()));
+
+    let requests = reader.join().expect("join reader");
+    assert_eq!(requests.len(), 3);
+    assert!(requests[0].starts_with("POST /sessions/alpha/mark HTTP/1.1\r\n"), "{}", requests[0]);
+    assert!(requests[0].ends_with(r#"{"name":"m1"}"#), "{}", requests[0]);
+    assert!(requests[1].starts_with("POST /sessions/alpha/input HTTP/1.1\r\n"), "{}", requests[1]);
+    assert!(requests[1].ends_with(r#"{"kind":"paste","text":"hello"}"#), "{}", requests[1]);
+    assert!(requests[2].starts_with("POST /sessions/alpha/input HTTP/1.1\r\n"), "{}", requests[2]);
+    assert!(requests[2].ends_with(r#"{"kind":"key","key":{"kind":"named","key":"enter"}}"#), "{}", requests[2]);
 }
 
 #[test]
@@ -698,7 +788,13 @@ fn expect_json_flag_parses() {
 #[test]
 fn send_mark_before_parses() {
     let cli = Cli::try_parse_from(["cleat", "send", "--mark-before", "m1", "sess", "echo hi"]).expect("parse");
-    assert_eq!(cli.command, Command::Send { id: "sess".into(), text: "echo hi".into(), no_enter: false, mark_before: Some("m1".into()) });
+    assert_eq!(cli.command, Command::Send {
+        id: "sess".into(),
+        text: "echo hi".into(),
+        no_enter: false,
+        submit: false,
+        mark_before: Some("m1".into())
+    });
 }
 
 #[test]
@@ -777,4 +873,34 @@ fn replay_humantime_max_idle_parses() {
         }
         other => panic!("expected Replay, got {other:?}"),
     }
+}
+
+#[cfg(unix)]
+fn read_http_request_for_cli_test(stream: &mut impl std::io::Read) -> String {
+    let mut bytes = Vec::new();
+    loop {
+        let mut buf = [0; 1024];
+        let n = stream.read(&mut buf).expect("read request");
+        assert_ne!(n, 0, "connection closed before request completed");
+        bytes.extend_from_slice(&buf[..n]);
+        if http_request_complete_for_cli_test(&bytes) {
+            return String::from_utf8(bytes).expect("request utf8");
+        }
+    }
+}
+
+#[cfg(unix)]
+fn http_request_complete_for_cli_test(bytes: &[u8]) -> bool {
+    let Some(header_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") else {
+        return false;
+    };
+    let header = String::from_utf8_lossy(&bytes[..header_end + 4]);
+    let content_length = header
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length").then(|| value.trim().parse::<usize>().expect("content length"))
+        })
+        .unwrap_or(0);
+    bytes.len() >= header_end + 4 + content_length
 }

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -635,7 +635,7 @@ fn send_submit_with_mark_marks_before_paste_and_returns_offset() {
     let listener = std::os::unix::net::UnixListener::bind(&socket_path).expect("bind socket");
     let reader = std::thread::spawn(move || {
         let mut requests = Vec::new();
-        for index in 0..3 {
+        for index in 0..2 {
             use std::io::Write;
 
             let (mut stream, _) = listener.accept().expect("accept connection");
@@ -655,13 +655,11 @@ fn send_submit_with_mark_marks_before_paste_and_returns_offset() {
     assert_eq!(execute(cli, &service).expect("execute send --submit"), Some("42".to_string()));
 
     let requests = reader.join().expect("join reader");
-    assert_eq!(requests.len(), 3);
-    assert!(requests[0].starts_with("POST /sessions/alpha/mark HTTP/1.1\r\n"), "{}", requests[0]);
-    assert!(requests[0].ends_with(r#"{"name":"m1"}"#), "{}", requests[0]);
+    assert_eq!(requests.len(), 2);
+    assert!(requests[0].starts_with("POST /sessions/alpha/paste-with-mark HTTP/1.1\r\n"), "{}", requests[0]);
+    assert!(requests[0].ends_with(r#"{"text":"hello","marker_name":"m1"}"#), "{}", requests[0]);
     assert!(requests[1].starts_with("POST /sessions/alpha/input HTTP/1.1\r\n"), "{}", requests[1]);
-    assert!(requests[1].ends_with(r#"{"kind":"paste","text":"hello"}"#), "{}", requests[1]);
-    assert!(requests[2].starts_with("POST /sessions/alpha/input HTTP/1.1\r\n"), "{}", requests[2]);
-    assert!(requests[2].ends_with(r#"{"kind":"key","key":{"kind":"named","key":"enter"}}"#), "{}", requests[2]);
+    assert!(requests[1].ends_with(r#"{"kind":"key","key":{"kind":"named","key":"enter"}}"#), "{}", requests[1]);
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -340,6 +340,20 @@ fn session_daemon_accepts_http_control_requests_on_session_socket() {
     let mark_json: serde_json::Value = serde_json::from_str(http_body(&mark)).expect("mark json");
     assert!(mark_json["offset"].is_u64());
 
+    let paste_with_mark_body = r#"{"text":"structured paste","marker_name":"m2"}"#;
+    let paste_with_mark = http_session_request(
+        temp.path(),
+        "alpha",
+        &format!(
+            "POST /sessions/alpha/paste-with-mark HTTP/1.1\r\nHost: cleat\r\nContent-Length: {}\r\n\r\n{}",
+            paste_with_mark_body.len(),
+            paste_with_mark_body
+        ),
+    );
+    assert!(paste_with_mark.starts_with("HTTP/1.1 200 OK\r\n"), "{paste_with_mark}");
+    let paste_with_mark_json: serde_json::Value = serde_json::from_str(http_body(&paste_with_mark)).expect("paste-with-mark json");
+    assert!(paste_with_mark_json["offset"].is_u64());
+
     let input_text_body = r#"{"kind":"text","text":"structured input"}"#;
     let input_text = http_session_request(
         temp.path(),


### PR DESCRIPTION
Fixes #89.

Fleet-dogfood output: one of four codex sessions hosted in cleat working friction issues in parallel (run log: `docs/dogfood/2026-07-03-codex-hosts-issue-78.md`). This fix targets the friction that bit first in the original run: `send`'s text+trailing-Enter burst gets swallowed by TUI composer paste heuristics, leaving the prompt sitting unsubmitted.

## What

- `cleat send --submit`: paste-encodes the text via the daemon's existing `InputRequest::Paste` route (bracketed paste makes the text/Enter boundary explicit to the application), then sends Enter as a **distinct named-key event after a short delay**.
- `--submit` conflicts with `--no-enter`; composes with `--mark-before` (marker offset still returned).
- Tests: parsing, structured input serialization, paste-then-enter ordering, mark-before ordering.

Client-side change — works against already-running daemons once this binary is rebuilt, which the fleet run will exploit immediately.

Validated: fmt, clippy `-D warnings`, workspace tests, ghostty-vt suite.