### PR TITLE
Bump ghostty pin to rebased cleat-integration (64daa599c)

### DIFF
--- a/tools/ghostty-toolchain.toml
+++ b/tools/ghostty-toolchain.toml
@@ -14,5 +14,5 @@ version = "0.15.2"
 # libvt branches upstream, retire this fork and re-pin to ghostty-org/ghostty.
 [ghostty]
 repo = "https://github.com/rjwittams/ghostty.git"
-ref = "5ac386088664b2209c0e0f8fce161977d2b1d31c"
+ref = "64daa599c531e6938bc4c52d9198a91f1e6ce8cf"
 build_step = "-Demit-lib-vt=true"


### PR DESCRIPTION
Fixes #104 — resequenced from 'after #98' to now: the fork rebase orphaned the old pin, so `prepare-ghostty-vt.sh` fails repo-wide in CI (currently blocking #105 and any branch's Ghostty VT job).

## ABI review (required by the toolchain maintenance note — headers are NOT byte-identical)

All diffs additive; no cleat FFI change needed:
- `kitty_graphics.h`: new storage-wide `GHOSTTY_KITTY_GRAPHICS_DATA_GENERATION` stamp (+docs) — the cheap per-frame image skip #99/#103 want.
- `terminal.h`: `GHOSTTY_SCROLL_VIEWPORT_ROW` appended **after** `DELTA` (existing tags keep values: Top=0, Bottom=1, Delta=2); its `size_t row` union member sits inside the existing `_padding[2]` (union size unchanged — the padding did its job).
- `vt.h` includes new `unicode.h` (new API, unbound by cleat).

Also carries (per the ghostty maintenance agent): Kitty relative placements (P/Q/H/V + virtual parent), kitty robustness fixes, virtual-placement C API, simdutf MSVC static-init fix in-tree (downstream patch retired); `libvt-image-generation` now upstream (`bdc0b6c19`), ABI-identical.

## Validation

Fresh `prepare-ghostty-vt.sh` against the new ref; feature-on build + all 15 test suites green; clippy clean; default-build workspace tests green.

Follow-up captured on #99/#103: adopt the storage-wide generation stamp for per-frame image skip.