### PR TITLE
[codex] Extract shared session actor; daemon adopts it (progress/servicing split)

### DIFF
--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -262,30 +262,30 @@ pub(crate) enum SessionCommand {
     RenderUpdate { reply: mpsc::Sender<Result<TerminalRenderUpdate, String>> },
     FullSnapshot { reply: mpsc::Sender<Result<TerminalSnapshot, String>> },
     ImageResourceData { image_id: u32, generation: u64, callback: ImageResourceDataCallback, reply: mpsc::Sender<Result<bool, String>> },
-    Inspect { has_controller: bool, watcher_count: usize, reply: mpsc::Sender<InspectResult> },
+    Inspect { has_controller: bool, watcher_count: usize, reply: mpsc::Sender<Result<InspectResult, String>> },
     ApplyAttachState { cols: u16, rows: u16, capabilities: vt::ClientCapabilities, reply: mpsc::Sender<Result<Option<Vec<u8>>, String>> },
     ReplayPayload { capabilities: vt::ClientCapabilities, reply: mpsc::Sender<Result<Option<Vec<u8>>, String>> },
     CaptureText { reply: mpsc::Sender<Result<String, String>> },
     ValidateTextMatching { reply: mpsc::Sender<Result<(), String>> },
-    ScreenContains { text: String, reply: mpsc::Sender<bool> },
-    LastPtyOutputAt { reply: mpsc::Sender<Option<Instant>> },
-    FlushRecording { reply: mpsc::Sender<()> },
-    RecordingActive { reply: mpsc::Sender<bool> },
-    RecordAttach { reply: mpsc::Sender<()> },
-    RecordDetach { reply: mpsc::Sender<()> },
+    ScreenContains { text: String, reply: mpsc::Sender<Result<bool, String>> },
+    LastPtyOutputAt { reply: mpsc::Sender<Result<Option<Instant>, String>> },
+    FlushRecording { reply: mpsc::Sender<Result<(), String>> },
+    RecordingActive { reply: mpsc::Sender<Result<bool, String>> },
+    RecordAttach { reply: mpsc::Sender<Result<(), String>> },
+    RecordDetach { reply: mpsc::Sender<Result<(), String>> },
     WriteInputWithMark { bytes: Vec<u8>, marker_name: String, reply: mpsc::Sender<Result<u64, String>> },
     PasteWithMark { text: Vec<u8>, marker_name: String, reply: mpsc::Sender<Result<u64, String>> },
     SetRecording { enable: bool, reply: mpsc::Sender<Result<(), String>> },
     Mark { name: Option<String>, reply: mpsc::Sender<Result<u64, String>> },
-    ResolveMarker { name: String, reply: mpsc::Sender<Option<u64>> },
-    ResolveNextMarker { after: u64, reply: mpsc::Sender<Option<u64>> },
+    ResolveMarker { name: String, reply: mpsc::Sender<Result<Option<u64>, String>> },
+    ResolveNextMarker { after: u64, reply: mpsc::Sender<Result<Option<u64>, String>> },
     DispatchSignal { signal: i32, target: SignalTarget, reply: mpsc::Sender<Result<(), String>> },
-    ExitCode { reply: mpsc::Sender<Option<i32>> },
-    ShouldKeepSessionDir { reply: mpsc::Sender<bool> },
+    ExitCode { reply: mpsc::Sender<Result<Option<i32>, String>> },
+    ShouldKeepSessionDir { reply: mpsc::Sender<Result<bool, String>> },
     MarkObserved { generation: u64, reply: mpsc::Sender<bool> },
     ScrollbackExtent { reply: mpsc::Sender<TerminalScrollbackExtent> },
     ScrollbarState { reply: mpsc::Sender<TerminalScrollbarState> },
-    SetClientPresence { active: bool, reply: mpsc::Sender<()> },
+    SetClientPresence { active: bool, reply: mpsc::Sender<Result<(), String>> },
     SubscribeRawOutput { reply: mpsc::Sender<RawOutputTap> },
     Stop { terminate: bool },
 }
@@ -482,11 +482,12 @@ fn wait_actor_ready_epoll(pty_fd: RawFd, command_fd: RawFd) -> Result<ActorReadi
     const TOKEN_COMMAND: u64 = 2;
 
     let epoll = Epoll::new(EpollCreateFlags::EPOLL_CLOEXEC).map_err(|err| format!("create actor epoll: {err}"))?;
+    let read_or_closed = EpollFlags::EPOLLIN | EpollFlags::EPOLLHUP | EpollFlags::EPOLLERR;
     epoll
-        .add(unsafe { std::os::fd::BorrowedFd::borrow_raw(pty_fd) }, EpollEvent::new(EpollFlags::EPOLLIN, TOKEN_PTY))
+        .add(unsafe { std::os::fd::BorrowedFd::borrow_raw(pty_fd) }, EpollEvent::new(read_or_closed, TOKEN_PTY))
         .map_err(|err| format!("register pty with actor epoll: {err}"))?;
     epoll
-        .add(unsafe { std::os::fd::BorrowedFd::borrow_raw(command_fd) }, EpollEvent::new(EpollFlags::EPOLLIN, TOKEN_COMMAND))
+        .add(unsafe { std::os::fd::BorrowedFd::borrow_raw(command_fd) }, EpollEvent::new(read_or_closed, TOKEN_COMMAND))
         .map_err(|err| format!("register command wake with actor epoll: {err}"))?;
 
     let mut events = [EpollEvent::empty(); 2];
@@ -500,7 +501,7 @@ fn wait_actor_ready_epoll(pty_fd: RawFd, command_fd: RawFd) -> Result<ActorReadi
 
     let mut readiness = ActorReadiness::default();
     for event in events.iter().take(event_count) {
-        if event.events().contains(EpollFlags::EPOLLIN) {
+        if event.events().intersects(read_or_closed) {
             match event.data() {
                 TOKEN_PTY => readiness.pty_readable = true,
                 TOKEN_COMMAND => readiness.command_readable = true,
@@ -514,8 +515,11 @@ fn wait_actor_ready_epoll(pty_fd: RawFd, command_fd: RawFd) -> Result<ActorReadi
 #[cfg(all(unix, not(any(target_os = "macos", target_os = "linux"))))]
 fn wait_actor_ready_poll(pty_fd: RawFd, command_fd: RawFd) -> Result<ActorReadiness, String> {
     let mut fds = [
-        PollFd::new(unsafe { std::os::fd::BorrowedFd::borrow_raw(pty_fd) }, PollFlags::POLLIN),
-        PollFd::new(unsafe { std::os::fd::BorrowedFd::borrow_raw(command_fd) }, PollFlags::POLLIN),
+        PollFd::new(unsafe { std::os::fd::BorrowedFd::borrow_raw(pty_fd) }, PollFlags::POLLIN | PollFlags::POLLHUP | PollFlags::POLLERR),
+        PollFd::new(
+            unsafe { std::os::fd::BorrowedFd::borrow_raw(command_fd) },
+            PollFlags::POLLIN | PollFlags::POLLHUP | PollFlags::POLLERR,
+        ),
     ];
     loop {
         match poll(&mut fds, PollTimeout::NONE) {
@@ -524,9 +528,10 @@ fn wait_actor_ready_poll(pty_fd: RawFd, command_fd: RawFd) -> Result<ActorReadin
             Err(err) => return Err(format!("poll actor fds: {err}")),
         }
     }
+    let read_or_closed = PollFlags::POLLIN | PollFlags::POLLHUP | PollFlags::POLLERR;
     Ok(ActorReadiness {
-        pty_readable: fds[0].revents().unwrap_or_else(PollFlags::empty).contains(PollFlags::POLLIN),
-        command_readable: fds[1].revents().unwrap_or_else(PollFlags::empty).contains(PollFlags::POLLIN),
+        pty_readable: fds[0].revents().unwrap_or_else(PollFlags::empty).intersects(read_or_closed),
+        command_readable: fds[1].revents().unwrap_or_else(PollFlags::empty).intersects(read_or_closed),
     })
 }
 
@@ -597,12 +602,9 @@ impl SessionActor {
     }
 
     pub(crate) fn set_client_presence(&self, active: bool) -> Result<(), String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::SetClientPresence { active, reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::SetClientPresence { active, reply })
     }
 
-    #[allow(dead_code)]
     pub(crate) fn subscribe_raw_output(&self) -> Result<RawOutputTap, String> {
         let (reply, recv) = mpsc::channel();
         self.tx.send(SessionCommand::SubscribeRawOutput { reply }).map_err(|_| "session actor is not running".to_string())?;
@@ -610,11 +612,7 @@ impl SessionActor {
     }
 
     pub(crate) fn inspect(&self, has_controller: bool, watcher_count: usize) -> Result<InspectResult, String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx
-            .send(SessionCommand::Inspect { has_controller, watcher_count, reply })
-            .map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::Inspect { has_controller, watcher_count, reply })
     }
 
     pub(crate) fn apply_attach_state(&self, cols: u16, rows: u16, capabilities: vt::ClientCapabilities) -> Result<Option<Vec<u8>>, String> {
@@ -650,39 +648,27 @@ impl SessionActor {
     }
 
     pub(crate) fn screen_contains(&self, text: String) -> Result<bool, String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::ScreenContains { text, reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::ScreenContains { text, reply })
     }
 
     pub(crate) fn last_pty_output_at(&self) -> Result<Option<Instant>, String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::LastPtyOutputAt { reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::LastPtyOutputAt { reply })
     }
 
     pub(crate) fn flush_recording(&self) -> Result<(), String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::FlushRecording { reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::FlushRecording { reply })
     }
 
     pub(crate) fn recording_active(&self) -> Result<bool, String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::RecordingActive { reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::RecordingActive { reply })
     }
 
     pub(crate) fn record_attach(&self) -> Result<(), String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::RecordAttach { reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::RecordAttach { reply })
     }
 
     pub(crate) fn record_detach(&self) -> Result<(), String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::RecordDetach { reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::RecordDetach { reply })
     }
 
     pub(crate) fn write_input_with_mark(&self, bytes: Vec<u8>, marker_name: String) -> Result<u64, String> {
@@ -702,15 +688,11 @@ impl SessionActor {
     }
 
     pub(crate) fn resolve_marker(&self, name: String) -> Result<Option<u64>, String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::ResolveMarker { name, reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::ResolveMarker { name, reply })
     }
 
     pub(crate) fn resolve_next_marker_after(&self, after: u64) -> Result<Option<u64>, String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::ResolveNextMarker { after, reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::ResolveNextMarker { after, reply })
     }
 
     pub(crate) fn dispatch_signal(&self, signal: i32, target: SignalTarget) -> Result<(), String> {
@@ -718,15 +700,11 @@ impl SessionActor {
     }
 
     pub(crate) fn exit_code(&self) -> Result<Option<i32>, String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::ExitCode { reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::ExitCode { reply })
     }
 
     pub(crate) fn should_keep_session_dir(&self) -> Result<bool, String> {
-        let (reply, recv) = mpsc::channel();
-        self.tx.send(SessionCommand::ShouldKeepSessionDir { reply }).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())
+        self.request_result(|reply| SessionCommand::ShouldKeepSessionDir { reply })
     }
 }
 
@@ -950,6 +928,7 @@ fn session_actor_handle_command(
             let _ = reply.send(result);
         }
         SessionCommand::FullSnapshot { reply } => {
+            session_actor_pump(runtime, state, wake);
             let _ = reply.send(runtime.snapshot(DirtyState::Full));
         }
         SessionCommand::ImageResourceData { image_id, generation, mut callback, reply } => {
@@ -957,7 +936,7 @@ fn session_actor_handle_command(
             let _ = reply.send(result);
         }
         SessionCommand::Inspect { has_controller, watcher_count, reply } => {
-            let _ = reply.send(runtime.inspect(has_controller, watcher_count));
+            let _ = reply.send(Ok(runtime.inspect(has_controller, watcher_count)));
         }
         SessionCommand::ApplyAttachState { cols, rows, capabilities, reply } => {
             let cols = cols.max(1);
@@ -977,25 +956,25 @@ fn session_actor_handle_command(
             let _ = reply.send(runtime.validate_text_matching());
         }
         SessionCommand::ScreenContains { text, reply } => {
-            let _ = reply.send(runtime.screen_contains(&text));
+            let _ = reply.send(Ok(runtime.screen_contains(&text)));
         }
         SessionCommand::LastPtyOutputAt { reply } => {
-            let _ = reply.send(runtime.last_pty_output_at());
+            let _ = reply.send(Ok(runtime.last_pty_output_at()));
         }
         SessionCommand::FlushRecording { reply } => {
             runtime.flush_recording();
-            let _ = reply.send(());
+            let _ = reply.send(Ok(()));
         }
         SessionCommand::RecordingActive { reply } => {
-            let _ = reply.send(runtime.recording_active());
+            let _ = reply.send(Ok(runtime.recording_active()));
         }
         SessionCommand::RecordAttach { reply } => {
             runtime.record_attach();
-            let _ = reply.send(());
+            let _ = reply.send(Ok(()));
         }
         SessionCommand::RecordDetach { reply } => {
             runtime.record_detach();
-            let _ = reply.send(());
+            let _ = reply.send(Ok(()));
         }
         SessionCommand::WriteInputWithMark { bytes, marker_name, reply } => {
             let _ = reply.send(runtime.write_input_with_mark(&bytes, marker_name));
@@ -1011,19 +990,19 @@ fn session_actor_handle_command(
             let _ = reply.send(runtime.mark(name));
         }
         SessionCommand::ResolveMarker { name, reply } => {
-            let _ = reply.send(runtime.resolve_marker(&name));
+            let _ = reply.send(Ok(runtime.resolve_marker(&name)));
         }
         SessionCommand::ResolveNextMarker { after, reply } => {
-            let _ = reply.send(runtime.resolve_next_marker_after(after));
+            let _ = reply.send(Ok(runtime.resolve_next_marker_after(after)));
         }
         SessionCommand::DispatchSignal { signal, target, reply } => {
             let _ = reply.send(runtime.dispatch_signal(signal, target));
         }
         SessionCommand::ExitCode { reply } => {
-            let _ = reply.send(state.exit_code);
+            let _ = reply.send(Ok(state.exit_code));
         }
         SessionCommand::ShouldKeepSessionDir { reply } => {
-            let _ = reply.send(runtime.should_keep_session_dir());
+            let _ = reply.send(Ok(runtime.should_keep_session_dir()));
         }
         SessionCommand::MarkObserved { generation, reply } => {
             let _ = reply.send(state.observation.mark_observed(generation));
@@ -1044,7 +1023,7 @@ fn session_actor_handle_command(
         }
         SessionCommand::SetClientPresence { active, reply } => {
             state.has_active_client = active;
-            let _ = reply.send(());
+            let _ = reply.send(Ok(()));
         }
         SessionCommand::SubscribeRawOutput { reply } => {
             let (tx, rx) = mpsc::sync_channel(RAW_OUTPUT_TAP_CHUNKS);

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -9,6 +9,7 @@ use std::{
         Arc,
     },
     thread,
+    time::Instant,
 };
 
 #[cfg(all(unix, not(any(target_os = "macos", target_os = "linux"))))]
@@ -25,7 +26,7 @@ use nix::{
 
 use crate::{
     platform::pty::PtyChild,
-    protocol::SignalTarget,
+    protocol::{InspectResult, SignalTarget},
     provider::{
         DirtyState, TerminalRenderUpdate, TerminalScrollbackExtent, TerminalScrollbarState, TerminalSnapshot, TerminalViewportKind,
         ViewportCommand, ViewportCommandOutcome,
@@ -40,13 +41,11 @@ const RAW_OUTPUT_TAP_CHUNKS: usize = 64;
 pub(crate) type WakeCallback = Arc<dyn Fn() + Send + Sync + 'static>;
 pub(crate) type ImageResourceDataCallback = Box<dyn FnMut(&[u8]) -> bool + Send>;
 
-#[allow(dead_code)]
 pub(crate) struct RawOutputTap {
     rx: Receiver<Vec<u8>>,
 }
 
 impl RawOutputTap {
-    #[allow(dead_code)]
     pub(crate) fn try_recv(&self) -> Result<Vec<u8>, mpsc::TryRecvError> {
         self.rx.try_recv()
     }
@@ -261,7 +260,28 @@ pub(crate) enum SessionCommand {
     ScrollViewport { command: ViewportCommand, reply: mpsc::Sender<Result<ViewportCommandOutcome, String>> },
     Snapshot { reply: mpsc::Sender<Result<TerminalSnapshot, String>> },
     RenderUpdate { reply: mpsc::Sender<Result<TerminalRenderUpdate, String>> },
+    FullSnapshot { reply: mpsc::Sender<Result<TerminalSnapshot, String>> },
     ImageResourceData { image_id: u32, generation: u64, callback: ImageResourceDataCallback, reply: mpsc::Sender<Result<bool, String>> },
+    Inspect { has_controller: bool, watcher_count: usize, reply: mpsc::Sender<InspectResult> },
+    ApplyAttachState { cols: u16, rows: u16, capabilities: vt::ClientCapabilities, reply: mpsc::Sender<Result<Option<Vec<u8>>, String>> },
+    ReplayPayload { capabilities: vt::ClientCapabilities, reply: mpsc::Sender<Result<Option<Vec<u8>>, String>> },
+    CaptureText { reply: mpsc::Sender<Result<String, String>> },
+    ValidateTextMatching { reply: mpsc::Sender<Result<(), String>> },
+    ScreenContains { text: String, reply: mpsc::Sender<bool> },
+    LastPtyOutputAt { reply: mpsc::Sender<Option<Instant>> },
+    FlushRecording { reply: mpsc::Sender<()> },
+    RecordingActive { reply: mpsc::Sender<bool> },
+    RecordAttach { reply: mpsc::Sender<()> },
+    RecordDetach { reply: mpsc::Sender<()> },
+    WriteInputWithMark { bytes: Vec<u8>, marker_name: String, reply: mpsc::Sender<Result<u64, String>> },
+    PasteWithMark { text: Vec<u8>, marker_name: String, reply: mpsc::Sender<Result<u64, String>> },
+    SetRecording { enable: bool, reply: mpsc::Sender<Result<(), String>> },
+    Mark { name: Option<String>, reply: mpsc::Sender<Result<u64, String>> },
+    ResolveMarker { name: String, reply: mpsc::Sender<Option<u64>> },
+    ResolveNextMarker { after: u64, reply: mpsc::Sender<Option<u64>> },
+    DispatchSignal { signal: i32, target: SignalTarget, reply: mpsc::Sender<Result<(), String>> },
+    ExitCode { reply: mpsc::Sender<Option<i32>> },
+    ShouldKeepSessionDir { reply: mpsc::Sender<bool> },
     MarkObserved { generation: u64, reply: mpsc::Sender<bool> },
     ScrollbackExtent { reply: mpsc::Sender<TerminalScrollbackExtent> },
     ScrollbarState { reply: mpsc::Sender<TerminalScrollbarState> },
@@ -588,6 +608,126 @@ impl SessionActor {
         self.tx.send(SessionCommand::SubscribeRawOutput { reply }).map_err(|_| "session actor is not running".to_string())?;
         recv.recv().map_err(|_| "session actor did not reply".to_string())
     }
+
+    pub(crate) fn inspect(&self, has_controller: bool, watcher_count: usize) -> Result<InspectResult, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx
+            .send(SessionCommand::Inspect { has_controller, watcher_count, reply })
+            .map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn apply_attach_state(&self, cols: u16, rows: u16, capabilities: vt::ClientCapabilities) -> Result<Option<Vec<u8>>, String> {
+        self.request_result(|reply| SessionCommand::ApplyAttachState { cols, rows, capabilities, reply })
+    }
+
+    pub(crate) fn resize(&self, cols: u16, rows: u16) -> Result<(), String> {
+        self.request_result(|reply| SessionCommand::Resize { cols, rows, reply })
+    }
+
+    pub(crate) fn write_input(&self, bytes: Vec<u8>) -> Result<(), String> {
+        self.request_result(|reply| SessionCommand::WriteInput { bytes, reply })
+    }
+
+    pub(crate) fn paste(&self, text: Vec<u8>) -> Result<usize, String> {
+        self.request_result(|reply| SessionCommand::Paste { text, reply })
+    }
+
+    pub(crate) fn replay_payload(&self, capabilities: vt::ClientCapabilities) -> Result<Option<Vec<u8>>, String> {
+        self.request_result(|reply| SessionCommand::ReplayPayload { capabilities, reply })
+    }
+
+    pub(crate) fn full_snapshot(&self) -> Result<TerminalSnapshot, String> {
+        self.request_result(|reply| SessionCommand::FullSnapshot { reply })
+    }
+
+    pub(crate) fn capture_text(&self) -> Result<String, String> {
+        self.request_result(|reply| SessionCommand::CaptureText { reply })
+    }
+
+    pub(crate) fn validate_text_matching(&self) -> Result<(), String> {
+        self.request_result(|reply| SessionCommand::ValidateTextMatching { reply })
+    }
+
+    pub(crate) fn screen_contains(&self, text: String) -> Result<bool, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::ScreenContains { text, reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn last_pty_output_at(&self) -> Result<Option<Instant>, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::LastPtyOutputAt { reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn flush_recording(&self) -> Result<(), String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::FlushRecording { reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn recording_active(&self) -> Result<bool, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::RecordingActive { reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn record_attach(&self) -> Result<(), String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::RecordAttach { reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn record_detach(&self) -> Result<(), String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::RecordDetach { reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn write_input_with_mark(&self, bytes: Vec<u8>, marker_name: String) -> Result<u64, String> {
+        self.request_result(|reply| SessionCommand::WriteInputWithMark { bytes, marker_name, reply })
+    }
+
+    pub(crate) fn paste_with_mark(&self, text: Vec<u8>, marker_name: String) -> Result<u64, String> {
+        self.request_result(|reply| SessionCommand::PasteWithMark { text, marker_name, reply })
+    }
+
+    pub(crate) fn set_recording(&self, enable: bool) -> Result<(), String> {
+        self.request_result(|reply| SessionCommand::SetRecording { enable, reply })
+    }
+
+    pub(crate) fn mark(&self, name: Option<String>) -> Result<u64, String> {
+        self.request_result(|reply| SessionCommand::Mark { name, reply })
+    }
+
+    pub(crate) fn resolve_marker(&self, name: String) -> Result<Option<u64>, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::ResolveMarker { name, reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn resolve_next_marker_after(&self, after: u64) -> Result<Option<u64>, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::ResolveNextMarker { after, reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn dispatch_signal(&self, signal: i32, target: SignalTarget) -> Result<(), String> {
+        self.request_result(|reply| SessionCommand::DispatchSignal { signal, target, reply })
+    }
+
+    pub(crate) fn exit_code(&self) -> Result<Option<i32>, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::ExitCode { reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    pub(crate) fn should_keep_session_dir(&self) -> Result<bool, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::ShouldKeepSessionDir { reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
 }
 
 impl Drop for SessionActor {
@@ -611,12 +751,26 @@ struct PumpResult {
     chunks: Vec<Vec<u8>>,
 }
 
-fn pump_session_runtime(runtime: &mut SessionRuntime, exited: &mut bool, has_active_client: bool) -> Result<PumpResult, String> {
+struct SessionActorLoopState {
+    observation: ObservationState,
+    exited: bool,
+    exit_code: Option<i32>,
+    has_active_client: bool,
+    raw_output_taps: Vec<SyncSender<Vec<u8>>>,
+}
+
+fn pump_session_runtime(
+    runtime: &mut SessionRuntime,
+    exited: &mut bool,
+    exit_code: &mut Option<i32>,
+    has_active_client: bool,
+) -> Result<PumpResult, String> {
     let mut exited_now = false;
     if !*exited {
-        if let Some(exit_code) = runtime.exit_code_if_exited()? {
-            runtime.record_exit_code(exit_code);
+        if let Some(code) = runtime.exit_code_if_exited()? {
+            runtime.record_exit_code(code);
             *exited = true;
+            *exit_code = Some(code);
             exited_now = true;
         }
     }
@@ -666,10 +820,13 @@ fn session_actor_loop(
     rx: mpsc::Receiver<SessionCommand>,
     #[cfg(unix)] command_wake: CommandWakeReader,
 ) {
-    let mut observation = ObservationState::new_with_mirror(rows, Some(mirror));
-    let mut exited = false;
-    let mut has_active_client = false;
-    let mut raw_output_taps = Vec::new();
+    let mut state = SessionActorLoopState {
+        observation: ObservationState::new_with_mirror(rows, Some(mirror)),
+        exited: false,
+        exit_code: None,
+        has_active_client: false,
+        raw_output_taps: Vec::new(),
+    };
     let _ = ready.send(Ok(()));
     #[cfg(unix)]
     loop {
@@ -682,33 +839,24 @@ fn session_actor_loop(
         };
         if readiness.command_readable {
             command_wake.drain();
-            if drain_session_commands(&rx, &mut runtime, &mut observation, &mut exited, &mut has_active_client, &mut raw_output_taps, &wake)
-            {
+            if drain_session_commands(&rx, &mut runtime, &mut state, &wake) {
                 break;
             }
         }
         if readiness.pty_readable {
-            session_actor_pump(&mut runtime, &mut observation, &mut exited, has_active_client, &mut raw_output_taps, &wake);
+            session_actor_pump(&mut runtime, &mut state, &wake);
         }
     }
     #[cfg(not(unix))]
     loop {
         match rx.recv_timeout(std::time::Duration::from_millis(10)) {
             Ok(command) => {
-                if session_actor_handle_command(
-                    command,
-                    &mut runtime,
-                    &mut observation,
-                    &mut exited,
-                    &mut has_active_client,
-                    &mut raw_output_taps,
-                    &wake,
-                ) {
+                if session_actor_handle_command(command, &mut runtime, &mut state, &wake) {
                     break;
                 }
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                session_actor_pump(&mut runtime, &mut observation, &mut exited, has_active_client, &mut raw_output_taps, &wake);
+                session_actor_pump(&mut runtime, &mut state, &wake);
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
@@ -721,16 +869,13 @@ fn session_actor_loop(
 fn drain_session_commands(
     rx: &mpsc::Receiver<SessionCommand>,
     runtime: &mut SessionRuntime,
-    observation: &mut ObservationState,
-    exited: &mut bool,
-    has_active_client: &mut bool,
-    raw_output_taps: &mut Vec<SyncSender<Vec<u8>>>,
+    state: &mut SessionActorLoopState,
     wake: &WakeCallback,
 ) -> bool {
     loop {
         match rx.try_recv() {
             Ok(command) => {
-                if session_actor_handle_command(command, runtime, observation, exited, has_active_client, raw_output_taps, wake) {
+                if session_actor_handle_command(command, runtime, state, wake) {
                     return true;
                 }
             }
@@ -746,10 +891,7 @@ fn drain_session_commands(
 fn session_actor_handle_command(
     command: SessionCommand,
     runtime: &mut SessionRuntime,
-    observation: &mut ObservationState,
-    exited: &mut bool,
-    has_active_client: &mut bool,
-    raw_output_taps: &mut Vec<SyncSender<Vec<u8>>>,
+    state: &mut SessionActorLoopState,
     wake: &WakeCallback,
 ) -> bool {
     let mut stop = false;
@@ -758,14 +900,14 @@ fn session_actor_handle_command(
             let cols = cols.max(1);
             let rows = rows.max(1);
             let result = runtime.resize(cols, rows).map(|_| {
-                mark_full_and_wake(observation, rows, wake);
+                mark_full_and_wake(&mut state.observation, rows, wake);
             });
             let _ = reply.send(result);
         }
         SessionCommand::SetCellSize { cell_width_px, cell_height_px, reply } => {
             let result = runtime.set_cell_size(cell_width_px, cell_height_px).map(|_| {
                 let rows = runtime.inspect(false, 0).terminal.rows;
-                mark_full_and_wake(observation, rows, wake);
+                mark_full_and_wake(&mut state.observation, rows, wake);
             });
             let _ = reply.send(result);
         }
@@ -773,7 +915,7 @@ fn session_actor_handle_command(
             let _ = reply.send(runtime.write_input(&bytes));
         }
         SessionCommand::Wheel { event, reply } => {
-            let result = route_wheel_event_on_actor(wake, runtime, observation, event);
+            let result = route_wheel_event_on_actor(wake, runtime, &mut state.observation, event);
             let _ = reply.send(result);
         }
         SessionCommand::Mouse { event, reply } => {
@@ -786,33 +928,105 @@ fn session_actor_handle_command(
             let result = runtime.scroll_viewport(command).inspect(|outcome| {
                 if *outcome == ViewportCommandOutcome::Moved {
                     let rows = runtime.inspect(false, 0).terminal.rows;
-                    mark_full_and_wake(observation, rows, wake);
+                    mark_full_and_wake(&mut state.observation, rows, wake);
                 }
             });
             let _ = reply.send(result);
         }
         SessionCommand::Snapshot { reply } => {
-            sync_terminal_modes_and_wake(runtime, observation, wake);
-            let result = runtime.snapshot(observation.dirty()).map(|mut snapshot| {
-                observation.annotate_snapshot(&mut snapshot);
+            sync_terminal_modes_and_wake(runtime, &mut state.observation, wake);
+            let result = runtime.snapshot(state.observation.dirty()).map(|mut snapshot| {
+                state.observation.annotate_snapshot(&mut snapshot);
                 snapshot
             });
             let _ = reply.send(result);
         }
         SessionCommand::RenderUpdate { reply } => {
-            sync_terminal_modes_and_wake(runtime, observation, wake);
-            let result = runtime.render_update(observation.dirty()).map(|mut update| {
-                observation.annotate_render_update(&mut update);
+            sync_terminal_modes_and_wake(runtime, &mut state.observation, wake);
+            let result = runtime.render_update(state.observation.dirty()).map(|mut update| {
+                state.observation.annotate_render_update(&mut update);
                 update
             });
             let _ = reply.send(result);
+        }
+        SessionCommand::FullSnapshot { reply } => {
+            let _ = reply.send(runtime.snapshot(DirtyState::Full));
         }
         SessionCommand::ImageResourceData { image_id, generation, mut callback, reply } => {
             let result = runtime.with_image_resource_data(image_id, generation, &mut callback);
             let _ = reply.send(result);
         }
+        SessionCommand::Inspect { has_controller, watcher_count, reply } => {
+            let _ = reply.send(runtime.inspect(has_controller, watcher_count));
+        }
+        SessionCommand::ApplyAttachState { cols, rows, capabilities, reply } => {
+            let cols = cols.max(1);
+            let rows = rows.max(1);
+            let result = runtime.apply_attach_state(cols, rows, &capabilities).inspect(|_| {
+                mark_full_and_wake(&mut state.observation, rows, wake);
+            });
+            let _ = reply.send(result);
+        }
+        SessionCommand::ReplayPayload { capabilities, reply } => {
+            let _ = reply.send(runtime.replay_payload(&capabilities));
+        }
+        SessionCommand::CaptureText { reply } => {
+            let _ = reply.send(runtime.capture_text());
+        }
+        SessionCommand::ValidateTextMatching { reply } => {
+            let _ = reply.send(runtime.validate_text_matching());
+        }
+        SessionCommand::ScreenContains { text, reply } => {
+            let _ = reply.send(runtime.screen_contains(&text));
+        }
+        SessionCommand::LastPtyOutputAt { reply } => {
+            let _ = reply.send(runtime.last_pty_output_at());
+        }
+        SessionCommand::FlushRecording { reply } => {
+            runtime.flush_recording();
+            let _ = reply.send(());
+        }
+        SessionCommand::RecordingActive { reply } => {
+            let _ = reply.send(runtime.recording_active());
+        }
+        SessionCommand::RecordAttach { reply } => {
+            runtime.record_attach();
+            let _ = reply.send(());
+        }
+        SessionCommand::RecordDetach { reply } => {
+            runtime.record_detach();
+            let _ = reply.send(());
+        }
+        SessionCommand::WriteInputWithMark { bytes, marker_name, reply } => {
+            let _ = reply.send(runtime.write_input_with_mark(&bytes, marker_name));
+        }
+        SessionCommand::PasteWithMark { text, marker_name, reply } => {
+            let result = runtime.encode_paste(&text).and_then(|bytes| runtime.write_input_with_mark(&bytes, marker_name));
+            let _ = reply.send(result);
+        }
+        SessionCommand::SetRecording { enable, reply } => {
+            let _ = reply.send(runtime.set_recording(enable));
+        }
+        SessionCommand::Mark { name, reply } => {
+            let _ = reply.send(runtime.mark(name));
+        }
+        SessionCommand::ResolveMarker { name, reply } => {
+            let _ = reply.send(runtime.resolve_marker(&name));
+        }
+        SessionCommand::ResolveNextMarker { after, reply } => {
+            let _ = reply.send(runtime.resolve_next_marker_after(after));
+        }
+        SessionCommand::DispatchSignal { signal, target, reply } => {
+            let _ = reply.send(runtime.dispatch_signal(signal, target));
+        }
+        SessionCommand::ExitCode { reply } => {
+            let _ = reply.send(state.exit_code);
+        }
+        SessionCommand::ShouldKeepSessionDir { reply } => {
+            let _ = reply.send(runtime.should_keep_session_dir());
+        }
         SessionCommand::MarkObserved { generation, reply } => {
-            let _ = reply.send(observation.mark_observed(generation));
+            let _ = reply.send(state.observation.mark_observed(generation));
         }
         SessionCommand::ScrollbackExtent { reply } => {
             let extent = runtime.scrollback_extent().unwrap_or_else(|_| TerminalScrollbackExtent {
@@ -829,53 +1043,46 @@ fn session_actor_handle_command(
             let _ = reply.send(scrollbar);
         }
         SessionCommand::SetClientPresence { active, reply } => {
-            *has_active_client = active;
+            state.has_active_client = active;
             let _ = reply.send(());
         }
         SessionCommand::SubscribeRawOutput { reply } => {
             let (tx, rx) = mpsc::sync_channel(RAW_OUTPUT_TAP_CHUNKS);
-            raw_output_taps.push(tx);
+            state.raw_output_taps.push(tx);
             let _ = reply.send(RawOutputTap { rx });
         }
         SessionCommand::Stop { terminate } => {
-            if terminate && !*exited {
+            if terminate && !state.exited {
                 let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
             }
             stop = true;
         }
     }
     if !stop {
-        session_actor_pump(runtime, observation, exited, *has_active_client, raw_output_taps, wake);
+        session_actor_pump(runtime, state, wake);
     }
     stop
 }
 
-fn session_actor_pump(
-    runtime: &mut SessionRuntime,
-    observation: &mut ObservationState,
-    exited: &mut bool,
-    has_active_client: bool,
-    raw_output_taps: &mut Vec<SyncSender<Vec<u8>>>,
-    wake: &WakeCallback,
-) {
-    match pump_session_runtime(runtime, exited, has_active_client) {
+fn session_actor_pump(runtime: &mut SessionRuntime, state: &mut SessionActorLoopState, wake: &WakeCallback) {
+    match pump_session_runtime(runtime, &mut state.exited, &mut state.exit_code, state.has_active_client) {
         Ok(result) => {
-            publish_raw_output(raw_output_taps, &result.chunks);
+            publish_raw_output(&mut state.raw_output_taps, &result.chunks);
             match result.outcome {
                 PumpOutcome::Clean => {}
-                PumpOutcome::PartialUnknown => mark_partial_unknown_and_wake(observation, wake),
+                PumpOutcome::PartialUnknown => mark_partial_unknown_and_wake(&mut state.observation, wake),
                 PumpOutcome::Full => {
                     let rows = runtime.inspect(false, 0).terminal.rows;
-                    mark_full_and_wake(observation, rows, wake);
+                    mark_full_and_wake(&mut state.observation, rows, wake);
                 }
             }
         }
         Err(_) => {
             let rows = runtime.inspect(false, 0).terminal.rows;
-            mark_full_and_wake(observation, rows, wake);
+            mark_full_and_wake(&mut state.observation, rows, wake);
         }
     }
-    sync_terminal_modes_and_wake(runtime, observation, wake);
+    sync_terminal_modes_and_wake(runtime, &mut state.observation, wake);
 }
 
 fn publish_raw_output(taps: &mut Vec<SyncSender<Vec<u8>>>, chunks: &[Vec<u8>]) {

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -1,10 +1,24 @@
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::{
+    io,
     sync::{
         atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering},
         mpsc, Arc,
     },
     thread,
-    time::Duration,
+};
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "linux"))))]
+use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
+#[cfg(target_os = "linux")]
+use nix::sys::epoll::{Epoll, EpollCreateFlags, EpollEvent, EpollFlags};
+#[cfg(target_os = "macos")]
+use nix::sys::event::{EvFlags, EventFilter, FilterFlag, KEvent, Kqueue};
+#[cfg(unix)]
+use nix::{
+    errno::Errno,
+    fcntl::{fcntl, FcntlArg, OFlag},
 };
 
 use crate::{
@@ -240,9 +254,243 @@ pub(crate) enum SessionCommand {
 }
 
 pub(crate) struct SessionActor {
-    tx: mpsc::Sender<SessionCommand>,
+    tx: CommandSender,
     observation: Arc<ObservationMirror>,
     worker: Option<thread::JoinHandle<()>>,
+}
+
+struct CommandSender {
+    tx: mpsc::Sender<SessionCommand>,
+    #[cfg(unix)]
+    wake: CommandWakeWriter,
+}
+
+impl CommandSender {
+    #[cfg(unix)]
+    fn new(tx: mpsc::Sender<SessionCommand>, wake: CommandWakeWriter) -> Self {
+        Self { tx, wake }
+    }
+
+    #[cfg(not(unix))]
+    fn new(tx: mpsc::Sender<SessionCommand>) -> Self {
+        Self { tx }
+    }
+
+    #[cfg(test)]
+    fn inert(tx: mpsc::Sender<SessionCommand>) -> Self {
+        Self {
+            tx,
+            #[cfg(unix)]
+            wake: CommandWakeWriter::noop(),
+        }
+    }
+
+    fn send(&self, command: SessionCommand) -> Result<(), mpsc::SendError<SessionCommand>> {
+        self.tx.send(command)?;
+        #[cfg(unix)]
+        self.wake.wake();
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+#[derive(Clone)]
+struct CommandWakeWriter {
+    fd: Option<Arc<OwnedFd>>,
+}
+
+#[cfg(unix)]
+impl CommandWakeWriter {
+    fn new(fd: OwnedFd) -> Self {
+        Self { fd: Some(Arc::new(fd)) }
+    }
+
+    #[cfg(test)]
+    fn noop() -> Self {
+        Self { fd: None }
+    }
+
+    fn wake(&self) {
+        let Some(fd) = &self.fd else {
+            return;
+        };
+        let byte = [1u8];
+        loop {
+            let written = unsafe { libc::write(fd.as_raw_fd(), byte.as_ptr().cast(), byte.len()) };
+            if written >= 0 {
+                return;
+            }
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return;
+        }
+    }
+}
+
+#[cfg(unix)]
+struct CommandWakeReader {
+    fd: OwnedFd,
+}
+
+#[cfg(unix)]
+impl CommandWakeReader {
+    fn drain(&self) {
+        let mut buf = [0u8; 64];
+        loop {
+            let read = unsafe { libc::read(self.fd.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len()) };
+            if read > 0 {
+                continue;
+            }
+            if read == 0 {
+                return;
+            }
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return;
+        }
+    }
+
+    fn raw_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+#[cfg(unix)]
+fn command_wake_pair() -> Result<(CommandWakeReader, CommandWakeWriter), String> {
+    let mut fds = [0; 2];
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+        return Err(format!("create actor command wake pipe: {}", io::Error::last_os_error()));
+    }
+    let read = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+    let write = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+    set_fd_nonblocking(read.as_raw_fd()).map_err(|err| format!("set actor command wake read nonblocking: {err}"))?;
+    set_fd_nonblocking(write.as_raw_fd()).map_err(|err| format!("set actor command wake write nonblocking: {err}"))?;
+    Ok((CommandWakeReader { fd: read }, CommandWakeWriter::new(write)))
+}
+
+#[cfg(unix)]
+fn set_fd_nonblocking(fd: RawFd) -> Result<(), Errno> {
+    let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
+    let flags = OFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFL)?);
+    fcntl(fd, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Default)]
+struct ActorReadiness {
+    pty_readable: bool,
+    command_readable: bool,
+}
+
+#[cfg(unix)]
+fn wait_actor_ready(pty_child: &PtyChild, command_fd: RawFd) -> Result<ActorReadiness, String> {
+    #[cfg(target_os = "macos")]
+    {
+        wait_actor_ready_kqueue(pty_child.master_fd(), command_fd)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        wait_actor_ready_epoll(pty_child.master_fd(), command_fd)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        wait_actor_ready_poll(pty_child.master_fd(), command_fd)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn wait_actor_ready_kqueue(pty_fd: RawFd, command_fd: RawFd) -> Result<ActorReadiness, String> {
+    const TOKEN_PTY: isize = 1;
+    const TOKEN_COMMAND: isize = 2;
+
+    let kqueue = Kqueue::new().map_err(|err| format!("create actor kqueue: {err}"))?;
+    let changes = [
+        KEvent::new(pty_fd as _, EventFilter::EVFILT_READ, EvFlags::EV_ADD, FilterFlag::empty(), 0, TOKEN_PTY),
+        KEvent::new(command_fd as _, EventFilter::EVFILT_READ, EvFlags::EV_ADD, FilterFlag::empty(), 0, TOKEN_COMMAND),
+    ];
+    let mut events = [KEvent::new(0, EventFilter::EVFILT_READ, EvFlags::empty(), FilterFlag::empty(), 0, 0); 2];
+    let event_count = loop {
+        match kqueue.kevent(&changes, &mut events, None) {
+            Ok(event_count) => break event_count,
+            Err(Errno::EINTR) => continue,
+            Err(err) => return Err(format!("kqueue actor fds: {err}")),
+        }
+    };
+
+    let mut readiness = ActorReadiness::default();
+    for event in events.iter().take(event_count) {
+        if event.flags().contains(EvFlags::EV_ERROR) {
+            if event.data() != 0 {
+                return Err(format!("kqueue actor fd registration: {}", Errno::from_raw(event.data() as i32)));
+            }
+            continue;
+        }
+        match event.udata() {
+            TOKEN_PTY => readiness.pty_readable = true,
+            TOKEN_COMMAND => readiness.command_readable = true,
+            _ => {}
+        }
+    }
+    Ok(readiness)
+}
+
+#[cfg(target_os = "linux")]
+fn wait_actor_ready_epoll(pty_fd: RawFd, command_fd: RawFd) -> Result<ActorReadiness, String> {
+    const TOKEN_PTY: u64 = 1;
+    const TOKEN_COMMAND: u64 = 2;
+
+    let epoll = Epoll::new(EpollCreateFlags::EPOLL_CLOEXEC).map_err(|err| format!("create actor epoll: {err}"))?;
+    epoll
+        .add(unsafe { std::os::fd::BorrowedFd::borrow_raw(pty_fd) }, EpollEvent::new(EpollFlags::EPOLLIN, TOKEN_PTY))
+        .map_err(|err| format!("register pty with actor epoll: {err}"))?;
+    epoll
+        .add(unsafe { std::os::fd::BorrowedFd::borrow_raw(command_fd) }, EpollEvent::new(EpollFlags::EPOLLIN, TOKEN_COMMAND))
+        .map_err(|err| format!("register command wake with actor epoll: {err}"))?;
+
+    let mut events = [EpollEvent::empty(); 2];
+    let event_count = loop {
+        match epoll.wait(&mut events, nix::poll::PollTimeout::NONE) {
+            Ok(event_count) => break event_count,
+            Err(Errno::EINTR) => continue,
+            Err(err) => return Err(format!("epoll actor fds: {err}")),
+        }
+    };
+
+    let mut readiness = ActorReadiness::default();
+    for event in events.iter().take(event_count) {
+        if event.events().contains(EpollFlags::EPOLLIN) {
+            match event.data() {
+                TOKEN_PTY => readiness.pty_readable = true,
+                TOKEN_COMMAND => readiness.command_readable = true,
+                _ => {}
+            }
+        }
+    }
+    Ok(readiness)
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "linux"))))]
+fn wait_actor_ready_poll(pty_fd: RawFd, command_fd: RawFd) -> Result<ActorReadiness, String> {
+    let mut fds = [
+        PollFd::new(unsafe { std::os::fd::BorrowedFd::borrow_raw(pty_fd) }, PollFlags::POLLIN),
+        PollFd::new(unsafe { std::os::fd::BorrowedFd::borrow_raw(command_fd) }, PollFlags::POLLIN),
+    ];
+    loop {
+        match poll(&mut fds, PollTimeout::NONE) {
+            Ok(_) => break,
+            Err(Errno::EINTR) => continue,
+            Err(err) => return Err(format!("poll actor fds: {err}")),
+        }
+    }
+    Ok(ActorReadiness {
+        pty_readable: fds[0].revents().unwrap_or_else(PollFlags::empty).contains(PollFlags::POLLIN),
+        command_readable: fds[1].revents().unwrap_or_else(PollFlags::empty).contains(PollFlags::POLLIN),
+    })
 }
 
 impl SessionActor {
@@ -254,13 +502,24 @@ impl SessionActor {
         let observation = Arc::new(ObservationMirror::new());
         let actor_observation = observation.clone();
         let (tx, rx) = mpsc::channel();
+        #[cfg(unix)]
+        let (command_wake_reader, command_wake_writer) = command_wake_pair()?;
         let (ready_tx, ready_rx) = mpsc::channel();
         let worker = thread::spawn(move || match build_runtime() {
-            Ok(runtime) => session_actor_loop(runtime, wake, rows, actor_observation, ready_tx, rx),
+            Ok(runtime) => {
+                #[cfg(unix)]
+                session_actor_loop(runtime, wake, rows, actor_observation, ready_tx, rx, command_wake_reader);
+                #[cfg(not(unix))]
+                session_actor_loop(runtime, wake, rows, actor_observation, ready_tx, rx);
+            }
             Err(err) => {
                 let _ = ready_tx.send(Err(err));
             }
         });
+        #[cfg(unix)]
+        let tx = CommandSender::new(tx, command_wake_writer);
+        #[cfg(not(unix))]
+        let tx = CommandSender::new(tx);
         match ready_rx.recv().map_err(|_| "session actor did not report startup".to_string())? {
             Ok(()) => Ok(Self { tx, observation, worker: Some(worker) }),
             Err(err) => {
@@ -276,7 +535,7 @@ impl SessionActor {
         observation: Arc<ObservationMirror>,
         worker: Option<thread::JoinHandle<()>>,
     ) -> Self {
-        Self { tx, observation, worker }
+        Self { tx: CommandSender::inert(tx), observation, worker }
     }
 
     pub(crate) fn observation(&self) -> &ObservationMirror {
@@ -369,12 +628,33 @@ fn session_actor_loop(
     mirror: Arc<ObservationMirror>,
     ready: mpsc::Sender<Result<(), String>>,
     rx: mpsc::Receiver<SessionCommand>,
+    #[cfg(unix)] command_wake: CommandWakeReader,
 ) {
     let mut observation = ObservationState::new_with_mirror(rows, Some(mirror));
     let mut exited = false;
     let _ = ready.send(Ok(()));
+    #[cfg(unix)]
     loop {
-        match rx.recv_timeout(Duration::from_millis(10)) {
+        let readiness = match wait_actor_ready(runtime.pty_child(), command_wake.raw_fd()) {
+            Ok(readiness) => readiness,
+            Err(_) => {
+                let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
+                break;
+            }
+        };
+        if readiness.command_readable {
+            command_wake.drain();
+            if drain_session_commands(&rx, &mut runtime, &mut observation, &mut exited, &wake) {
+                break;
+            }
+        }
+        if readiness.pty_readable {
+            session_actor_pump(&mut runtime, &mut observation, &mut exited, &wake);
+        }
+    }
+    #[cfg(not(unix))]
+    loop {
+        match rx.recv_timeout(std::time::Duration::from_millis(10)) {
             Ok(command) => {
                 if session_actor_handle_command(command, &mut runtime, &mut observation, &mut exited, &wake) {
                     break;
@@ -386,6 +666,29 @@ fn session_actor_loop(
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
                 break;
+            }
+        }
+    }
+}
+
+fn drain_session_commands(
+    rx: &mpsc::Receiver<SessionCommand>,
+    runtime: &mut SessionRuntime,
+    observation: &mut ObservationState,
+    exited: &mut bool,
+    wake: &WakeCallback,
+) -> bool {
+    loop {
+        match rx.try_recv() {
+            Ok(command) => {
+                if session_actor_handle_command(command, runtime, observation, exited, wake) {
+                    return true;
+                }
+            }
+            Err(mpsc::TryRecvError::Empty) => return false,
+            Err(mpsc::TryRecvError::Disconnected) => {
+                let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
+                return true;
             }
         }
     }
@@ -682,6 +985,3 @@ fn legacy_mouse_byte(value: u16) -> Option<u8> {
     let encoded = value.checked_add(32)?;
     u8::try_from(encoded).ok()
 }
-
-#[allow(dead_code)]
-fn _pty_child_anchor(_: &PtyChild) {}

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -4,7 +4,9 @@ use std::{
     io,
     sync::{
         atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering},
-        mpsc, Arc,
+        mpsc,
+        mpsc::{Receiver, SyncSender},
+        Arc,
     },
     thread,
 };
@@ -33,9 +35,22 @@ use crate::{
 };
 
 const POSIX_SIGTERM: i32 = 15;
+const RAW_OUTPUT_TAP_CHUNKS: usize = 64;
 
 pub(crate) type WakeCallback = Arc<dyn Fn() + Send + Sync + 'static>;
 pub(crate) type ImageResourceDataCallback = Box<dyn FnMut(&[u8]) -> bool + Send>;
+
+#[allow(dead_code)]
+pub(crate) struct RawOutputTap {
+    rx: Receiver<Vec<u8>>,
+}
+
+impl RawOutputTap {
+    #[allow(dead_code)]
+    pub(crate) fn try_recv(&self) -> Result<Vec<u8>, mpsc::TryRecvError> {
+        self.rx.try_recv()
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct ObservationState {
@@ -250,6 +265,8 @@ pub(crate) enum SessionCommand {
     MarkObserved { generation: u64, reply: mpsc::Sender<bool> },
     ScrollbackExtent { reply: mpsc::Sender<TerminalScrollbackExtent> },
     ScrollbarState { reply: mpsc::Sender<TerminalScrollbarState> },
+    SetClientPresence { active: bool, reply: mpsc::Sender<()> },
+    SubscribeRawOutput { reply: mpsc::Sender<RawOutputTap> },
     Stop { terminate: bool },
 }
 
@@ -558,6 +575,19 @@ impl SessionActor {
         self.tx.send(make_command(reply)).map_err(|_| "session actor is not running".to_string())?;
         recv.recv().map_err(|_| "session actor did not reply".to_string())?
     }
+
+    pub(crate) fn set_client_presence(&self, active: bool) -> Result<(), String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::SetClientPresence { active, reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn subscribe_raw_output(&self) -> Result<RawOutputTap, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(SessionCommand::SubscribeRawOutput { reply }).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())
+    }
 }
 
 impl Drop for SessionActor {
@@ -576,7 +606,12 @@ enum PumpOutcome {
     Full,
 }
 
-fn pump_session_runtime(runtime: &mut SessionRuntime, exited: &mut bool) -> Result<PumpOutcome, String> {
+struct PumpResult {
+    outcome: PumpOutcome,
+    chunks: Vec<Vec<u8>>,
+}
+
+fn pump_session_runtime(runtime: &mut SessionRuntime, exited: &mut bool, has_active_client: bool) -> Result<PumpResult, String> {
     let mut exited_now = false;
     if !*exited {
         if let Some(exit_code) = runtime.exit_code_if_exited()? {
@@ -586,19 +621,20 @@ fn pump_session_runtime(runtime: &mut SessionRuntime, exited: &mut bool) -> Resu
         }
     }
     let output = if exited_now {
-        runtime.drain_output_after_exit(false)?
+        runtime.drain_output_after_exit(has_active_client)?
     } else if *exited {
         PtyOutput { chunks: Vec::new() }
     } else {
-        runtime.read_available_output(false)?
+        runtime.read_available_output(has_active_client)?
     };
-    if exited_now {
-        Ok(PumpOutcome::Full)
+    let outcome = if exited_now {
+        PumpOutcome::Full
     } else if !output.chunks.is_empty() {
-        Ok(PumpOutcome::PartialUnknown)
+        PumpOutcome::PartialUnknown
     } else {
-        Ok(PumpOutcome::Clean)
-    }
+        PumpOutcome::Clean
+    };
+    Ok(PumpResult { outcome, chunks: output.chunks })
 }
 
 fn mark_full_and_wake(observation: &mut ObservationState, rows: u16, wake: &WakeCallback) {
@@ -632,6 +668,8 @@ fn session_actor_loop(
 ) {
     let mut observation = ObservationState::new_with_mirror(rows, Some(mirror));
     let mut exited = false;
+    let mut has_active_client = false;
+    let mut raw_output_taps = Vec::new();
     let _ = ready.send(Ok(()));
     #[cfg(unix)]
     loop {
@@ -644,24 +682,33 @@ fn session_actor_loop(
         };
         if readiness.command_readable {
             command_wake.drain();
-            if drain_session_commands(&rx, &mut runtime, &mut observation, &mut exited, &wake) {
+            if drain_session_commands(&rx, &mut runtime, &mut observation, &mut exited, &mut has_active_client, &mut raw_output_taps, &wake)
+            {
                 break;
             }
         }
         if readiness.pty_readable {
-            session_actor_pump(&mut runtime, &mut observation, &mut exited, &wake);
+            session_actor_pump(&mut runtime, &mut observation, &mut exited, has_active_client, &mut raw_output_taps, &wake);
         }
     }
     #[cfg(not(unix))]
     loop {
         match rx.recv_timeout(std::time::Duration::from_millis(10)) {
             Ok(command) => {
-                if session_actor_handle_command(command, &mut runtime, &mut observation, &mut exited, &wake) {
+                if session_actor_handle_command(
+                    command,
+                    &mut runtime,
+                    &mut observation,
+                    &mut exited,
+                    &mut has_active_client,
+                    &mut raw_output_taps,
+                    &wake,
+                ) {
                     break;
                 }
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                session_actor_pump(&mut runtime, &mut observation, &mut exited, &wake);
+                session_actor_pump(&mut runtime, &mut observation, &mut exited, has_active_client, &mut raw_output_taps, &wake);
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
@@ -676,12 +723,14 @@ fn drain_session_commands(
     runtime: &mut SessionRuntime,
     observation: &mut ObservationState,
     exited: &mut bool,
+    has_active_client: &mut bool,
+    raw_output_taps: &mut Vec<SyncSender<Vec<u8>>>,
     wake: &WakeCallback,
 ) -> bool {
     loop {
         match rx.try_recv() {
             Ok(command) => {
-                if session_actor_handle_command(command, runtime, observation, exited, wake) {
+                if session_actor_handle_command(command, runtime, observation, exited, has_active_client, raw_output_taps, wake) {
                     return true;
                 }
             }
@@ -699,6 +748,8 @@ fn session_actor_handle_command(
     runtime: &mut SessionRuntime,
     observation: &mut ObservationState,
     exited: &mut bool,
+    has_active_client: &mut bool,
+    raw_output_taps: &mut Vec<SyncSender<Vec<u8>>>,
     wake: &WakeCallback,
 ) -> bool {
     let mut stop = false;
@@ -777,6 +828,15 @@ fn session_actor_handle_command(
             });
             let _ = reply.send(scrollbar);
         }
+        SessionCommand::SetClientPresence { active, reply } => {
+            *has_active_client = active;
+            let _ = reply.send(());
+        }
+        SessionCommand::SubscribeRawOutput { reply } => {
+            let (tx, rx) = mpsc::sync_channel(RAW_OUTPUT_TAP_CHUNKS);
+            raw_output_taps.push(tx);
+            let _ = reply.send(RawOutputTap { rx });
+        }
         SessionCommand::Stop { terminate } => {
             if terminate && !*exited {
                 let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
@@ -785,21 +845,51 @@ fn session_actor_handle_command(
         }
     }
     if !stop {
-        session_actor_pump(runtime, observation, exited, wake);
+        session_actor_pump(runtime, observation, exited, *has_active_client, raw_output_taps, wake);
     }
     stop
 }
 
-fn session_actor_pump(runtime: &mut SessionRuntime, observation: &mut ObservationState, exited: &mut bool, wake: &WakeCallback) {
-    match pump_session_runtime(runtime, exited) {
-        Ok(PumpOutcome::Clean) => {}
-        Ok(PumpOutcome::PartialUnknown) => mark_partial_unknown_and_wake(observation, wake),
-        Ok(PumpOutcome::Full) | Err(_) => {
+fn session_actor_pump(
+    runtime: &mut SessionRuntime,
+    observation: &mut ObservationState,
+    exited: &mut bool,
+    has_active_client: bool,
+    raw_output_taps: &mut Vec<SyncSender<Vec<u8>>>,
+    wake: &WakeCallback,
+) {
+    match pump_session_runtime(runtime, exited, has_active_client) {
+        Ok(result) => {
+            publish_raw_output(raw_output_taps, &result.chunks);
+            match result.outcome {
+                PumpOutcome::Clean => {}
+                PumpOutcome::PartialUnknown => mark_partial_unknown_and_wake(observation, wake),
+                PumpOutcome::Full => {
+                    let rows = runtime.inspect(false, 0).terminal.rows;
+                    mark_full_and_wake(observation, rows, wake);
+                }
+            }
+        }
+        Err(_) => {
             let rows = runtime.inspect(false, 0).terminal.rows;
             mark_full_and_wake(observation, rows, wake);
         }
     }
     sync_terminal_modes_and_wake(runtime, observation, wake);
+}
+
+fn publish_raw_output(taps: &mut Vec<SyncSender<Vec<u8>>>, chunks: &[Vec<u8>]) {
+    if chunks.is_empty() || taps.is_empty() {
+        return;
+    }
+    taps.retain(|tap| {
+        for chunk in chunks {
+            if tap.try_send(chunk.clone()).is_err() {
+                return false;
+            }
+        }
+        true
+    });
 }
 
 fn route_paste_on_actor(runtime: &mut SessionRuntime, text: &[u8]) -> Result<usize, String> {

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -1,0 +1,687 @@
+use std::{
+    sync::{
+        atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering},
+        mpsc, Arc,
+    },
+    thread,
+    time::Duration,
+};
+
+use crate::{
+    platform::pty::PtyChild,
+    protocol::SignalTarget,
+    provider::{
+        DirtyState, TerminalRenderUpdate, TerminalScrollbackExtent, TerminalScrollbarState, TerminalSnapshot, TerminalViewportKind,
+        ViewportCommand, ViewportCommandOutcome,
+    },
+    session_runtime::{PtyOutput, SessionRuntime},
+    vt,
+};
+
+const POSIX_SIGTERM: i32 = 15;
+
+pub(crate) type WakeCallback = Arc<dyn Fn() + Send + Sync + 'static>;
+pub(crate) type ImageResourceDataCallback = Box<dyn FnMut(&[u8]) -> bool + Send>;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ObservationState {
+    pub(crate) render_generation: u64,
+    pub(crate) observed_generation: u64,
+    dirty: DirtyState,
+    dirty_rows: Vec<u16>,
+    terminal_modes: Option<vt::TerminalModeState>,
+    mirror: Option<Arc<ObservationMirror>>,
+}
+
+impl ObservationState {
+    pub(crate) fn new(rows: u16) -> Self {
+        Self::new_with_mirror(rows, None)
+    }
+
+    pub(crate) fn new_with_mirror(rows: u16, mirror: Option<Arc<ObservationMirror>>) -> Self {
+        let mut state = Self {
+            render_generation: 0,
+            observed_generation: 0,
+            dirty: DirtyState::Clean,
+            dirty_rows: Vec::new(),
+            terminal_modes: None,
+            mirror,
+        };
+        state.mark_full(rows);
+        state
+    }
+
+    pub(crate) fn dirty(&self) -> DirtyState {
+        if self.render_generation > self.observed_generation {
+            self.dirty
+        } else {
+            DirtyState::Clean
+        }
+    }
+
+    pub(crate) fn mark_full(&mut self, _rows: u16) -> bool {
+        let was_clean = self.dirty() == DirtyState::Clean;
+        self.render_generation = self.render_generation.saturating_add(1);
+        self.dirty = DirtyState::Full;
+        self.dirty_rows.clear();
+        self.publish_mirror();
+        was_clean
+    }
+
+    pub(crate) fn mark_partial_rows(&mut self, rows: impl IntoIterator<Item = u16>) -> bool {
+        let was_clean = self.dirty() == DirtyState::Clean;
+        self.render_generation = self.render_generation.saturating_add(1);
+        if self.dirty != DirtyState::Full {
+            self.dirty = DirtyState::Partial;
+            for row in rows {
+                if !self.dirty_rows.contains(&row) {
+                    self.dirty_rows.push(row);
+                }
+            }
+            self.dirty_rows.sort_unstable();
+        }
+        self.publish_mirror();
+        was_clean
+    }
+
+    pub(crate) fn mark_partial_unknown(&mut self) -> bool {
+        let was_clean = self.dirty() == DirtyState::Clean;
+        self.render_generation = self.render_generation.saturating_add(1);
+        if self.dirty != DirtyState::Full {
+            self.dirty = DirtyState::Partial;
+            self.dirty_rows.clear();
+        }
+        self.publish_mirror();
+        was_clean
+    }
+
+    pub(crate) fn sync_terminal_modes(&mut self, terminal_modes: vt::TerminalModeState) -> bool {
+        let previous = self.terminal_modes.replace(terminal_modes);
+        match previous {
+            None => false,
+            Some(previous) if previous == terminal_modes => false,
+            Some(_) => self.mark_partial_unknown(),
+        }
+    }
+
+    pub(crate) fn mark_observed(&mut self, generation: u64) -> bool {
+        if generation > self.render_generation {
+            return false;
+        }
+        self.observed_generation = self.observed_generation.max(generation);
+        if self.observed_generation >= self.render_generation {
+            self.dirty = DirtyState::Clean;
+            self.dirty_rows.clear();
+        }
+        self.publish_mirror();
+        true
+    }
+
+    pub(crate) fn annotate_snapshot(&self, snapshot: &mut TerminalSnapshot) {
+        snapshot.render_generation = self.render_generation;
+        snapshot.dirty = self.dirty();
+        snapshot.dirty_rows = if snapshot.dirty == DirtyState::Partial {
+            if self.dirty_rows.is_empty() {
+                snapshot.dirty_rows.clone()
+            } else {
+                self.dirty_rows.clone()
+            }
+        } else {
+            Vec::new()
+        };
+    }
+
+    pub(crate) fn annotate_render_update(&self, update: &mut TerminalRenderUpdate) {
+        update.render_generation = self.render_generation;
+        let dirty = self.dirty();
+        if dirty == DirtyState::Clean {
+            update.dirty = DirtyState::Clean;
+            update.ops.clear();
+        } else if update.dirty == DirtyState::Clean {
+            update.dirty = dirty;
+        }
+    }
+
+    fn publish_mirror(&self) {
+        if let Some(mirror) = &self.mirror {
+            mirror.store(self.render_generation, self.observed_generation, self.dirty);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ObservationMirror {
+    render_generation: AtomicU64,
+    observed_generation: AtomicU64,
+    dirty: AtomicU8,
+}
+
+impl ObservationMirror {
+    pub(crate) fn new() -> Self {
+        Self {
+            render_generation: AtomicU64::new(0),
+            observed_generation: AtomicU64::new(0),
+            dirty: AtomicU8::new(dirty_state_to_u8(DirtyState::Clean)),
+        }
+    }
+
+    pub(crate) fn store(&self, render_generation: u64, observed_generation: u64, dirty: DirtyState) {
+        self.dirty.store(dirty_state_to_u8(dirty), AtomicOrdering::SeqCst);
+        self.observed_generation.store(observed_generation, AtomicOrdering::SeqCst);
+        self.render_generation.store(render_generation, AtomicOrdering::SeqCst);
+    }
+
+    pub(crate) fn dirty(&self) -> DirtyState {
+        let render_generation = self.render_generation.load(AtomicOrdering::SeqCst);
+        let observed_generation = self.observed_generation.load(AtomicOrdering::SeqCst);
+        if render_generation > observed_generation {
+            dirty_state_from_u8(self.dirty.load(AtomicOrdering::SeqCst))
+        } else {
+            DirtyState::Clean
+        }
+    }
+}
+
+fn dirty_state_to_u8(dirty: DirtyState) -> u8 {
+    match dirty {
+        DirtyState::Clean => 0,
+        DirtyState::Partial => 1,
+        DirtyState::Full => 2,
+    }
+}
+
+fn dirty_state_from_u8(value: u8) -> DirtyState {
+    match value {
+        1 => DirtyState::Partial,
+        2 => DirtyState::Full,
+        _ => {
+            debug_assert_eq!(value, 0, "unexpected DirtyState byte");
+            DirtyState::Clean
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SessionWheelEvent {
+    pub(crate) modifiers: vt::MouseModifiers,
+    pub(crate) cell_col: u16,
+    pub(crate) cell_row: u16,
+    pub(crate) x_px: f32,
+    pub(crate) y_px: f32,
+    pub(crate) wheel_delta_x: f32,
+    pub(crate) wheel_delta_y: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SessionMouseEvent {
+    pub(crate) action: vt::MouseAction,
+    pub(crate) button: Option<vt::MouseButton>,
+    pub(crate) any_button_pressed: bool,
+    pub(crate) modifiers: vt::MouseModifiers,
+    pub(crate) x_px: f32,
+    pub(crate) y_px: f32,
+}
+
+pub(crate) enum SessionCommand {
+    Resize { cols: u16, rows: u16, reply: mpsc::Sender<Result<(), String>> },
+    SetCellSize { cell_width_px: u32, cell_height_px: u32, reply: mpsc::Sender<Result<(), String>> },
+    WriteInput { bytes: Vec<u8>, reply: mpsc::Sender<Result<(), String>> },
+    Wheel { event: SessionWheelEvent, reply: mpsc::Sender<Result<usize, String>> },
+    Mouse { event: SessionMouseEvent, reply: mpsc::Sender<Result<usize, String>> },
+    Paste { text: Vec<u8>, reply: mpsc::Sender<Result<usize, String>> },
+    ScrollViewport { command: ViewportCommand, reply: mpsc::Sender<Result<ViewportCommandOutcome, String>> },
+    Snapshot { reply: mpsc::Sender<Result<TerminalSnapshot, String>> },
+    RenderUpdate { reply: mpsc::Sender<Result<TerminalRenderUpdate, String>> },
+    ImageResourceData { image_id: u32, generation: u64, callback: ImageResourceDataCallback, reply: mpsc::Sender<Result<bool, String>> },
+    MarkObserved { generation: u64, reply: mpsc::Sender<bool> },
+    ScrollbackExtent { reply: mpsc::Sender<TerminalScrollbackExtent> },
+    ScrollbarState { reply: mpsc::Sender<TerminalScrollbarState> },
+    Stop { terminate: bool },
+}
+
+pub(crate) struct SessionActor {
+    tx: mpsc::Sender<SessionCommand>,
+    observation: Arc<ObservationMirror>,
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+impl SessionActor {
+    pub(crate) fn spawn(
+        rows: u16,
+        wake: WakeCallback,
+        build_runtime: impl FnOnce() -> Result<SessionRuntime, String> + Send + 'static,
+    ) -> Result<Self, String> {
+        let observation = Arc::new(ObservationMirror::new());
+        let actor_observation = observation.clone();
+        let (tx, rx) = mpsc::channel();
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let worker = thread::spawn(move || match build_runtime() {
+            Ok(runtime) => session_actor_loop(runtime, wake, rows, actor_observation, ready_tx, rx),
+            Err(err) => {
+                let _ = ready_tx.send(Err(err));
+            }
+        });
+        match ready_rx.recv().map_err(|_| "session actor did not report startup".to_string())? {
+            Ok(()) => Ok(Self { tx, observation, worker: Some(worker) }),
+            Err(err) => {
+                let _ = worker.join();
+                Err(err)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_parts(
+        tx: mpsc::Sender<SessionCommand>,
+        observation: Arc<ObservationMirror>,
+        worker: Option<thread::JoinHandle<()>>,
+    ) -> Self {
+        Self { tx, observation, worker }
+    }
+
+    pub(crate) fn observation(&self) -> &ObservationMirror {
+        &self.observation
+    }
+
+    pub(crate) fn request<T>(&self, make_command: impl FnOnce(mpsc::Sender<T>) -> SessionCommand, fallback: T) -> T {
+        let (reply, recv) = mpsc::channel();
+        if self.tx.send(make_command(reply)).is_err() {
+            return fallback;
+        }
+        recv.recv().unwrap_or(fallback)
+    }
+
+    pub(crate) fn request_result<T>(
+        &self,
+        make_command: impl FnOnce(mpsc::Sender<Result<T, String>>) -> SessionCommand,
+    ) -> Result<T, String> {
+        let (reply, recv) = mpsc::channel();
+        self.tx.send(make_command(reply)).map_err(|_| "session actor is not running".to_string())?;
+        recv.recv().map_err(|_| "session actor did not reply".to_string())?
+    }
+}
+
+impl Drop for SessionActor {
+    fn drop(&mut self) {
+        let _ = self.tx.send(SessionCommand::Stop { terminate: true });
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PumpOutcome {
+    Clean,
+    PartialUnknown,
+    Full,
+}
+
+fn pump_session_runtime(runtime: &mut SessionRuntime, exited: &mut bool) -> Result<PumpOutcome, String> {
+    let mut exited_now = false;
+    if !*exited {
+        if let Some(exit_code) = runtime.exit_code_if_exited()? {
+            runtime.record_exit_code(exit_code);
+            *exited = true;
+            exited_now = true;
+        }
+    }
+    let output = if exited_now {
+        runtime.drain_output_after_exit(false)?
+    } else if *exited {
+        PtyOutput { chunks: Vec::new() }
+    } else {
+        runtime.read_available_output(false)?
+    };
+    if exited_now {
+        Ok(PumpOutcome::Full)
+    } else if !output.chunks.is_empty() {
+        Ok(PumpOutcome::PartialUnknown)
+    } else {
+        Ok(PumpOutcome::Clean)
+    }
+}
+
+fn mark_full_and_wake(observation: &mut ObservationState, rows: u16, wake: &WakeCallback) {
+    if observation.mark_full(rows) {
+        wake();
+    }
+}
+
+fn mark_partial_unknown_and_wake(observation: &mut ObservationState, wake: &WakeCallback) {
+    if observation.mark_partial_unknown() {
+        wake();
+    }
+}
+
+fn sync_terminal_modes_and_wake(runtime: &SessionRuntime, observation: &mut ObservationState, wake: &WakeCallback) {
+    if let Ok(terminal_modes) = runtime.terminal_mode_state() {
+        if observation.sync_terminal_modes(terminal_modes) {
+            wake();
+        }
+    }
+}
+
+fn session_actor_loop(
+    mut runtime: SessionRuntime,
+    wake: WakeCallback,
+    rows: u16,
+    mirror: Arc<ObservationMirror>,
+    ready: mpsc::Sender<Result<(), String>>,
+    rx: mpsc::Receiver<SessionCommand>,
+) {
+    let mut observation = ObservationState::new_with_mirror(rows, Some(mirror));
+    let mut exited = false;
+    let _ = ready.send(Ok(()));
+    loop {
+        match rx.recv_timeout(Duration::from_millis(10)) {
+            Ok(command) => {
+                if session_actor_handle_command(command, &mut runtime, &mut observation, &mut exited, &wake) {
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                session_actor_pump(&mut runtime, &mut observation, &mut exited, &wake);
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
+                break;
+            }
+        }
+    }
+}
+
+fn session_actor_handle_command(
+    command: SessionCommand,
+    runtime: &mut SessionRuntime,
+    observation: &mut ObservationState,
+    exited: &mut bool,
+    wake: &WakeCallback,
+) -> bool {
+    let mut stop = false;
+    match command {
+        SessionCommand::Resize { cols, rows, reply } => {
+            let cols = cols.max(1);
+            let rows = rows.max(1);
+            let result = runtime.resize(cols, rows).map(|_| {
+                mark_full_and_wake(observation, rows, wake);
+            });
+            let _ = reply.send(result);
+        }
+        SessionCommand::SetCellSize { cell_width_px, cell_height_px, reply } => {
+            let result = runtime.set_cell_size(cell_width_px, cell_height_px).map(|_| {
+                let rows = runtime.inspect(false, 0).terminal.rows;
+                mark_full_and_wake(observation, rows, wake);
+            });
+            let _ = reply.send(result);
+        }
+        SessionCommand::WriteInput { bytes, reply } => {
+            let _ = reply.send(runtime.write_input(&bytes));
+        }
+        SessionCommand::Wheel { event, reply } => {
+            let result = route_wheel_event_on_actor(wake, runtime, observation, event);
+            let _ = reply.send(result);
+        }
+        SessionCommand::Mouse { event, reply } => {
+            let _ = reply.send(route_mouse_event_on_actor(runtime, event));
+        }
+        SessionCommand::Paste { text, reply } => {
+            let _ = reply.send(route_paste_on_actor(runtime, &text));
+        }
+        SessionCommand::ScrollViewport { command, reply } => {
+            let result = runtime.scroll_viewport(command).inspect(|outcome| {
+                if *outcome == ViewportCommandOutcome::Moved {
+                    let rows = runtime.inspect(false, 0).terminal.rows;
+                    mark_full_and_wake(observation, rows, wake);
+                }
+            });
+            let _ = reply.send(result);
+        }
+        SessionCommand::Snapshot { reply } => {
+            sync_terminal_modes_and_wake(runtime, observation, wake);
+            let result = runtime.snapshot(observation.dirty()).map(|mut snapshot| {
+                observation.annotate_snapshot(&mut snapshot);
+                snapshot
+            });
+            let _ = reply.send(result);
+        }
+        SessionCommand::RenderUpdate { reply } => {
+            sync_terminal_modes_and_wake(runtime, observation, wake);
+            let result = runtime.render_update(observation.dirty()).map(|mut update| {
+                observation.annotate_render_update(&mut update);
+                update
+            });
+            let _ = reply.send(result);
+        }
+        SessionCommand::ImageResourceData { image_id, generation, mut callback, reply } => {
+            let result = runtime.with_image_resource_data(image_id, generation, &mut callback);
+            let _ = reply.send(result);
+        }
+        SessionCommand::MarkObserved { generation, reply } => {
+            let _ = reply.send(observation.mark_observed(generation));
+        }
+        SessionCommand::ScrollbackExtent { reply } => {
+            let extent = runtime.scrollback_extent().unwrap_or_else(|_| TerminalScrollbackExtent {
+                normal_scrollback_rows: 0,
+                live_rows: runtime.inspect(false, 0).terminal.rows,
+                alternate_screen: false,
+            });
+            let _ = reply.send(extent);
+        }
+        SessionCommand::ScrollbarState { reply } => {
+            let scrollbar = runtime.scrollbar_state().unwrap_or_else(|_| {
+                TerminalScrollbarState::for_live_viewport(TerminalViewportKind::LiveNormal, runtime.inspect(false, 0).terminal.rows)
+            });
+            let _ = reply.send(scrollbar);
+        }
+        SessionCommand::Stop { terminate } => {
+            if terminate && !*exited {
+                let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
+            }
+            stop = true;
+        }
+    }
+    if !stop {
+        session_actor_pump(runtime, observation, exited, wake);
+    }
+    stop
+}
+
+fn session_actor_pump(runtime: &mut SessionRuntime, observation: &mut ObservationState, exited: &mut bool, wake: &WakeCallback) {
+    match pump_session_runtime(runtime, exited) {
+        Ok(PumpOutcome::Clean) => {}
+        Ok(PumpOutcome::PartialUnknown) => mark_partial_unknown_and_wake(observation, wake),
+        Ok(PumpOutcome::Full) | Err(_) => {
+            let rows = runtime.inspect(false, 0).terminal.rows;
+            mark_full_and_wake(observation, rows, wake);
+        }
+    }
+    sync_terminal_modes_and_wake(runtime, observation, wake);
+}
+
+fn route_paste_on_actor(runtime: &mut SessionRuntime, text: &[u8]) -> Result<usize, String> {
+    let bytes = runtime.encode_paste(text)?;
+    if bytes.is_empty() {
+        return Ok(0);
+    }
+    runtime.write_input(&bytes)?;
+    Ok(1)
+}
+
+fn route_mouse_event_on_actor(runtime: &mut SessionRuntime, event: SessionMouseEvent) -> Result<usize, String> {
+    let bytes = runtime.encode_mouse(event.action, event.button, event.any_button_pressed, event.modifiers, event.x_px, event.y_px)?;
+    if bytes.is_empty() {
+        return Ok(0);
+    }
+    runtime.write_input(&bytes)?;
+    Ok(1)
+}
+
+fn route_wheel_event_on_actor(
+    wake: &WakeCallback,
+    runtime: &mut SessionRuntime,
+    observation: &mut ObservationState,
+    event: SessionWheelEvent,
+) -> Result<usize, String> {
+    let modes = runtime.terminal_mode_state()?;
+    if modes.mouse_tracking {
+        let bytes = mouse_report_bytes_from_wheel(event, modes).ok_or_else(|| "mouse wheel event cannot be encoded".to_string())?;
+        if bytes.is_empty() {
+            return Ok(0);
+        }
+        runtime.write_input(&bytes)?;
+        return Ok(1);
+    }
+
+    if modes.active_alternate_screen && modes.alternate_scroll {
+        let bytes = alternate_scroll_cursor_bytes_from_wheel(event, modes);
+        if bytes.is_empty() {
+            return Ok(0);
+        }
+        runtime.write_input(&bytes)?;
+        return Ok(1);
+    }
+
+    let delta_rows = viewport_delta_rows_from_wheel(event);
+    if delta_rows == 0 {
+        return Ok(0);
+    }
+    match runtime.scroll_viewport(ViewportCommand::DeltaRows(delta_rows)) {
+        Ok(ViewportCommandOutcome::Moved) => {
+            let rows = runtime.inspect(false, 0).terminal.rows;
+            mark_full_and_wake(observation, rows, wake);
+            Ok(0)
+        }
+        Ok(ViewportCommandOutcome::NoOp | ViewportCommandOutcome::Unsupported) => Ok(0),
+        Err(err) => Err(err),
+    }
+}
+
+fn wheel_tick_count(delta: f32) -> usize {
+    if !delta.is_finite() {
+        return 0;
+    }
+    let rounded = delta.round().abs();
+    if rounded == 0.0 {
+        0
+    } else if rounded > usize::MAX as f32 {
+        usize::MAX
+    } else {
+        rounded as usize
+    }
+}
+
+fn viewport_delta_rows_from_wheel(event: SessionWheelEvent) -> i64 {
+    if !event.wheel_delta_y.is_finite() {
+        return 0;
+    }
+    let rounded = event.wheel_delta_y.round();
+    if rounded == 0.0 {
+        return 0;
+    }
+    let rows = if rounded > i64::MAX as f32 {
+        i64::MAX
+    } else if rounded < i64::MIN as f32 {
+        i64::MIN
+    } else {
+        rounded as i64
+    };
+    rows.saturating_neg()
+}
+
+pub(crate) fn alternate_scroll_cursor_bytes_from_wheel(event: SessionWheelEvent, modes: vt::TerminalModeState) -> Vec<u8> {
+    let count = wheel_tick_count(event.wheel_delta_y);
+    if count == 0 {
+        return Vec::new();
+    }
+    let seq = if event.wheel_delta_y.is_sign_positive() {
+        if modes.application_cursor_keys {
+            b"\x1bOA".as_slice()
+        } else {
+            b"\x1b[A".as_slice()
+        }
+    } else if modes.application_cursor_keys {
+        b"\x1bOB".as_slice()
+    } else {
+        b"\x1b[B".as_slice()
+    };
+    seq.repeat(count)
+}
+
+pub(crate) fn mouse_report_bytes_from_wheel(event: SessionWheelEvent, modes: vt::TerminalModeState) -> Option<Vec<u8>> {
+    let y_count = wheel_tick_count(event.wheel_delta_y);
+    let x_count = wheel_tick_count(event.wheel_delta_x);
+    if y_count == 0 && x_count == 0 {
+        return Some(Vec::new());
+    }
+
+    let mut out = Vec::new();
+    let modifiers = mouse_report_modifier_code(event.modifiers);
+    if y_count > 0 {
+        let button = if event.wheel_delta_y.is_sign_positive() { 64 } else { 65 } + modifiers;
+        append_mouse_report(&mut out, button, y_count, event, modes)?;
+    }
+    if x_count > 0 {
+        let button = if event.wheel_delta_x.is_sign_positive() { 66 } else { 67 } + modifiers;
+        append_mouse_report(&mut out, button, x_count, event, modes)?;
+    }
+    Some(out)
+}
+
+fn append_mouse_report(
+    out: &mut Vec<u8>,
+    button_code: u16,
+    count: usize,
+    event: SessionWheelEvent,
+    modes: vt::TerminalModeState,
+) -> Option<()> {
+    let (x, y) = if modes.mouse_sgr_pixels {
+        (one_based_coordinate(event.x_px), one_based_coordinate(event.y_px))
+    } else {
+        (u32::from(event.cell_col) + 1, u32::from(event.cell_row) + 1)
+    };
+
+    for _ in 0..count {
+        if modes.mouse_sgr || modes.mouse_sgr_pixels {
+            out.extend_from_slice(format!("\x1b[<{button_code};{x};{y}M").as_bytes());
+        } else {
+            let b = legacy_mouse_byte(button_code)?;
+            let x = legacy_mouse_byte(u16::try_from(x).ok()?)?;
+            let y = legacy_mouse_byte(u16::try_from(y).ok()?)?;
+            out.extend_from_slice(&[b'\x1b', b'[', b'M', b, x, y]);
+        }
+    }
+    Some(())
+}
+
+fn mouse_report_modifier_code(modifiers: vt::MouseModifiers) -> u16 {
+    let mut code = 0;
+    if modifiers.shift {
+        code += 4;
+    }
+    if modifiers.alt {
+        code += 8;
+    }
+    if modifiers.ctrl {
+        code += 16;
+    }
+    code
+}
+
+fn one_based_coordinate(value: f32) -> u32 {
+    if !value.is_finite() || value <= 0.0 {
+        1
+    } else if value >= u32::MAX as f32 {
+        u32::MAX
+    } else {
+        value.round() as u32 + 1
+    }
+}
+
+fn legacy_mouse_byte(value: u16) -> Option<u8> {
+    let encoded = value.checked_add(32)?;
+    u8::try_from(encoded).ok()
+}
+
+#[allow(dead_code)]
+fn _pty_child_anchor(_: &PtyChild) {}

--- a/crates/cleat/src/host/mod.rs
+++ b/crates/cleat/src/host/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod actor;

--- a/crates/cleat/src/lib.rs
+++ b/crates/cleat/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cast_reader;
 pub mod cli;
 pub mod da;
 pub mod duration_parser;
+mod host;
 mod http_uds;
 pub mod keys;
 pub mod platform;

--- a/crates/cleat/src/platform/ipc/unix.rs
+++ b/crates/cleat/src/platform/ipc/unix.rs
@@ -27,6 +27,10 @@ pub fn set_stream_read_timeout(stream: &SessionStream, timeout: Option<Duration>
     stream.set_read_timeout(timeout).map_err(|err| format!("set stream read timeout: {err}"))
 }
 
+pub fn set_stream_write_timeout(stream: &SessionStream, timeout: Option<Duration>) -> Result<(), String> {
+    stream.set_write_timeout(timeout).map_err(|err| format!("set stream write timeout: {err}"))
+}
+
 pub fn shutdown_stream(stream: &SessionStream) {
     let _ = stream.shutdown(Shutdown::Both);
 }

--- a/crates/cleat/src/platform/ipc/unsupported.rs
+++ b/crates/cleat/src/platform/ipc/unsupported.rs
@@ -56,6 +56,10 @@ pub fn set_stream_read_timeout(_stream: &SessionStream, _timeout: Option<Duratio
     Err("session IPC stream is only supported on Unix".to_string())
 }
 
+pub fn set_stream_write_timeout(_stream: &SessionStream, _timeout: Option<Duration>) -> Result<(), String> {
+    Err("session IPC stream is only supported on Unix".to_string())
+}
+
 pub fn shutdown_stream(_stream: &SessionStream) {}
 
 fn unsupported_io() -> io::Error {

--- a/crates/cleat/src/platform/ipc/windows.rs
+++ b/crates/cleat/src/platform/ipc/windows.rs
@@ -139,6 +139,10 @@ pub fn set_stream_read_timeout(_stream: &SessionStream, _timeout: Option<Duratio
     Ok(())
 }
 
+pub fn set_stream_write_timeout(_stream: &SessionStream, _timeout: Option<Duration>) -> Result<(), String> {
+    Ok(())
+}
+
 pub fn shutdown_stream(stream: &SessionStream) {
     unsafe {
         CancelIoEx(stream.handle, null_mut());

--- a/crates/cleat/src/platform/unix.rs
+++ b/crates/cleat/src/platform/unix.rs
@@ -32,6 +32,7 @@ use crate::{
 };
 
 const STRIP_ENV_VARS: &[&str] = &["SSH_TTY", "SSH_CONNECTION", "SSH_CLIENT"];
+const PTY_WRITE_READY_TIMEOUT_MS: i32 = 250;
 
 pub struct PtyChild {
     master_fd: RawFd,
@@ -422,6 +423,7 @@ fn read_fd(fd: RawFd, buf: &mut [u8]) -> Result<usize, io::Error> {
 fn write_fd_all(fd: RawFd, mut bytes: &[u8]) -> Result<(), String> {
     while !bytes.is_empty() {
         match nix_write(borrow_raw(fd), bytes) {
+            Ok(0) => return Err("write pty input: wrote zero bytes".to_string()),
             Ok(written) => bytes = &bytes[written..],
             Err(err) => {
                 let err = io::Error::from(err);
@@ -438,8 +440,15 @@ fn write_fd_all(fd: RawFd, mut bytes: &[u8]) -> Result<(), String> {
 
 fn wait_for_writable(fd: RawFd) -> Result<(), String> {
     let mut fds = [PollFd::new(borrow_raw(fd), PollFlags::POLLOUT)];
-    poll(&mut fds, PollTimeout::NONE).map_err(|err| format!("poll writable pty fd: {err}"))?;
-    Ok(())
+    let timeout = PollTimeout::try_from(PTY_WRITE_READY_TIMEOUT_MS).map_err(|err| format!("invalid pty write timeout: {err}"))?;
+    loop {
+        match poll(&mut fds, timeout) {
+            Ok(0) => return Err("timed out waiting for pty to become writable".to_string()),
+            Ok(_) => return Ok(()),
+            Err(Errno::EINTR) => continue,
+            Err(err) => return Err(format!("poll writable pty fd: {err}")),
+        }
+    }
 }
 
 fn resize_pty(fd: RawFd, cols: u16, rows: u16, width_px: u32, height_px: u32) -> Result<(), String> {

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -1712,6 +1712,7 @@ fn create_in_process_session(provider: &CleatProvider, desc: CleatSessionDesc) -
         Ok(runtime)
     })
     .map_err(|err| err.replace("session actor", "in-process session actor"))?;
+    actor.set_client_presence(false)?;
     Ok(InProcessSession { actor })
 }
 

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -3,20 +3,15 @@ use std::{
     path::PathBuf,
     ptr, slice,
     str::Utf8Error,
-    sync::{
-        atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering},
-        mpsc, Arc, Mutex,
-    },
-    thread,
-    time::Duration,
+    sync::{Arc, Mutex},
 };
 
 use http::{Method, StatusCode};
 
 use crate::{
+    host::actor::{ObservationState, SessionActor, SessionCommand, SessionMouseEvent, SessionWheelEvent},
     http_uds, keys,
     platform::ipc::connect_session_stream,
-    protocol::SignalTarget,
     provider::{
         DirtyState, ProviderFeatures, TerminalCell, TerminalCellFlags, TerminalCellWidth, TerminalCursor, TerminalCursorStyle,
         TerminalGeometry, TerminalImagePlacement, TerminalImageResource, TerminalRenderUpdate, TerminalRenderUpdateOpKind, TerminalRgb,
@@ -25,7 +20,7 @@ use crate::{
     },
     runtime::{RuntimeLayout, TerminalSize},
     session::{ensure_session_started, session_socket_path, SessionStartOptions},
-    session_runtime::{PtyOutput, SessionRuntime},
+    session_runtime::SessionRuntime,
     vt::{self, Rgb, TerminalColors, VtEngineKind},
 };
 
@@ -133,8 +128,6 @@ pub const CLEAT_IMAGE_FORMAT_GRAY: u32 = 4;
 pub const CLEAT_IMAGE_COMPRESSION_NONE: u32 = 0;
 pub const CLEAT_IMAGE_COMPRESSION_ZLIB_DEFLATE: u32 = 1;
 pub const CLEAT_IMAGE_PLACEMENT_VIRTUAL: u32 = TERMINAL_IMAGE_PLACEMENT_VIRTUAL;
-
-const POSIX_SIGTERM: i32 = 15;
 
 pub type CleatImageResourceDataFn = Option<unsafe extern "C" fn(user_data: *mut c_void, data: *const u8, data_len: usize) -> bool>;
 
@@ -538,9 +531,7 @@ struct MockSession {
 }
 
 struct InProcessSession {
-    tx: mpsc::Sender<InProcessCommand>,
-    observation: Arc<ObservationMirror>,
-    worker: Option<thread::JoinHandle<()>>,
+    actor: SessionActor,
 }
 
 struct DaemonSession {
@@ -557,273 +548,6 @@ pub type CleatWakeFn = Option<unsafe extern "C" fn(*mut c_void)>;
 pub struct WakeCallback {
     wake: CleatWakeFn,
     user_data: usize,
-}
-
-#[derive(Clone, Debug)]
-struct ObservationState {
-    render_generation: u64,
-    observed_generation: u64,
-    dirty: DirtyState,
-    dirty_rows: Vec<u16>,
-    terminal_modes: Option<vt::TerminalModeState>,
-    mirror: Option<Arc<ObservationMirror>>,
-}
-
-impl ObservationState {
-    fn new(rows: u16) -> Self {
-        Self::new_with_mirror(rows, None)
-    }
-
-    fn new_with_mirror(rows: u16, mirror: Option<Arc<ObservationMirror>>) -> Self {
-        let mut state = Self {
-            render_generation: 0,
-            observed_generation: 0,
-            dirty: DirtyState::Clean,
-            dirty_rows: Vec::new(),
-            terminal_modes: None,
-            mirror,
-        };
-        state.mark_full(rows);
-        state
-    }
-
-    fn dirty(&self) -> DirtyState {
-        if self.render_generation > self.observed_generation {
-            self.dirty
-        } else {
-            DirtyState::Clean
-        }
-    }
-
-    fn mark_full(&mut self, _rows: u16) -> bool {
-        let was_clean = self.dirty() == DirtyState::Clean;
-        self.render_generation = self.render_generation.saturating_add(1);
-        self.dirty = DirtyState::Full;
-        self.dirty_rows.clear();
-        self.publish_mirror();
-        was_clean
-    }
-
-    fn mark_partial_rows(&mut self, rows: impl IntoIterator<Item = u16>) -> bool {
-        let was_clean = self.dirty() == DirtyState::Clean;
-        self.render_generation = self.render_generation.saturating_add(1);
-        if self.dirty != DirtyState::Full {
-            self.dirty = DirtyState::Partial;
-            for row in rows {
-                if !self.dirty_rows.contains(&row) {
-                    self.dirty_rows.push(row);
-                }
-            }
-            self.dirty_rows.sort_unstable();
-        }
-        self.publish_mirror();
-        was_clean
-    }
-
-    fn mark_partial_unknown(&mut self) -> bool {
-        let was_clean = self.dirty() == DirtyState::Clean;
-        self.render_generation = self.render_generation.saturating_add(1);
-        if self.dirty != DirtyState::Full {
-            self.dirty = DirtyState::Partial;
-            self.dirty_rows.clear();
-        }
-        self.publish_mirror();
-        was_clean
-    }
-
-    fn sync_terminal_modes(&mut self, terminal_modes: vt::TerminalModeState) -> bool {
-        let previous = self.terminal_modes.replace(terminal_modes);
-        match previous {
-            None => false,
-            Some(previous) if previous == terminal_modes => false,
-            Some(_) => self.mark_partial_unknown(),
-        }
-    }
-
-    fn mark_observed(&mut self, generation: u64) -> bool {
-        if generation > self.render_generation {
-            return false;
-        }
-        self.observed_generation = self.observed_generation.max(generation);
-        if self.observed_generation >= self.render_generation {
-            self.dirty = DirtyState::Clean;
-            self.dirty_rows.clear();
-        }
-        self.publish_mirror();
-        true
-    }
-
-    fn annotate_snapshot(&self, snapshot: &mut TerminalSnapshot) {
-        snapshot.render_generation = self.render_generation;
-        snapshot.dirty = self.dirty();
-        snapshot.dirty_rows = if snapshot.dirty == DirtyState::Partial {
-            if self.dirty_rows.is_empty() {
-                snapshot.dirty_rows.clone()
-            } else {
-                self.dirty_rows.clone()
-            }
-        } else {
-            Vec::new()
-        };
-    }
-
-    fn annotate_render_update(&self, update: &mut TerminalRenderUpdate) {
-        update.render_generation = self.render_generation;
-        let dirty = self.dirty();
-        if dirty == DirtyState::Clean {
-            update.dirty = DirtyState::Clean;
-            update.ops.clear();
-        } else if update.dirty == DirtyState::Clean {
-            update.dirty = dirty;
-        }
-    }
-
-    fn publish_mirror(&self) {
-        if let Some(mirror) = &self.mirror {
-            mirror.store(self.render_generation, self.observed_generation, self.dirty);
-        }
-    }
-}
-
-#[derive(Debug)]
-struct ObservationMirror {
-    render_generation: AtomicU64,
-    observed_generation: AtomicU64,
-    dirty: AtomicU8,
-}
-
-impl ObservationMirror {
-    fn new() -> Self {
-        Self {
-            render_generation: AtomicU64::new(0),
-            observed_generation: AtomicU64::new(0),
-            dirty: AtomicU8::new(dirty_state_to_u8(DirtyState::Clean)),
-        }
-    }
-
-    fn store(&self, render_generation: u64, observed_generation: u64, dirty: DirtyState) {
-        self.dirty.store(dirty_state_to_u8(dirty), AtomicOrdering::SeqCst);
-        self.observed_generation.store(observed_generation, AtomicOrdering::SeqCst);
-        self.render_generation.store(render_generation, AtomicOrdering::SeqCst);
-    }
-
-    fn dirty(&self) -> DirtyState {
-        let render_generation = self.render_generation.load(AtomicOrdering::SeqCst);
-        let observed_generation = self.observed_generation.load(AtomicOrdering::SeqCst);
-        if render_generation > observed_generation {
-            dirty_state_from_u8(self.dirty.load(AtomicOrdering::SeqCst))
-        } else {
-            DirtyState::Clean
-        }
-    }
-}
-
-fn dirty_state_to_u8(dirty: DirtyState) -> u8 {
-    match dirty {
-        DirtyState::Clean => 0,
-        DirtyState::Partial => 1,
-        DirtyState::Full => 2,
-    }
-}
-
-fn dirty_state_from_u8(value: u8) -> DirtyState {
-    match value {
-        1 => DirtyState::Partial,
-        2 => DirtyState::Full,
-        _ => {
-            debug_assert_eq!(value, 0, "unexpected DirtyState byte");
-            DirtyState::Clean
-        }
-    }
-}
-
-impl Drop for InProcessSession {
-    fn drop(&mut self) {
-        let _ = self.tx.send(InProcessCommand::Stop { terminate: true });
-        if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-struct CleatWheelEvent {
-    modifiers: u16,
-    cell_col: u16,
-    cell_row: u16,
-    x_px: f32,
-    y_px: f32,
-    wheel_delta_x: f32,
-    wheel_delta_y: f32,
-}
-
-#[derive(Clone, Copy)]
-struct CleatMouseEvent {
-    mouse_kind: u32,
-    mouse_button: u32,
-    mouse_buttons: u16,
-    modifiers: u16,
-    x_px: f32,
-    y_px: f32,
-}
-
-enum InProcessCommand {
-    Resize {
-        cols: u16,
-        rows: u16,
-        reply: mpsc::Sender<Result<(), String>>,
-    },
-    SetCellSize {
-        cell_width_px: u32,
-        cell_height_px: u32,
-        reply: mpsc::Sender<Result<(), String>>,
-    },
-    WriteInput {
-        bytes: Vec<u8>,
-        reply: mpsc::Sender<Result<(), String>>,
-    },
-    Wheel {
-        event: CleatWheelEvent,
-        reply: mpsc::Sender<Result<usize, String>>,
-    },
-    Mouse {
-        event: CleatMouseEvent,
-        reply: mpsc::Sender<Result<usize, String>>,
-    },
-    Paste {
-        text: Vec<u8>,
-        reply: mpsc::Sender<Result<usize, String>>,
-    },
-    ScrollViewport {
-        command: ViewportCommand,
-        reply: mpsc::Sender<Result<ViewportCommandOutcome, String>>,
-    },
-    Snapshot {
-        reply: mpsc::Sender<Result<TerminalSnapshot, String>>,
-    },
-    RenderUpdate {
-        reply: mpsc::Sender<Result<TerminalRenderUpdate, String>>,
-    },
-    ImageResourceData {
-        image_id: u32,
-        generation: u64,
-        callback: CleatImageResourceDataFn,
-        user_data: usize,
-        reply: mpsc::Sender<Result<bool, String>>,
-    },
-    MarkObserved {
-        generation: u64,
-        reply: mpsc::Sender<bool>,
-    },
-    ScrollbackExtent {
-        reply: mpsc::Sender<TerminalScrollbackExtent>,
-    },
-    ScrollbarState {
-        reply: mpsc::Sender<TerminalScrollbarState>,
-    },
-    Stop {
-        terminate: bool,
-    },
 }
 
 struct OwnedSnapshot {
@@ -1290,7 +1014,7 @@ pub unsafe extern "C" fn cleat_session_resize(session: *mut CleatSession, cols: 
             true
         }
         SessionBackend::InProcess(in_process) => {
-            in_process_request_result(in_process, |reply| InProcessCommand::Resize { cols: cols.max(1), rows: rows.max(1), reply }).is_ok()
+            in_process.actor.request_result(|reply| SessionCommand::Resize { cols: cols.max(1), rows: rows.max(1), reply }).is_ok()
         }
         SessionBackend::Daemon(daemon) => {
             if daemon_resize(daemon, cols.max(1), rows.max(1)).is_err() {
@@ -1327,9 +1051,7 @@ pub unsafe extern "C" fn cleat_session_update_geometry(session: *mut CleatSessio
         }
         SessionBackend::InProcess(in_process) => {
             let (cell_width_px, cell_height_px) = geometry_cell_size_to_backend(geometry);
-            if in_process_request_result(in_process, |reply| InProcessCommand::SetCellSize { cell_width_px, cell_height_px, reply })
-                .is_err()
-            {
+            if in_process.actor.request_result(|reply| SessionCommand::SetCellSize { cell_width_px, cell_height_px, reply }).is_err() {
                 return false;
             }
             session.geometry = geometry;
@@ -1443,7 +1165,7 @@ fn send_input_event(session: &mut CleatSession, event: &CleatInputEvent) -> Opti
             Err(_) => None,
         },
         SessionBackend::InProcess(in_process) => match input_event_bytes(event) {
-            Ok(Some(bytes)) => in_process_request_result(in_process, |reply| InProcessCommand::WriteInput { bytes, reply }).ok().map(|_| 1),
+            Ok(Some(bytes)) => in_process.actor.request_result(|reply| SessionCommand::WriteInput { bytes, reply }).ok().map(|_| 1),
             Ok(None) if is_wheel_event(event) => route_in_process_wheel_event(in_process, event),
             Ok(None) if event.kind == CLEAT_INPUT_MOUSE => route_in_process_mouse_event(in_process, event),
             Ok(None) if event.kind == CLEAT_INPUT_PASTE => route_in_process_paste_event(in_process, event),
@@ -1468,8 +1190,8 @@ fn is_wheel_event(event: &CleatInputEvent) -> bool {
 }
 
 fn route_in_process_wheel_event(in_process: &InProcessSession, event: &CleatInputEvent) -> Option<usize> {
-    let wheel = CleatWheelEvent {
-        modifiers: event.modifiers,
+    let wheel = SessionWheelEvent {
+        modifiers: mouse_modifiers(event.modifiers),
         cell_col: event.cell_col,
         cell_row: event.cell_row,
         x_px: event.x_px,
@@ -1477,35 +1199,38 @@ fn route_in_process_wheel_event(in_process: &InProcessSession, event: &CleatInpu
         wheel_delta_x: event.wheel_delta_x,
         wheel_delta_y: event.wheel_delta_y,
     };
-    in_process_request_result(in_process, |reply| InProcessCommand::Wheel { event: wheel, reply }).ok()
+    in_process.actor.request_result(|reply| SessionCommand::Wheel { event: wheel, reply }).ok()
 }
 
 fn route_in_process_paste_event(in_process: &InProcessSession, event: &CleatInputEvent) -> Option<usize> {
     let text = read_event_text_bytes(event).ok()?;
-    in_process_request_result(in_process, |reply| InProcessCommand::Paste { text, reply }).ok()
-}
-
-fn route_in_process_paste_on_actor(runtime: &mut SessionRuntime, text: &[u8]) -> Result<usize, String> {
-    // The engine wraps in bracketed-paste markers when the program enabled mode
-    // 2004 and strips unsafe bytes; otherwise it returns the text unchanged.
-    let bytes = runtime.encode_paste(text)?;
-    if bytes.is_empty() {
-        return Ok(0);
-    }
-    runtime.write_input(&bytes)?;
-    Ok(1)
+    in_process.actor.request_result(|reply| SessionCommand::Paste { text, reply }).ok()
 }
 
 fn route_in_process_mouse_event(in_process: &InProcessSession, event: &CleatInputEvent) -> Option<usize> {
-    let mouse = CleatMouseEvent {
-        mouse_kind: event.mouse_kind,
-        mouse_button: event.mouse_button,
-        mouse_buttons: event.mouse_buttons,
-        modifiers: event.modifiers,
+    let action = match event.mouse_kind {
+        CLEAT_MOUSE_PRESS => vt::MouseAction::Press,
+        CLEAT_MOUSE_RELEASE => vt::MouseAction::Release,
+        CLEAT_MOUSE_MOVE => vt::MouseAction::Motion,
+        _ => return Some(0),
+    };
+    let mouse = SessionMouseEvent {
+        action,
+        button: cleat_mouse_button(event.mouse_button),
+        any_button_pressed: event.mouse_buttons != 0,
+        modifiers: mouse_modifiers(event.modifiers),
         x_px: event.x_px,
         y_px: event.y_px,
     };
-    in_process_request_result(in_process, |reply| InProcessCommand::Mouse { event: mouse, reply }).ok()
+    in_process.actor.request_result(|reply| SessionCommand::Mouse { event: mouse, reply }).ok()
+}
+
+fn mouse_modifiers(modifiers: u16) -> vt::MouseModifiers {
+    vt::MouseModifiers {
+        shift: modifiers & CLEAT_MOD_SHIFT != 0,
+        ctrl: modifiers & CLEAT_MOD_CTRL != 0,
+        alt: modifiers & CLEAT_MOD_ALT != 0,
+    }
 }
 
 /// Map a Cleat button id to a backend-neutral named button. Wheel directions are
@@ -1521,126 +1246,11 @@ fn cleat_mouse_button(button: u32) -> Option<vt::MouseButton> {
     }
 }
 
-fn route_in_process_mouse_event_on_actor(runtime: &mut SessionRuntime, event: CleatMouseEvent) -> Result<usize, String> {
-    let action = match event.mouse_kind {
-        CLEAT_MOUSE_PRESS => vt::MouseAction::Press,
-        CLEAT_MOUSE_RELEASE => vt::MouseAction::Release,
-        CLEAT_MOUSE_MOVE => vt::MouseAction::Motion,
-        _ => return Ok(0),
-    };
-    let button = cleat_mouse_button(event.mouse_button);
-    let any_button_pressed = event.mouse_buttons != 0;
-    let modifiers = vt::MouseModifiers {
-        shift: event.modifiers & CLEAT_MOD_SHIFT != 0,
-        ctrl: event.modifiers & CLEAT_MOD_CTRL != 0,
-        alt: event.modifiers & CLEAT_MOD_ALT != 0,
-    };
-    // The encoder gates against the live tracking mode and dedupes motion, so an
-    // empty result just means "nothing to report" for this event.
-    let bytes = runtime.encode_mouse(action, button, any_button_pressed, modifiers, event.x_px, event.y_px)?;
-    if bytes.is_empty() {
-        return Ok(0);
-    }
-    runtime.write_input(&bytes)?;
-    Ok(1)
-}
-
-fn route_in_process_wheel_event_on_actor(
-    wake: &Arc<Mutex<WakeCallback>>,
-    runtime: &mut SessionRuntime,
-    observation: &mut ObservationState,
-    event: CleatWheelEvent,
-) -> Result<usize, String> {
-    let modes = runtime.terminal_mode_state()?;
-    if modes.mouse_tracking {
-        let bytes = mouse_report_bytes_from_wheel(event, modes).ok_or_else(|| "mouse wheel event cannot be encoded".to_string())?;
-        if bytes.is_empty() {
-            return Ok(0);
-        }
-        runtime.write_input(&bytes)?;
-        return Ok(1);
-    }
-
-    if modes.active_alternate_screen && modes.alternate_scroll {
-        let bytes = alternate_scroll_cursor_bytes_from_wheel(event, modes);
-        if bytes.is_empty() {
-            return Ok(0);
-        }
-        runtime.write_input(&bytes)?;
-        return Ok(1);
-    }
-
-    let delta_rows = viewport_delta_rows_from_wheel(event);
-    if delta_rows == 0 {
-        return Ok(0);
-    }
-    match runtime.scroll_viewport(ViewportCommand::DeltaRows(delta_rows)) {
-        Ok(ViewportCommandOutcome::Moved) => {
-            let rows = runtime.inspect(false, 0).terminal.rows;
-            mark_full_and_wake(observation, rows, wake);
-            Ok(0)
-        }
-        Ok(ViewportCommandOutcome::NoOp | ViewportCommandOutcome::Unsupported) => Ok(0),
-        Err(err) => Err(err),
-    }
-}
-
-fn wheel_tick_count(delta: f32) -> usize {
-    if !delta.is_finite() {
-        return 0;
-    }
-    let rounded = delta.round().abs();
-    if rounded == 0.0 {
-        0
-    } else if rounded > usize::MAX as f32 {
-        usize::MAX
-    } else {
-        rounded as usize
-    }
-}
-
-fn viewport_delta_rows_from_wheel(event: CleatWheelEvent) -> i64 {
-    if !event.wheel_delta_y.is_finite() {
-        return 0;
-    }
-    let rounded = event.wheel_delta_y.round();
-    if rounded == 0.0 {
-        return 0;
-    }
-    let rows = if rounded > i64::MAX as f32 {
-        i64::MAX
-    } else if rounded < i64::MIN as f32 {
-        i64::MIN
-    } else {
-        rounded as i64
-    };
-    rows.saturating_neg()
-}
-
-fn alternate_scroll_cursor_bytes_from_wheel(event: CleatWheelEvent, modes: vt::TerminalModeState) -> Vec<u8> {
-    let count = wheel_tick_count(event.wheel_delta_y);
-    if count == 0 {
-        return Vec::new();
-    }
-    let seq = if event.wheel_delta_y.is_sign_positive() {
-        if modes.application_cursor_keys {
-            b"\x1bOA".as_slice()
-        } else {
-            b"\x1b[A".as_slice()
-        }
-    } else if modes.application_cursor_keys {
-        b"\x1bOB".as_slice()
-    } else {
-        b"\x1b[B".as_slice()
-    };
-    seq.repeat(count)
-}
-
 #[cfg(test)]
 fn mouse_report_bytes(event: &CleatInputEvent, modes: vt::TerminalModeState) -> Option<Vec<u8>> {
-    mouse_report_bytes_from_wheel(
-        CleatWheelEvent {
-            modifiers: event.modifiers,
+    crate::host::actor::mouse_report_bytes_from_wheel(
+        SessionWheelEvent {
+            modifiers: mouse_modifiers(event.modifiers),
             cell_col: event.cell_col,
             cell_row: event.cell_row,
             x_px: event.x_px,
@@ -1654,9 +1264,9 @@ fn mouse_report_bytes(event: &CleatInputEvent, modes: vt::TerminalModeState) -> 
 
 #[cfg(test)]
 fn alternate_scroll_cursor_bytes(event: &CleatInputEvent, modes: vt::TerminalModeState) -> Vec<u8> {
-    alternate_scroll_cursor_bytes_from_wheel(
-        CleatWheelEvent {
-            modifiers: event.modifiers,
+    crate::host::actor::alternate_scroll_cursor_bytes_from_wheel(
+        SessionWheelEvent {
+            modifiers: mouse_modifiers(event.modifiers),
             cell_col: event.cell_col,
             cell_row: event.cell_row,
             x_px: event.x_px,
@@ -1666,81 +1276,6 @@ fn alternate_scroll_cursor_bytes(event: &CleatInputEvent, modes: vt::TerminalMod
         },
         modes,
     )
-}
-
-fn mouse_report_bytes_from_wheel(event: CleatWheelEvent, modes: vt::TerminalModeState) -> Option<Vec<u8>> {
-    let y_count = wheel_tick_count(event.wheel_delta_y);
-    let x_count = wheel_tick_count(event.wheel_delta_x);
-    if y_count == 0 && x_count == 0 {
-        return Some(Vec::new());
-    }
-
-    let mut out = Vec::new();
-    let modifiers = mouse_report_modifier_code(event.modifiers);
-    if y_count > 0 {
-        let button = if event.wheel_delta_y.is_sign_positive() { 64 } else { 65 } + modifiers;
-        append_mouse_report(&mut out, button, y_count, event, modes)?;
-    }
-    if x_count > 0 {
-        let button = if event.wheel_delta_x.is_sign_positive() { 66 } else { 67 } + modifiers;
-        append_mouse_report(&mut out, button, x_count, event, modes)?;
-    }
-    Some(out)
-}
-
-fn append_mouse_report(
-    out: &mut Vec<u8>,
-    button_code: u16,
-    count: usize,
-    event: CleatWheelEvent,
-    modes: vt::TerminalModeState,
-) -> Option<()> {
-    let (x, y) = if modes.mouse_sgr_pixels {
-        (one_based_coordinate(event.x_px), one_based_coordinate(event.y_px))
-    } else {
-        (u32::from(event.cell_col) + 1, u32::from(event.cell_row) + 1)
-    };
-
-    for _ in 0..count {
-        if modes.mouse_sgr || modes.mouse_sgr_pixels {
-            out.extend_from_slice(format!("\x1b[<{button_code};{x};{y}M").as_bytes());
-        } else {
-            let b = legacy_mouse_byte(button_code)?;
-            let x = legacy_mouse_byte(u16::try_from(x).ok()?)?;
-            let y = legacy_mouse_byte(u16::try_from(y).ok()?)?;
-            out.extend_from_slice(&[b'\x1b', b'[', b'M', b, x, y]);
-        }
-    }
-    Some(())
-}
-
-fn mouse_report_modifier_code(modifiers: u16) -> u16 {
-    let mut code = 0;
-    if modifiers & CLEAT_MOD_SHIFT != 0 {
-        code += 4;
-    }
-    if modifiers & CLEAT_MOD_ALT != 0 {
-        code += 8;
-    }
-    if modifiers & CLEAT_MOD_CTRL != 0 {
-        code += 16;
-    }
-    code
-}
-
-fn one_based_coordinate(value: f32) -> u32 {
-    if !value.is_finite() || value <= 0.0 {
-        1
-    } else if value >= u32::MAX as f32 {
-        u32::MAX
-    } else {
-        value.round() as u32 + 1
-    }
-}
-
-fn legacy_mouse_byte(value: u16) -> Option<u8> {
-    let encoded = value.checked_add(32)?;
-    u8::try_from(encoded).ok()
 }
 
 fn record_input_acceptance(session: &mut CleatSession, count: usize, out: *mut CleatInputResult) {
@@ -1773,7 +1308,7 @@ pub unsafe extern "C" fn cleat_session_write_bytes(session: *mut CleatSession, b
             true
         }
         SessionBackend::InProcess(in_process) => {
-            in_process_request_result(in_process, |reply| InProcessCommand::WriteInput { bytes: bytes.to_vec(), reply }).is_ok()
+            in_process.actor.request_result(|reply| SessionCommand::WriteInput { bytes: bytes.to_vec(), reply }).is_ok()
         }
         SessionBackend::Daemon(daemon) => {
             if daemon_write_bytes(daemon, bytes).is_err() {
@@ -1798,7 +1333,7 @@ pub unsafe extern "C" fn cleat_session_poll(session: *mut CleatSession) -> Cleat
     };
     match &mut session.backend {
         SessionBackend::Mock(mock) => mock.observation.dirty().into(),
-        SessionBackend::InProcess(in_process) => in_process.observation.dirty().into(),
+        SessionBackend::InProcess(in_process) => in_process.actor.observation().dirty().into(),
         SessionBackend::Daemon(daemon) => daemon.observation.dirty().into(),
     }
 }
@@ -1813,7 +1348,7 @@ pub unsafe extern "C" fn cleat_session_dirty(session: *const CleatSession) -> Cl
     unsafe { session.as_ref() }
         .map(|session| match &session.backend {
             SessionBackend::Mock(mock) => mock.observation.dirty().into(),
-            SessionBackend::InProcess(in_process) => in_process.observation.dirty().into(),
+            SessionBackend::InProcess(in_process) => in_process.actor.observation().dirty().into(),
             SessionBackend::Daemon(daemon) => daemon.observation.dirty().into(),
         })
         .unwrap_or(CleatDirtyState::Full)
@@ -1832,7 +1367,7 @@ pub unsafe extern "C" fn cleat_session_mark_observed(session: *mut CleatSession,
     match &mut session.backend {
         SessionBackend::Mock(mock) => mock.observation.mark_observed(generation),
         SessionBackend::InProcess(in_process) => {
-            in_process_request(in_process, |reply| InProcessCommand::MarkObserved { generation, reply }, false)
+            in_process.actor.request(|reply| SessionCommand::MarkObserved { generation, reply }, false)
         }
         SessionBackend::Daemon(daemon) => daemon.observation.mark_observed(generation),
     }
@@ -1929,12 +1464,10 @@ pub unsafe extern "C" fn cleat_session_snapshot(session: *mut CleatSession, out:
             mock.observation.annotate_snapshot(&mut snapshot);
             snapshot
         }
-        SessionBackend::InProcess(in_process) => {
-            match in_process_request_result(in_process, |reply| InProcessCommand::Snapshot { reply }) {
-                Ok(snapshot) => snapshot,
-                Err(_) => return false,
-            }
-        }
+        SessionBackend::InProcess(in_process) => match in_process.actor.request_result(|reply| SessionCommand::Snapshot { reply }) {
+            Ok(snapshot) => snapshot,
+            Err(_) => return false,
+        },
         SessionBackend::Daemon(daemon) => match daemon_snapshot(daemon) {
             Ok(mut snapshot) => {
                 daemon.observation.annotate_snapshot(&mut snapshot);
@@ -1975,12 +1508,10 @@ pub unsafe extern "C" fn cleat_session_render_update(session: *mut CleatSession,
             mock.observation.annotate_snapshot(&mut snapshot);
             TerminalRenderUpdate::from_snapshot(snapshot)
         }
-        SessionBackend::InProcess(in_process) => {
-            match in_process_request_result(in_process, |reply| InProcessCommand::RenderUpdate { reply }) {
-                Ok(update) => update,
-                Err(_) => return false,
-            }
-        }
+        SessionBackend::InProcess(in_process) => match in_process.actor.request_result(|reply| SessionCommand::RenderUpdate { reply }) {
+            Ok(update) => update,
+            Err(_) => return false,
+        },
         SessionBackend::Daemon(daemon) => match daemon_snapshot(daemon) {
             Ok(mut snapshot) => {
                 daemon.observation.annotate_snapshot(&mut snapshot);
@@ -2021,14 +1552,18 @@ pub unsafe extern "C" fn cleat_session_with_image_resource_data(
     };
     match &mut session.backend {
         SessionBackend::Mock(_) | SessionBackend::Daemon(_) => false,
-        SessionBackend::InProcess(in_process) => in_process_request_result(in_process, |reply| InProcessCommand::ImageResourceData {
-            image_id,
-            generation,
-            callback: Some(callback),
-            user_data: user_data as usize,
-            reply,
-        })
-        .unwrap_or(false),
+        SessionBackend::InProcess(in_process) => {
+            let user_data = user_data as usize;
+            in_process
+                .actor
+                .request_result(|reply| SessionCommand::ImageResourceData {
+                    image_id,
+                    generation,
+                    callback: Box::new(move |bytes| unsafe { callback(user_data as *mut c_void, bytes.as_ptr(), bytes.len()) }),
+                    reply,
+                })
+                .unwrap_or(false)
+        }
     }
 }
 
@@ -2059,7 +1594,7 @@ fn session_scrollback_extent(session: &mut CleatSession) -> TerminalScrollbackEx
     match &mut session.backend {
         SessionBackend::Mock(mock) => TerminalScrollbackExtent { normal_scrollback_rows: 0, live_rows: mock.rows, alternate_screen: false },
         SessionBackend::InProcess(in_process) => {
-            in_process_request(in_process, |reply| InProcessCommand::ScrollbackExtent { reply }, TerminalScrollbackExtent {
+            in_process.actor.request(|reply| SessionCommand::ScrollbackExtent { reply }, TerminalScrollbackExtent {
                 normal_scrollback_rows: 0,
                 live_rows: 0,
                 alternate_screen: false,
@@ -2075,7 +1610,7 @@ fn session_scrollbar_state(session: &mut CleatSession) -> TerminalScrollbarState
     match &mut session.backend {
         SessionBackend::Mock(mock) => TerminalScrollbarState::for_live_viewport(TerminalViewportKind::LiveNormal, mock.rows),
         SessionBackend::InProcess(in_process) => {
-            in_process_request(in_process, |reply| InProcessCommand::ScrollbarState { reply }, TerminalScrollbarState::default())
+            in_process.actor.request(|reply| SessionCommand::ScrollbarState { reply }, TerminalScrollbarState::default())
         }
         SessionBackend::Daemon(daemon) => TerminalScrollbarState::for_live_viewport(TerminalViewportKind::LiveNormal, daemon.rows),
     }
@@ -2090,43 +1625,11 @@ fn session_scroll_viewport(session: &mut CleatSession, command: Option<ViewportC
             ViewportCommand::Top | ViewportCommand::Bottom | ViewportCommand::DeltaRows(_) => ViewportCommandOutcome::NoOp,
         },
         SessionBackend::InProcess(in_process) => {
-            match in_process_request_result(in_process, |reply| InProcessCommand::ScrollViewport { command, reply }) {
+            match in_process.actor.request_result(|reply| SessionCommand::ScrollViewport { command, reply }) {
                 Ok(outcome) => outcome,
                 Err(_) => ViewportCommandOutcome::Unsupported,
             }
         }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum PumpOutcome {
-    Clean,
-    PartialUnknown,
-    Full,
-}
-
-fn pump_in_process_runtime(runtime: &mut SessionRuntime, exited: &mut bool) -> Result<PumpOutcome, String> {
-    let mut exited_now = false;
-    if !*exited {
-        if let Some(exit_code) = runtime.exit_code_if_exited()? {
-            runtime.record_exit_code(exit_code);
-            *exited = true;
-            exited_now = true;
-        }
-    }
-    let output = if exited_now {
-        runtime.drain_output_after_exit(false)?
-    } else if *exited {
-        PtyOutput { chunks: Vec::new() }
-    } else {
-        runtime.read_available_output(false)?
-    };
-    if exited_now {
-        Ok(PumpOutcome::Full)
-    } else if !output.chunks.is_empty() {
-        Ok(PumpOutcome::PartialUnknown)
-    } else {
-        Ok(PumpOutcome::Clean)
     }
 }
 
@@ -2142,20 +1645,6 @@ fn mark_partial_rows_and_wake(observation: &mut ObservationState, rows: impl Int
     }
 }
 
-fn mark_partial_unknown_and_wake(observation: &mut ObservationState, wake: &Arc<Mutex<WakeCallback>>) {
-    if observation.mark_partial_unknown() {
-        notify_wake(wake);
-    }
-}
-
-fn sync_terminal_modes_and_wake(runtime: &SessionRuntime, observation: &mut ObservationState, wake: &Arc<Mutex<WakeCallback>>) {
-    if let Ok(terminal_modes) = runtime.terminal_mode_state() {
-        if observation.sync_terminal_modes(terminal_modes) {
-            notify_wake(wake);
-        }
-    }
-}
-
 fn notify_wake(wake: &Arc<Mutex<WakeCallback>>) {
     let callback = match wake.lock() {
         Ok(callback) => *callback,
@@ -2164,171 +1653,6 @@ fn notify_wake(wake: &Arc<Mutex<WakeCallback>>) {
     if let Some(wake) = callback.wake {
         unsafe { wake(callback.user_data as *mut c_void) };
     }
-}
-
-fn in_process_request<T>(session: &InProcessSession, make_command: impl FnOnce(mpsc::Sender<T>) -> InProcessCommand, fallback: T) -> T {
-    let (reply, recv) = mpsc::channel();
-    if session.tx.send(make_command(reply)).is_err() {
-        return fallback;
-    }
-    recv.recv().unwrap_or(fallback)
-}
-
-fn in_process_request_result<T>(
-    session: &InProcessSession,
-    make_command: impl FnOnce(mpsc::Sender<Result<T, String>>) -> InProcessCommand,
-) -> Result<T, String> {
-    let (reply, recv) = mpsc::channel();
-    session.tx.send(make_command(reply)).map_err(|_| "in-process session actor is not running".to_string())?;
-    recv.recv().map_err(|_| "in-process session actor did not reply".to_string())?
-}
-
-fn in_process_actor_loop(
-    mut runtime: SessionRuntime,
-    wake: Arc<Mutex<WakeCallback>>,
-    rows: u16,
-    mirror: Arc<ObservationMirror>,
-    ready: mpsc::Sender<Result<(), String>>,
-    rx: mpsc::Receiver<InProcessCommand>,
-) {
-    let mut observation = ObservationState::new_with_mirror(rows, Some(mirror));
-    let mut exited = false;
-    let _ = ready.send(Ok(()));
-    loop {
-        match rx.recv_timeout(Duration::from_millis(10)) {
-            Ok(command) => {
-                if in_process_actor_handle_command(command, &mut runtime, &mut observation, &mut exited, &wake) {
-                    break;
-                }
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                in_process_actor_pump(&mut runtime, &mut observation, &mut exited, &wake);
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
-                break;
-            }
-        }
-    }
-}
-
-fn in_process_actor_handle_command(
-    command: InProcessCommand,
-    runtime: &mut SessionRuntime,
-    observation: &mut ObservationState,
-    exited: &mut bool,
-    wake: &Arc<Mutex<WakeCallback>>,
-) -> bool {
-    let mut stop = false;
-    match command {
-        InProcessCommand::Resize { cols, rows, reply } => {
-            let cols = cols.max(1);
-            let rows = rows.max(1);
-            let result = runtime.resize(cols, rows).map(|_| {
-                mark_full_and_wake(observation, rows, wake);
-            });
-            let _ = reply.send(result);
-        }
-        InProcessCommand::SetCellSize { cell_width_px, cell_height_px, reply } => {
-            let result = runtime.set_cell_size(cell_width_px, cell_height_px).map(|_| {
-                let rows = runtime.inspect(false, 0).terminal.rows;
-                mark_full_and_wake(observation, rows, wake);
-            });
-            let _ = reply.send(result);
-        }
-        InProcessCommand::WriteInput { bytes, reply } => {
-            let _ = reply.send(runtime.write_input(&bytes));
-        }
-        InProcessCommand::Wheel { event, reply } => {
-            let result = route_in_process_wheel_event_on_actor(wake, runtime, observation, event);
-            let _ = reply.send(result);
-        }
-        InProcessCommand::Mouse { event, reply } => {
-            let _ = reply.send(route_in_process_mouse_event_on_actor(runtime, event));
-        }
-        InProcessCommand::Paste { text, reply } => {
-            let _ = reply.send(route_in_process_paste_on_actor(runtime, &text));
-        }
-        InProcessCommand::ScrollViewport { command, reply } => {
-            let result = runtime.scroll_viewport(command).inspect(|outcome| {
-                if *outcome == ViewportCommandOutcome::Moved {
-                    let rows = runtime.inspect(false, 0).terminal.rows;
-                    mark_full_and_wake(observation, rows, wake);
-                }
-            });
-            let _ = reply.send(result);
-        }
-        InProcessCommand::Snapshot { reply } => {
-            sync_terminal_modes_and_wake(runtime, observation, wake);
-            let result = runtime.snapshot(observation.dirty()).map(|mut snapshot| {
-                observation.annotate_snapshot(&mut snapshot);
-                snapshot
-            });
-            let _ = reply.send(result);
-        }
-        InProcessCommand::RenderUpdate { reply } => {
-            sync_terminal_modes_and_wake(runtime, observation, wake);
-            let result = runtime.render_update(observation.dirty()).map(|mut update| {
-                observation.annotate_render_update(&mut update);
-                update
-            });
-            let _ = reply.send(result);
-        }
-        InProcessCommand::ImageResourceData { image_id, generation, callback, user_data, reply } => {
-            let result = match callback {
-                Some(callback) => {
-                    let mut call_client = |bytes: &[u8]| unsafe { callback(user_data as *mut c_void, bytes.as_ptr(), bytes.len()) };
-                    runtime.with_image_resource_data(image_id, generation, &mut call_client)
-                }
-                None => Ok(false),
-            };
-            let _ = reply.send(result);
-        }
-        InProcessCommand::MarkObserved { generation, reply } => {
-            let _ = reply.send(observation.mark_observed(generation));
-        }
-        InProcessCommand::ScrollbackExtent { reply } => {
-            let extent = runtime.scrollback_extent().unwrap_or_else(|_| TerminalScrollbackExtent {
-                normal_scrollback_rows: 0,
-                live_rows: runtime.inspect(false, 0).terminal.rows,
-                alternate_screen: false,
-            });
-            let _ = reply.send(extent);
-        }
-        InProcessCommand::ScrollbarState { reply } => {
-            let scrollbar = runtime.scrollbar_state().unwrap_or_else(|_| {
-                TerminalScrollbarState::for_live_viewport(TerminalViewportKind::LiveNormal, runtime.inspect(false, 0).terminal.rows)
-            });
-            let _ = reply.send(scrollbar);
-        }
-        InProcessCommand::Stop { terminate } => {
-            if terminate && !*exited {
-                let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
-            }
-            stop = true;
-        }
-    }
-    if !stop {
-        in_process_actor_pump(runtime, observation, exited, wake);
-    }
-    stop
-}
-
-fn in_process_actor_pump(
-    runtime: &mut SessionRuntime,
-    observation: &mut ObservationState,
-    exited: &mut bool,
-    wake: &Arc<Mutex<WakeCallback>>,
-) {
-    match pump_in_process_runtime(runtime, exited) {
-        Ok(PumpOutcome::Clean) => {}
-        Ok(PumpOutcome::PartialUnknown) => mark_partial_unknown_and_wake(observation, wake),
-        Ok(PumpOutcome::Full) | Err(_) => {
-            let rows = runtime.inspect(false, 0).terminal.rows;
-            mark_full_and_wake(observation, rows, wake);
-        }
-    }
-    sync_terminal_modes_and_wake(runtime, observation, wake);
 }
 
 /// # Safety
@@ -2379,32 +1703,16 @@ fn create_in_process_session(provider: &CleatProvider, desc: CleatSessionDesc) -
     let initial_geometry = TerminalGeometry::from_cell_size(cols, rows, desc.cell_width_px, desc.cell_height_px);
     let (cell_width_px, cell_height_px) = geometry_cell_size_to_backend(initial_geometry);
     let wake = provider.wake.clone();
-    let observation = Arc::new(ObservationMirror::new());
-    let actor_observation = observation.clone();
-    let (tx, rx) = mpsc::channel();
-    let (ready_tx, ready_rx) = mpsc::channel();
-    let worker = thread::spawn(move || {
-        let result = (|| {
-            let mut vt_engine = vt::make_vt_engine_with_colors(vt_engine, cols, rows, colors)?;
-            vt_engine.set_cell_size(cell_width_px, cell_height_px)?;
-            let mut runtime = SessionRuntime::spawn(session_dir, &metadata, vt_engine)?;
-            runtime.resize(cols, rows)?;
-            Ok(runtime)
-        })();
-        match result {
-            Ok(runtime) => in_process_actor_loop(runtime, wake, rows, actor_observation, ready_tx, rx),
-            Err(err) => {
-                let _ = ready_tx.send(Err(err));
-            }
-        }
-    });
-    match ready_rx.recv().map_err(|_| "in-process session actor did not report startup".to_string())? {
-        Ok(()) => Ok(InProcessSession { tx, observation, worker: Some(worker) }),
-        Err(err) => {
-            let _ = worker.join();
-            Err(err)
-        }
-    }
+    let actor_wake = Arc::new(move || notify_wake(&wake));
+    let actor = SessionActor::spawn(rows, actor_wake, move || {
+        let mut vt_engine = vt::make_vt_engine_with_colors(vt_engine, cols, rows, colors)?;
+        vt_engine.set_cell_size(cell_width_px, cell_height_px)?;
+        let mut runtime = SessionRuntime::spawn(session_dir, &metadata, vt_engine)?;
+        runtime.resize(cols, rows)?;
+        Ok(runtime)
+    })
+    .map_err(|err| err.replace("session actor", "in-process session actor"))?;
+    Ok(InProcessSession { actor })
 }
 
 fn create_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Result<DaemonSession, String> {
@@ -2801,11 +2109,21 @@ fn cell_width_tag(width: TerminalCellWidth) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            mpsc,
+        },
+        time::Duration,
+    };
 
     use super::*;
-    use crate::provider::{
-        TerminalImagePlacement, TerminalImageResource, TerminalRenderCell, TerminalRenderRow, TerminalRenderStyle, TerminalRenderUpdateOp,
+    use crate::{
+        host::actor::ObservationMirror,
+        provider::{
+            TerminalImagePlacement, TerminalImageResource, TerminalRenderCell, TerminalRenderRow, TerminalRenderStyle,
+            TerminalRenderUpdateOp,
+        },
     };
 
     unsafe extern "C" fn count_wake(user_data: *mut c_void) {
@@ -3082,11 +2400,11 @@ mod tests {
 
     #[test]
     fn in_process_dirty_queries_do_not_wait_for_actor_replies() {
-        let (tx, _rx) = mpsc::channel::<InProcessCommand>();
+        let (tx, _rx) = mpsc::channel::<SessionCommand>();
         let observation = Arc::new(ObservationMirror::new());
         observation.store(1, 0, DirtyState::Full);
         let session = Box::into_raw(Box::new(CleatSession {
-            backend: SessionBackend::InProcess(Box::new(InProcessSession { tx, observation, worker: None })),
+            backend: SessionBackend::InProcess(Box::new(InProcessSession { actor: SessionActor::from_parts(tx, observation, None) })),
             geometry: TerminalGeometry::default(),
             next_input_sequence: 1,
             wake: Arc::new(Mutex::new(WakeCallback::default())),
@@ -3111,11 +2429,11 @@ mod tests {
 
     #[test]
     fn in_process_dirty_queries_read_clean_mirror_state() {
-        let (tx, _rx) = mpsc::channel::<InProcessCommand>();
+        let (tx, _rx) = mpsc::channel::<SessionCommand>();
         let observation = Arc::new(ObservationMirror::new());
         observation.store(1, 1, DirtyState::Full);
         let session = Box::into_raw(Box::new(CleatSession {
-            backend: SessionBackend::InProcess(Box::new(InProcessSession { tx, observation, worker: None })),
+            backend: SessionBackend::InProcess(Box::new(InProcessSession { actor: SessionActor::from_parts(tx, observation, None) })),
             geometry: TerminalGeometry::default(),
             next_input_sequence: 1,
             wake: Arc::new(Mutex::new(WakeCallback::default())),
@@ -3134,11 +2452,11 @@ mod tests {
 
     #[test]
     fn in_process_dirty_queries_read_partial_mirror_state() {
-        let (tx, _rx) = mpsc::channel::<InProcessCommand>();
+        let (tx, _rx) = mpsc::channel::<SessionCommand>();
         let observation = Arc::new(ObservationMirror::new());
         observation.store(2, 1, DirtyState::Partial);
         let session = Box::into_raw(Box::new(CleatSession {
-            backend: SessionBackend::InProcess(Box::new(InProcessSession { tx, observation, worker: None })),
+            backend: SessionBackend::InProcess(Box::new(InProcessSession { actor: SessionActor::from_parts(tx, observation, None) })),
             geometry: TerminalGeometry::default(),
             next_input_sequence: 1,
             wake: Arc::new(Mutex::new(WakeCallback::default())),

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -22,7 +22,7 @@ use crate::{
         daemon::{is_session_daemon_alive, spawn_daemon_process},
         ipc::{
             bind_session_listener, connect_session_stream, session_socket_path as platform_session_socket_path, set_listener_nonblocking,
-            set_stream_nonblocking, set_stream_read_timeout, shutdown_stream, SessionStream,
+            set_stream_nonblocking, set_stream_read_timeout, set_stream_write_timeout, shutdown_stream, SessionStream,
         },
         terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
@@ -38,6 +38,7 @@ const REATTACH_CLEAR_SEQUENCE: &[u8] = b"\x1b[2J\x1b[H";
 const MAX_PENDING_CLIENT_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 const SESSION_DAEMON_SERVICING_TICK: Duration = Duration::from_millis(10);
 const SESSION_HTTP_HANDSHAKE_DEADLINE: Duration = Duration::from_millis(250);
+const SESSION_HTTP_RESPONSE_WRITE_DEADLINE: Duration = Duration::from_millis(250);
 const TERMINATE_SIGNAL: i32 = 15;
 const SCREEN_STABLE_CHANGED_CELL_TOLERANCE: usize = 16;
 
@@ -530,10 +531,10 @@ fn drain_raw_output_tap(
     root: &Path,
     id: &str,
     actor: &SessionActor,
-    raw_output_tap: &RawOutputTap,
+    raw_output_tap: &mut RawOutputTap,
     active_client: &mut Option<ActiveClient>,
     watchers: &mut Vec<ActiveClient>,
-) -> bool {
+) -> Result<bool, String> {
     let mut drained = false;
     loop {
         match raw_output_tap.try_recv() {
@@ -541,7 +542,11 @@ fn drain_raw_output_tap(
                 drained = true;
                 enqueue_output_chunk(root, id, actor, active_client, watchers, chunk);
             }
-            Err(std::sync::mpsc::TryRecvError::Empty | std::sync::mpsc::TryRecvError::Disconnected) => return drained,
+            Err(std::sync::mpsc::TryRecvError::Empty) => return Ok(drained),
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                *raw_output_tap = actor.subscribe_raw_output()?;
+                return Ok(drained);
+            }
         }
     }
 }
@@ -577,7 +582,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
     let actor = SessionActor::spawn(session.initial_size.rows, Arc::new(|| {}), move || {
         crate::session_runtime::SessionRuntime::spawn(actor_session_dir, &actor_session, default_vt_engine(&actor_session)?)
     })?;
-    let raw_output_tap = actor.subscribe_raw_output()?;
+    let mut raw_output_tap = actor.subscribe_raw_output()?;
     let mut active_client: Option<ActiveClient> = None;
     let mut watchers: Vec<ActiveClient> = Vec::new();
     let mut had_foreground_client = false;
@@ -601,6 +606,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                     {
                         set_stream_nonblocking(&stream, true).map_err(|err| format!("set accepted stream nonblocking: {err}"))?;
                     }
+                    set_stream_write_timeout(&stream, Some(SESSION_HTTP_RESPONSE_WRITE_DEADLINE))?;
                     let request = {
                         let mut reader = HttpHandshakeReader::new(&mut stream, SESSION_HTTP_HANDSHAKE_DEADLINE);
                         let mut prefix = [0; 5];
@@ -642,7 +648,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
             }
         }
 
-        did_work |= drain_raw_output_tap(root, id, &actor, &raw_output_tap, &mut active_client, &mut watchers);
+        did_work |= drain_raw_output_tap(root, id, &actor, &mut raw_output_tap, &mut active_client, &mut watchers)?;
         drain_watcher_inputs(&mut watchers);
 
         if active_client.is_some() {
@@ -782,7 +788,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
         actor.flush_recording()?;
 
         if actor.exit_code()?.is_some() {
-            drain_raw_output_tap(root, id, &actor, &raw_output_tap, &mut active_client, &mut watchers);
+            drain_raw_output_tap(root, id, &actor, &mut raw_output_tap, &mut active_client, &mut watchers)?;
             for mut wait in pending_waits.drain(..) {
                 let elapsed_ms = wait.registered_at.elapsed().as_millis() as u64;
                 let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::SessionGone, elapsed_ms);

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -16,6 +16,7 @@ use std::{
 use http::StatusCode;
 
 use crate::{
+    host::actor::{RawOutputTap, SessionActor},
     http_uds,
     platform::{
         daemon::{is_session_daemon_alive, spawn_daemon_process},
@@ -23,12 +24,10 @@ use crate::{
             bind_session_listener, connect_session_stream, session_socket_path as platform_session_socket_path, set_listener_nonblocking,
             set_stream_nonblocking, set_stream_read_timeout, shutdown_stream, SessionStream,
         },
-        pty::poll_session_ready,
         terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
     protocol::Frame,
     runtime::{RuntimeLayout, SessionMetadata, TerminalSize},
-    session_runtime::SessionRuntime,
     vt::{self, ScreenGrid, VtEngine, VtEngineKind},
 };
 
@@ -37,6 +36,7 @@ const DETACH_CLEANUP_SEQUENCE: &[u8] =
     b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[<u\x1b[r\x1b[0m\x1b[?25h\x1b[2J\x1b[H\x1b[?1049l";
 const REATTACH_CLEAR_SEQUENCE: &[u8] = b"\x1b[2J\x1b[H";
 const MAX_PENDING_CLIENT_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
+const SESSION_DAEMON_SERVICING_TICK: Duration = Duration::from_millis(10);
 const TERMINATE_SIGNAL: i32 = 15;
 const SCREEN_STABLE_CHANGED_CELL_TOLERANCE: usize = 16;
 
@@ -508,7 +508,7 @@ fn write_http_wait_result(stream: &mut SessionStream, status: crate::protocol::W
 fn enqueue_output_chunk(
     root: &Path,
     id: &str,
-    runtime: &mut SessionRuntime,
+    actor: &SessionActor,
     active_client: &mut Option<ActiveClient>,
     watchers: &mut Vec<ActiveClient>,
     chunk: Vec<u8>,
@@ -517,11 +517,32 @@ fn enqueue_output_chunk(
     if let Some(client) = active_client.as_mut() {
         if client.enqueue_frame(&frame).is_err() {
             let _ = fs::remove_file(foreground_path(root, id));
-            runtime.record_detach();
+            let _ = actor.record_detach();
+            let _ = actor.set_client_presence(false);
             *active_client = None;
         }
     }
     watchers.retain_mut(|watcher| watcher.enqueue_frame(&frame).is_ok());
+}
+
+fn drain_raw_output_tap(
+    root: &Path,
+    id: &str,
+    actor: &SessionActor,
+    raw_output_tap: &RawOutputTap,
+    active_client: &mut Option<ActiveClient>,
+    watchers: &mut Vec<ActiveClient>,
+) -> bool {
+    let mut drained = false;
+    loop {
+        match raw_output_tap.try_recv() {
+            Ok(chunk) => {
+                drained = true;
+                enqueue_output_chunk(root, id, actor, active_client, watchers, chunk);
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty | std::sync::mpsc::TryRecvError::Disconnected) => return drained,
+        }
+    }
 }
 
 fn drain_watcher_inputs(watchers: &mut Vec<ActiveClient>) {
@@ -550,24 +571,25 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
     set_listener_nonblocking(&listener, true)?;
     fs::write(daemon_pid_path(root, id), std::process::id().to_string()).map_err(|err| format!("write daemon pid: {err}"))?;
 
-    let mut runtime = SessionRuntime::spawn(session_dir.clone(), session, default_vt_engine(session)?)?;
+    let actor_session_dir = session_dir.clone();
+    let actor_session = session.clone();
+    let actor = SessionActor::spawn(session.initial_size.rows, Arc::new(|| {}), move || {
+        crate::session_runtime::SessionRuntime::spawn(actor_session_dir, &actor_session, default_vt_engine(&actor_session)?)
+    })?;
+    let raw_output_tap = actor.subscribe_raw_output()?;
     let mut active_client: Option<ActiveClient> = None;
     let mut watchers: Vec<ActiveClient> = Vec::new();
     let mut had_foreground_client = false;
     let mut pending_waits: Vec<PendingWait> = Vec::new();
     let mut pending_expects: Vec<PendingExpect> = Vec::new();
+    let mut should_keep_session_dir = session.record;
     loop {
-        let poll_result = poll_session_ready(
-            &listener,
-            active_client.as_ref().map(|client| &client.stream),
-            active_client.as_ref().map(|client| !client.pending_output.is_empty()).unwrap_or(false),
-            runtime.pty_child(),
-            100,
-        )?;
+        let mut did_work = false;
 
-        if poll_result.listener_readable {
+        loop {
             match listener.accept() {
                 Ok((mut stream, _)) => {
+                    did_work = true;
                     // Accepted sockets inherit nonblocking mode from the listener on macOS/BSD.
                     // Reset to blocking so the initial frame read works correctly.
                     #[cfg(unix)]
@@ -590,7 +612,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                     }
 
                     let mut http_state = HttpRequestState {
-                        runtime: &mut runtime,
+                        actor: &actor,
                         active_client: &mut active_client,
                         watchers: &mut watchers,
                         had_foreground_client: &mut had_foreground_client,
@@ -601,20 +623,19 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                         let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &err);
                     }
                 }
-                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
                 Err(err) => return Err(format!("accept client: {err}")),
             }
         }
 
+        did_work |= drain_raw_output_tap(root, id, &actor, &raw_output_tap, &mut active_client, &mut watchers);
         drain_watcher_inputs(&mut watchers);
 
         if active_client.is_some() {
             let mut client_disconnected = false;
             let mut pending = VecDeque::new();
-            let client_read_timeout =
-                if poll_result.pty_readable || poll_result.client_writable { Duration::ZERO } else { Duration::from_millis(100) };
             if let Some(client) = active_client.as_mut() {
-                match client.drain_input_frames(&mut pending, client_read_timeout) {
+                match client.drain_input_frames(&mut pending, Duration::ZERO) {
                     Ok(true) => {}
                     Ok(false) => client_disconnected = true,
                     Err(err) => return Err(format!("read client frame: {err}")),
@@ -622,12 +643,13 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
             }
 
             while let Some(frame) = pending.pop_front() {
+                did_work = true;
                 match frame {
                     Frame::Input(bytes) => {
-                        runtime.write_input(&bytes)?;
+                        actor.write_input(bytes)?;
                     }
                     Frame::Resize { cols, rows } => {
-                        runtime.resize(cols, rows)?;
+                        actor.resize(cols, rows)?;
                     }
                     _ => {}
                 }
@@ -635,37 +657,30 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
 
             if client_disconnected && active_client.is_some() {
                 let _ = fs::remove_file(foreground_path(root, id));
-                runtime.record_detach();
+                actor.record_detach()?;
+                actor.set_client_presence(false)?;
                 active_client = None;
+                did_work = true;
             }
         }
 
-        if poll_result.client_writable {
-            let client_writable = match active_client.as_mut() {
-                Some(client) => client.flush_pending_output()?,
-                None => true,
-            };
-            if !client_writable {
-                let _ = fs::remove_file(foreground_path(root, id));
-                runtime.record_detach();
-                active_client = None;
-            }
+        let client_writable = match active_client.as_mut() {
+            Some(client) => client.flush_pending_output()?,
+            None => true,
+        };
+        if !client_writable {
+            let _ = fs::remove_file(foreground_path(root, id));
+            actor.record_detach()?;
+            actor.set_client_presence(false)?;
+            active_client = None;
+            did_work = true;
         }
         flush_watchers(&mut watchers);
-
-        if poll_result.pty_readable {
-            let output = runtime.read_available_output(active_client.is_some())?;
-            for chunk in output.chunks {
-                enqueue_output_chunk(root, id, &mut runtime, &mut active_client, &mut watchers, chunk);
-            }
-        }
-
-        runtime.flush_recording_if_idle(poll_result.pty_readable, poll_result.client_readable);
 
         // Evaluate pending waits on each loop tick.
         // Write errors are intentionally discarded — the client may have disconnected.
         let screen_stable_fingerprint = if pending_waits.iter().any(|wait| wait.screen_stable.is_some()) {
-            runtime.snapshot(crate::provider::DirtyState::Full).ok().map(ScreenStableFingerprint::from_snapshot)
+            actor.full_snapshot().ok().map(ScreenStableFingerprint::from_snapshot)
         } else {
             None
         };
@@ -689,7 +704,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                 match condition {
                     crate::protocol::WaitCondition::OutputIdle { quiet_ms } => {
                         // Silence measured from max(registration_time, last_output_time)
-                        let silence_since = match runtime.last_pty_output_at() {
+                        let silence_since = match actor.last_pty_output_at().ok().flatten() {
                             Some(t) if t > wait.registered_at => t,
                             _ => wait.registered_at,
                         };
@@ -700,7 +715,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                         }
                     }
                     crate::protocol::WaitCondition::TextMatch { text } => {
-                        if runtime.screen_contains(text.as_str()) {
+                        if actor.screen_contains(text.clone()).unwrap_or(false) {
                             let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
                             return false;
                         }
@@ -722,7 +737,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
 
         // Evaluate pending expects by scanning the cast file for text matches.
         if !pending_expects.is_empty() {
-            runtime.flush_recording();
+            actor.flush_recording()?;
             let cast_path = root.join(id).join(crate::recording::CAST_FILE_NAME);
             pending_expects.retain_mut(|expect| {
                 let elapsed = expect.registered_at.elapsed();
@@ -750,12 +765,10 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                 true
             });
         }
+        actor.flush_recording()?;
 
-        if let Some(exit_code) = runtime.exit_code_if_exited()? {
-            let output = runtime.drain_output_after_exit(active_client.is_some())?;
-            for chunk in output.chunks {
-                enqueue_output_chunk(root, id, &mut runtime, &mut active_client, &mut watchers, chunk);
-            }
+        if actor.exit_code()?.is_some() {
+            drain_raw_output_tap(root, id, &actor, &raw_output_tap, &mut active_client, &mut watchers);
             for mut wait in pending_waits.drain(..) {
                 let elapsed_ms = wait.registered_at.elapsed().as_millis() as u64;
                 let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::SessionGone, elapsed_ms);
@@ -764,12 +777,16 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                 let elapsed_ms = expect.registered_at.elapsed().as_millis() as u64;
                 let _ = write_http_wait_result(&mut expect.stream, crate::protocol::WaitStatus::SessionGone, elapsed_ms);
             }
-            runtime.record_exit_code(exit_code);
             if let Some(client) = active_client.as_mut() {
                 let _ = client.flush_pending_output();
             }
             flush_watchers(&mut watchers);
+            should_keep_session_dir = actor.should_keep_session_dir().unwrap_or(should_keep_session_dir);
             break;
+        }
+
+        if !did_work {
+            thread::sleep(SESSION_DAEMON_SERVICING_TICK);
         }
     }
 
@@ -777,7 +794,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
     let _ = fs::remove_file(&socket_path);
     let _ = fs::remove_file(daemon_pid_path(root, id));
     let _ = fs::remove_file(foreground_path(root, id));
-    if !runtime.should_keep_session_dir() {
+    if !should_keep_session_dir {
         let _ = fs::remove_dir_all(&session_dir);
     }
     Ok(())
@@ -789,7 +806,7 @@ pub fn run_session_daemon(_root: &Path, _session: &SessionMetadata) -> Result<()
 }
 
 struct HttpRequestState<'a> {
-    runtime: &'a mut SessionRuntime,
+    actor: &'a SessionActor,
     active_client: &'a mut Option<ActiveClient>,
     watchers: &'a mut Vec<ActiveClient>,
     had_foreground_client: &'a mut bool,
@@ -817,16 +834,16 @@ fn handle_http_request(
         )
         .map_err(|err| format!("write HTTP response: {err}")),
         http_uds::Route::Sessions => {
-            let result = state.runtime.inspect(state.active_client.is_some(), state.watchers.len());
+            let result = state.actor.inspect(state.active_client.is_some(), state.watchers.len())?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::SessionListResponse { sessions: vec![result] })
                 .map_err(|err| format!("write HTTP sessions response: {err}"))
         }
         http_uds::Route::SessionInspect { id } if id == daemon_id => {
-            let result = state.runtime.inspect(state.active_client.is_some(), state.watchers.len());
+            let result = state.actor.inspect(state.active_client.is_some(), state.watchers.len())?;
             http_uds::write_json(stream, StatusCode::OK, &result).map_err(|err| format!("write HTTP inspect response: {err}"))
         }
         http_uds::Route::SessionDelete { id } if id == daemon_id => {
-            state.runtime.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Leader)?;
+            state.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Leader)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP delete response: {err}"))
         }
         http_uds::Route::SessionAttach { id } if id == daemon_id => 'attach: {
@@ -839,7 +856,7 @@ fn handle_http_request(
             }
 
             let capabilities = attach_capabilities_from_http(body.capabilities);
-            let replay = state.runtime.apply_attach_state(body.cols, body.rows, &capabilities)?;
+            let replay = state.actor.apply_attach_state(body.cols, body.rows, capabilities)?;
             http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP attach upgrade response: {err}"))?;
             let attach_stream = stream.try_clone().map_err(|err| format!("clone HTTP attach stream: {err}"))?;
             #[cfg(unix)]
@@ -856,14 +873,15 @@ fn handle_http_request(
             let _ = fs::write(foreground_path(root, daemon_id), b"1");
             *state.active_client = Some(client);
             *state.had_foreground_client = true;
-            state.runtime.record_attach();
+            state.actor.set_client_presence(true)?;
+            state.actor.record_attach()?;
             Ok(())
         }
         http_uds::Route::SessionWatch { id } if id == daemon_id => {
             let body: http_uds::AttachRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP watch request: {err}"))?;
             let capabilities = attach_capabilities_from_http(body.capabilities);
-            let replay = state.runtime.replay_payload(&capabilities)?;
+            let replay = state.actor.replay_payload(capabilities)?;
             http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP watch upgrade response: {err}"))?;
             let watch_stream = stream.try_clone().map_err(|err| format!("clone HTTP watch stream: {err}"))?;
             #[cfg(unix)]
@@ -880,22 +898,23 @@ fn handle_http_request(
         http_uds::Route::SessionDetach { id } if id == daemon_id => {
             let _ = fs::remove_file(foreground_path(root, daemon_id));
             if state.active_client.is_some() {
-                state.runtime.record_detach();
+                state.actor.record_detach()?;
             }
+            state.actor.set_client_presence(false)?;
             *state.active_client = None;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP detach response: {err}"))
         }
         http_uds::Route::SessionExpect { id } if id == daemon_id => 'expect: {
             let body: http_uds::ExpectRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP expect request: {err}"))?;
-            if !state.runtime.recording_active() {
+            if !state.actor.recording_active()? {
                 http_uds::write_error(stream, StatusCode::CONFLICT, "recording not active")
                     .map_err(|err| format!("write HTTP expect error: {err}"))?;
                 break 'expect Ok(());
             }
 
             let cast_path = root.join(daemon_id).join(crate::recording::CAST_FILE_NAME);
-            state.runtime.flush_recording();
+            state.actor.flush_recording()?;
             if cast_path.exists() {
                 if let Ok(events) = crate::cast_reader::read_output_since(&cast_path, body.since_offset) {
                     let output: String = events.iter().map(|event| event.data.as_str()).collect();
@@ -932,21 +951,20 @@ fn handle_http_request(
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP input request: {err}"))?;
             match body {
                 http_uds::InputRequest::Text { text } => {
-                    state.runtime.write_input(text.as_bytes())?;
+                    state.actor.write_input(text.into_bytes())?;
                 }
                 http_uds::InputRequest::Paste { text } => {
-                    let bytes = state.runtime.encode_paste(text.as_bytes())?;
-                    state.runtime.write_input(&bytes)?;
+                    state.actor.paste(text.into_bytes())?;
                 }
                 http_uds::InputRequest::Key { key } => {
                     let bytes = http_input_key_bytes(key);
-                    state.runtime.write_input(&bytes)?;
+                    state.actor.write_input(bytes)?;
                 }
                 http_uds::InputRequest::RawBytes { bytes } => {
-                    state.runtime.write_input(&bytes)?;
+                    state.actor.write_input(bytes)?;
                 }
                 http_uds::InputRequest::Resize { cols, rows } => {
-                    state.runtime.resize(cols, rows)?;
+                    state.actor.resize(cols, rows)?;
                 }
             }
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP input response: {err}"))
@@ -954,61 +972,61 @@ fn handle_http_request(
         http_uds::Route::SessionKeys { id } if id == daemon_id => {
             let body: http_uds::KeysRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP keys request: {err}"))?;
-            state.runtime.write_input(&body.bytes)?;
+            state.actor.write_input(body.bytes)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP keys response: {err}"))
         }
         http_uds::Route::SessionKeysWithMark { id } if id == daemon_id => {
             let body: http_uds::KeysWithMarkRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP keys-with-mark request: {err}"))?;
-            let offset = state.runtime.write_input_with_mark(&body.bytes, body.marker_name)?;
+            let offset = state.actor.write_input_with_mark(body.bytes, body.marker_name)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
                 .map_err(|err| format!("write HTTP keys-with-mark response: {err}"))
         }
         http_uds::Route::SessionPasteWithMark { id } if id == daemon_id => {
             let body: http_uds::PasteWithMarkRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP paste-with-mark request: {err}"))?;
-            let bytes = state.runtime.encode_paste(body.text.as_bytes())?;
-            let offset = state.runtime.write_input_with_mark(&bytes, body.marker_name)?;
+            let offset = state.actor.paste_with_mark(body.text.into_bytes(), body.marker_name)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
                 .map_err(|err| format!("write HTTP paste-with-mark response: {err}"))
         }
         http_uds::Route::SessionRecord { id } if id == daemon_id => {
             let body: http_uds::RecordRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP record request: {err}"))?;
-            state.runtime.set_recording(body.enable)?;
+            state.actor.set_recording(body.enable)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP record response: {err}"))
         }
         http_uds::Route::SessionMark { id } if id == daemon_id => {
             let body: http_uds::MarkRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP mark request: {err}"))?;
-            let offset = state.runtime.mark(body.name)?;
+            let offset = state.actor.mark(body.name)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
                 .map_err(|err| format!("write HTTP mark response: {err}"))
         }
         http_uds::Route::SessionResolveMarker { id } if id == daemon_id => {
             let body: http_uds::ResolveMarkerRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP resolve-marker request: {err}"))?;
-            match state.runtime.resolve_marker(&body.name) {
+            let marker_name = body.name;
+            match state.actor.resolve_marker(marker_name.clone())? {
                 Some(offset) => http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
                     .map_err(|err| format!("write HTTP resolve-marker response: {err}")),
-                None => http_uds::write_error(stream, StatusCode::NOT_FOUND, &format!("marker not found: {}", body.name))
+                None => http_uds::write_error(stream, StatusCode::NOT_FOUND, &format!("marker not found: {marker_name}"))
                     .map_err(|err| format!("write HTTP resolve-marker error: {err}")),
             }
         }
         http_uds::Route::SessionResolveNextMarker { id } if id == daemon_id => {
             let body: http_uds::ResolveNextMarkerRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP resolve-next-marker request: {err}"))?;
-            let offset = state.runtime.resolve_next_marker_after(body.after);
+            let offset = state.actor.resolve_next_marker_after(body.after)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::ResolveNextMarkerResponse { offset })
                 .map_err(|err| format!("write HTTP resolve-next-marker response: {err}"))
         }
         http_uds::Route::SessionResize { id } if id == daemon_id => {
             let body: http_uds::ResizeRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP resize request: {err}"))?;
-            state.runtime.resize(body.cols, body.rows)?;
+            state.actor.resize(body.cols, body.rows)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP resize response: {err}"))
         }
-        http_uds::Route::SessionScreen { id } if id == daemon_id => match state.runtime.capture_text() {
+        http_uds::Route::SessionScreen { id } if id == daemon_id => match state.actor.capture_text() {
             Ok(text) => http_uds::write_json(stream, StatusCode::OK, &http_uds::ScreenResponse { text })
                 .map_err(|err| format!("write HTTP screen response: {err}")),
             Err(err) => http_uds::write_error(stream, StatusCode::CONFLICT, &err).map_err(|err| format!("write HTTP screen error: {err}")),
@@ -1016,22 +1034,16 @@ fn handle_http_request(
         http_uds::Route::SessionSignal { id } if id == daemon_id => {
             let body: http_uds::SignalRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP signal request: {err}"))?;
-            state.runtime.dispatch_signal(body.signal, signal_target_from_http(body.target))?;
+            state.actor.dispatch_signal(body.signal, signal_target_from_http(body.target))?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP signal response: {err}"))
         }
-        http_uds::Route::SessionSnapshot { id } if id == daemon_id => {
-            let output = state.runtime.read_available_output(state.active_client.is_some())?;
-            for chunk in output.chunks {
-                enqueue_output_chunk(root, daemon_id, state.runtime, state.active_client, state.watchers, chunk);
+        http_uds::Route::SessionSnapshot { id } if id == daemon_id => match state.actor.full_snapshot() {
+            Ok(snapshot) => http_uds::write_json(stream, StatusCode::OK, &http_uds::snapshot_response(snapshot))
+                .map_err(|err| format!("write HTTP snapshot response: {err}")),
+            Err(err) => {
+                http_uds::write_error(stream, StatusCode::CONFLICT, &err).map_err(|err| format!("write HTTP snapshot error: {err}"))
             }
-            match state.runtime.snapshot(crate::provider::DirtyState::Full) {
-                Ok(snapshot) => http_uds::write_json(stream, StatusCode::OK, &http_uds::snapshot_response(snapshot))
-                    .map_err(|err| format!("write HTTP snapshot response: {err}")),
-                Err(err) => {
-                    http_uds::write_error(stream, StatusCode::CONFLICT, &err).map_err(|err| format!("write HTTP snapshot error: {err}"))
-                }
-            }
-        }
+        },
         http_uds::Route::SessionWait { id } if id == daemon_id => 'wait: {
             let body: http_uds::WaitRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP wait request: {err}"))?;
@@ -1046,7 +1058,7 @@ fn handle_http_request(
             let has_screen_stable =
                 conditions.iter().any(|condition| matches!(condition, crate::protocol::WaitCondition::ScreenStable { .. }));
             if has_text_match {
-                if let Err(err) = state.runtime.validate_text_matching() {
+                if let Err(err) = state.actor.validate_text_matching() {
                     http_uds::write_error(stream, StatusCode::CONFLICT, &format!("text matching not supported: {err}"))
                         .map_err(|err| format!("write HTTP wait error: {err}"))?;
                     break 'wait Ok(());
@@ -1054,7 +1066,7 @@ fn handle_http_request(
             }
             let registered_at = Instant::now();
             let screen_stable = if has_screen_stable {
-                match state.runtime.snapshot(crate::provider::DirtyState::Full) {
+                match state.actor.full_snapshot() {
                     Ok(snapshot) => Some(ScreenStableState::new(ScreenStableFingerprint::from_snapshot(snapshot), registered_at)),
                     Err(err) => {
                         http_uds::write_error(stream, StatusCode::CONFLICT, &format!("screen stability not supported: {err}"))
@@ -1069,7 +1081,7 @@ fn handle_http_request(
             if has_text_match {
                 for condition in &conditions {
                     if let crate::protocol::WaitCondition::TextMatch { text } = condition {
-                        if state.runtime.screen_contains(text.as_str()) {
+                        if state.actor.screen_contains(text.clone())? {
                             http_uds::write_json(stream, StatusCode::OK, &http_uds::WaitResultResponse {
                                 status: http_uds::WaitStatusResponse::Ready,
                                 elapsed_ms: 0,

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::VecDeque,
     fs,
-    io::{Read, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -37,6 +37,7 @@ const DETACH_CLEANUP_SEQUENCE: &[u8] =
 const REATTACH_CLEAR_SEQUENCE: &[u8] = b"\x1b[2J\x1b[H";
 const MAX_PENDING_CLIENT_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 const SESSION_DAEMON_SERVICING_TICK: Duration = Duration::from_millis(10);
+const SESSION_HTTP_HANDSHAKE_DEADLINE: Duration = Duration::from_millis(250);
 const TERMINATE_SIGNAL: i32 = 15;
 const SCREEN_STABLE_CHANGED_CELL_TOLERANCE: usize = 16;
 
@@ -595,21 +596,34 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                     #[cfg(unix)]
                     {
                         set_stream_nonblocking(&stream, false).map_err(|err| format!("set accepted stream blocking: {err}"))?;
-                        let _ = set_stream_read_timeout(&stream, Some(Duration::from_millis(100)));
                     }
                     #[cfg(windows)]
                     {
                         set_stream_nonblocking(&stream, true).map_err(|err| format!("set accepted stream nonblocking: {err}"))?;
                     }
-                    let mut prefix = [0; 5];
-                    if let Err(err) = stream.read_exact(&mut prefix) {
-                        let _ = Frame::Error(format!("failed to read request: {err}")).write(&mut stream);
-                        continue;
-                    }
-                    if !http_uds::looks_like_http_prefix(&prefix) {
-                        let _ = Frame::Error("session daemon requires HTTP requests".to_string()).write(&mut stream);
-                        continue;
-                    }
+                    let request = {
+                        let mut reader = HttpHandshakeReader::new(&mut stream, SESSION_HTTP_HANDSHAKE_DEADLINE);
+                        let mut prefix = [0; 5];
+                        if let Err(err) = reader.read_exact(&mut prefix) {
+                            let _ = Frame::Error(format!("failed to read request: {err}")).write(&mut stream);
+                            continue;
+                        }
+                        if !http_uds::looks_like_http_prefix(&prefix) {
+                            let _ = Frame::Error("session daemon requires HTTP requests".to_string()).write(&mut stream);
+                            continue;
+                        }
+                        match http_uds::read_request_with_prefix(&mut reader, &prefix) {
+                            Ok(request) => request,
+                            Err(err) => {
+                                let _ = http_uds::write_error(
+                                    &mut stream,
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    &format!("read HTTP request: {err}"),
+                                );
+                                continue;
+                            }
+                        }
+                    };
 
                     let mut http_state = HttpRequestState {
                         actor: &actor,
@@ -619,7 +633,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                         pending_waits: &mut pending_waits,
                         pending_expects: &mut pending_expects,
                     };
-                    if let Err(err) = handle_http_request(root, id, &mut stream, &prefix, &mut http_state) {
+                    if let Err(err) = handle_http_request(root, id, &mut stream, request, &mut http_state) {
                         let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &err);
                     }
                 }
@@ -814,14 +828,42 @@ struct HttpRequestState<'a> {
     pending_expects: &'a mut Vec<PendingExpect>,
 }
 
+struct HttpHandshakeReader<'a> {
+    stream: &'a mut SessionStream,
+    deadline: Instant,
+}
+
+impl<'a> HttpHandshakeReader<'a> {
+    fn new(stream: &'a mut SessionStream, budget: Duration) -> Self {
+        Self { stream, deadline: Instant::now() + budget }
+    }
+
+    fn remaining_budget(&self) -> io::Result<Duration> {
+        let Some(remaining) = self.deadline.checked_duration_since(Instant::now()) else {
+            return Err(io::Error::new(io::ErrorKind::TimedOut, "HTTP request handshake deadline exceeded"));
+        };
+        if remaining.is_zero() {
+            return Err(io::Error::new(io::ErrorKind::TimedOut, "HTTP request handshake deadline exceeded"));
+        }
+        Ok(remaining)
+    }
+}
+
+impl Read for HttpHandshakeReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let remaining = self.remaining_budget()?;
+        set_stream_read_timeout(self.stream, Some(remaining)).map_err(io::Error::other)?;
+        self.stream.read(buf)
+    }
+}
+
 fn handle_http_request(
     root: &Path,
     daemon_id: &str,
     stream: &mut SessionStream,
-    prefix: &[u8],
+    request: http_uds::HttpRequest,
     state: &mut HttpRequestState<'_>,
 ) -> Result<(), String> {
-    let request = http_uds::read_request_with_prefix(stream, prefix).map_err(|err| format!("read HTTP request: {err}"))?;
     match http_uds::route(&request) {
         http_uds::Route::Root | http_uds::Route::Health => http_uds::write_json(
             stream,

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -120,12 +120,6 @@ impl SessionRuntime {
         }
     }
 
-    pub(crate) fn flush_recording_if_idle(&mut self, pty_readable: bool, client_readable: bool) {
-        if !pty_readable && !client_readable {
-            self.flush_recording();
-        }
-    }
-
     pub(crate) fn record_attach(&mut self) {
         self.record_custom_event('a', r#"{"client":"foreground"}"#);
     }

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -132,6 +132,17 @@ fn collect_output_until(stream: &mut UnixStream, needle: &str, timeout: Duration
     String::from_utf8_lossy(&output).into_owned()
 }
 
+fn drain_available_output(stream: &mut UnixStream) {
+    stream.set_read_timeout(Some(Duration::from_millis(20))).expect("set read timeout");
+    loop {
+        match Frame::read(stream) {
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock || err.kind() == std::io::ErrorKind::TimedOut => return,
+            Err(err) => panic!("drain output frame: {err}"),
+        }
+    }
+}
+
 struct EnvVarGuard {
     key: &'static str,
     original: Option<std::ffi::OsString>,
@@ -843,6 +854,44 @@ fn watcher_receives_live_output_without_taking_control() {
     assert!(controller_output.contains("watched-from-control"), "controller output was {controller_output:?}");
     assert!(watcher_output.contains("watched-from-control"), "watcher output was {watcher_output:?}");
     assert!(!watcher_output.contains("ignored-from-watcher"), "watcher input should be ignored, got {watcher_output:?}");
+}
+
+#[test]
+fn dribbling_http_handshake_does_not_block_attached_output() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let cmd = r#"i=0; while :; do printf 'dribble-tick-%04d\n' "$i"; i=$((i+1)); sleep 0.05; done"#;
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some(cmd.into()), false).expect("create alpha");
+
+    let mut controller = http_attach_stream(temp.path(), "alpha", 100, 30, ClientCapabilities::conservative_fallback());
+    let initial_output = collect_output_until(&mut controller, "dribble-tick-", Duration::from_secs(2));
+    assert!(initial_output.contains("dribble-tick-"), "initial output was {initial_output:?}");
+    drain_available_output(&mut controller);
+
+    let socket_path = session_socket_path(temp.path(), "alpha");
+    let dribbler = std::thread::spawn(move || {
+        let mut stream = UnixStream::connect(socket_path).expect("connect dribbler");
+        let request = b"POST /sessions/alpha/inspect HTTP/1.1\r\nHost: cleat\r\nContent-Length: 0\r\n\r\n";
+        for (index, byte) in request.iter().enumerate() {
+            if let Err(err) = stream.write_all(&[*byte]) {
+                assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe, "write dribbled byte: {err}");
+                return;
+            }
+            if index >= 4 {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    });
+
+    let output_while_dribbling = collect_output_until(&mut controller, "dribble-tick-", Duration::from_millis(750));
+    dribbler.join().expect("join dribbler");
+
+    assert!(
+        output_while_dribbling.contains("dribble-tick-"),
+        "attached output stalled behind a partial HTTP request; received {output_while_dribbling:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #98. Refs #78 — the daemon attach output path is rebuilt here; #78 should be verified against this before it closes.

Phase 1 of the daemon-mode/M:N arc (specs: provider-threading 'Daemon Progress And Servicing Split'; ADR 0004). Implemented by a cleat-hosted codex from the scoping plan on the issue; driven with `send --submit` and monitored with `wait --screen-stable` — both products of the previous fleet run.

## Commits (each independently green on all four gates)

1. **Extract shared session actor** — actor + observation state move from `provider_ffi.rs` to `src/host/actor.rs` (~1,284 lines); command enum domain-typed (FFI mouse/wheel/image types laundered out); wake becomes a closure; `provider_ffi` thins by ~870 lines to converters + dispatch. Zero behavior change.
2. **Kernel events for session actor** — actor blocks on kqueue/epoll over {PTY master, command-wake self-pipe}; the 10 ms `recv_timeout` tick is deleted. Embedded (uishell) sessions get the same event-driven feed the daemon got in #88.
3. **Raw-output tap** — bounded subscriber channels for PTY output chunks (drop-on-full `try_send`; a slow subscriber is dropped, never blocks the feed) + client-presence command for detached query replies.
4. **Daemon adoption** — `run_session_daemon` = servicing loop + one actor; attach/watch relay from the tap; waits/expects evaluated on a 10 ms servicing tick via actor queries. **Terminal progress is now structurally independent of connection and client I/O.**
5. **Handshake deadline + regression test** — 250 ms overall budget on the accepted-connection HTTP handshake; `dribbling_http_handshake_does_not_block_attached_output` (red before, green after) proves a byte-dribbling client cannot stall output delivery to the attached client.

## Deliberately interim (replaced by #99's channel-framed connection)

- Synchronous per-connection HTTP parse (now deadline-bounded)
- The 10 ms servicing tick for client input relay and waits

Validated per commit: fmt, clippy `-D warnings`, workspace tests, ghostty-vt suite.