### PR TITLE
[codex] Channel-framed packet connection: subscription + binary render-update packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,12 +84,21 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -153,12 +171,22 @@ dependencies = [
  "libc",
  "nix",
  "png",
+ "postcard",
  "serde",
  "serde_json",
  "sysinfo",
  "tempfile",
  "uuid",
  "windows-sys",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -186,6 +214,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossterm"
@@ -218,6 +252,18 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "equivalent"
@@ -280,6 +326,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +348,20 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -506,6 +575,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -635,6 +726,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +782,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/cleat/Cargo.toml
+++ b/crates/cleat/Cargo.toml
@@ -13,12 +13,13 @@ default = []
 ghostty-vt = ["dep:png"]
 
 [dependencies]
-bitflags = "2"
+bitflags = { version = "2", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 comfy-table = "7"
 http = "1"
 httparse = "1"
 humantime = "2"
+postcard = { version = "1", features = ["alloc"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 libc = "0.2"

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -115,6 +115,13 @@ pub enum Command {
         #[arg(value_name = "ID")]
         id: String,
     },
+    /// Subscribe to packet render updates and print debug summaries
+    Packets {
+        #[arg(value_name = "ID")]
+        id: String,
+        #[arg(long, default_value_t = 1, value_parser = parse_positive_usize, help = "Number of render packets to print")]
+        count: usize,
+    },
     /// Create a new session
     #[command(
         alias = "create",
@@ -501,6 +508,11 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 Err(e) => ExecResult::Err(e),
             }
         }
+        Command::Packets { id, count } => match run_packets_command(service, &id, count) {
+            Ok(lines) if lines.is_empty() => ExecResult::Ok(None),
+            Ok(lines) => ExecResult::Ok(Some(lines.join("\n"))),
+            Err(err) => ExecResult::Err(err),
+        },
         Command::Launch { id, json, size, vt, cwd, cmd, record } => {
             // Windows can provide basic sessions through ConPTY plus the
             // passthrough engine while Ghostty VT support is still optional.
@@ -931,6 +943,82 @@ fn format_session_status(status: &crate::protocol::SessionStatus) -> &'static st
     }
 }
 
+fn run_packets_command(service: &SessionService, id: &str, count: usize) -> Result<Vec<String>, String> {
+    let (mut client, directory) = service.connect_packets(id)?;
+    if !directory.sessions.iter().any(|entry| entry.session_id == id) {
+        return Err(format!("session {id} was not present in packet directory"));
+    }
+    const DEBUG_CHANNEL: u32 = 1;
+    client.open_channel(DEBUG_CHANNEL, id).map_err(|err| format!("open packet channel: {err}"))?;
+
+    let mut lines = Vec::with_capacity(count);
+    let mut previous_modes = None;
+    for _ in 0..count {
+        let packet = client.read_render(DEBUG_CHANNEL).map_err(|err| format!("read packet render: {err}"))?;
+        let update = packet.update;
+        lines.push(format_packet_summary(&update, previous_modes));
+        previous_modes = Some(update.terminal_modes);
+        client.ack(DEBUG_CHANNEL, update.render_generation).map_err(|err| format!("ack packet render: {err}"))?;
+    }
+    Ok(lines)
+}
+
+fn format_packet_summary(update: &crate::provider::TerminalRenderUpdate, previous_modes: Option<crate::vt::TerminalModeState>) -> String {
+    let full_replace_ops =
+        update.ops.iter().filter(|op| op.kind == crate::provider::TerminalRenderUpdateOpKind::FullVisibleReplace).count();
+    let row_replace_ops = update.ops.iter().filter(|op| op.kind == crate::provider::TerminalRenderUpdateOpKind::RowReplace).count();
+    let scroll_copy_ops = update.ops.iter().filter(|op| op.kind == crate::provider::TerminalRenderUpdateOpKind::ScrollCopy).count();
+    let changed_rows: u16 = update.ops.iter().map(|op| op.row_count).sum();
+    format!(
+        "gen={} ops={} full={} rows={} scroll={} changed_rows={} mode_changes={} images={}/{}",
+        update.render_generation,
+        update.ops.len(),
+        full_replace_ops,
+        row_replace_ops,
+        scroll_copy_ops,
+        changed_rows,
+        format_mode_changes(previous_modes, update.terminal_modes),
+        update.image_resources.len(),
+        update.image_placements.len()
+    )
+}
+
+fn format_mode_changes(previous: Option<crate::vt::TerminalModeState>, current: crate::vt::TerminalModeState) -> String {
+    let Some(previous) = previous else {
+        return "initial".to_string();
+    };
+    let mut changes = Vec::new();
+    if previous.active_alternate_screen != current.active_alternate_screen {
+        changes.push(format!("alt_screen={}", current.active_alternate_screen));
+    }
+    if previous.application_cursor_keys != current.application_cursor_keys {
+        changes.push(format!("app_cursor={}", current.application_cursor_keys));
+    }
+    if previous.alternate_scroll != current.alternate_scroll {
+        changes.push(format!("alt_scroll={}", current.alternate_scroll));
+    }
+    if previous.mouse_tracking != current.mouse_tracking {
+        changes.push(format!("mouse_tracking={}", current.mouse_tracking));
+    }
+    if previous.mouse_tracking_mode != current.mouse_tracking_mode {
+        changes.push(format!("mouse_mode={:?}", current.mouse_tracking_mode));
+    }
+    if previous.mouse_report_format != current.mouse_report_format {
+        changes.push(format!("mouse_format={:?}", current.mouse_report_format));
+    }
+    if previous.mouse_sgr != current.mouse_sgr {
+        changes.push(format!("mouse_sgr={}", current.mouse_sgr));
+    }
+    if previous.mouse_sgr_pixels != current.mouse_sgr_pixels {
+        changes.push(format!("mouse_sgr_pixels={}", current.mouse_sgr_pixels));
+    }
+    if changes.is_empty() {
+        "none".to_string()
+    } else {
+        changes.join(",")
+    }
+}
+
 fn format_inspect_human(result: &crate::protocol::InspectResult) -> String {
     use comfy_table::{presets::NOTHING, Table};
 
@@ -1000,6 +1088,15 @@ fn parse_terminal_size(value: &str) -> Result<TerminalSize, String> {
         return Err("size dimensions must be greater than zero".to_string());
     }
     Ok(TerminalSize { cols, rows })
+}
+
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    let count = value.parse::<usize>().map_err(|err| err.to_string())?;
+    if count == 0 {
+        Err("count must be at least 1".to_string())
+    } else {
+        Ok(count)
+    }
 }
 
 fn parse_repeat(value: &str) -> Result<usize, String> {

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -260,6 +260,7 @@ pub(crate) enum SessionCommand {
     ScrollViewport { command: ViewportCommand, reply: mpsc::Sender<Result<ViewportCommandOutcome, String>> },
     Snapshot { reply: mpsc::Sender<Result<TerminalSnapshot, String>> },
     RenderUpdate { reply: mpsc::Sender<Result<TerminalRenderUpdate, String>> },
+    FullRenderUpdate { reply: mpsc::Sender<Result<TerminalRenderUpdate, String>> },
     FullSnapshot { reply: mpsc::Sender<Result<TerminalSnapshot, String>> },
     ImageResourceData { image_id: u32, generation: u64, callback: ImageResourceDataCallback, reply: mpsc::Sender<Result<bool, String>> },
     Inspect { has_controller: bool, watcher_count: usize, reply: mpsc::Sender<Result<InspectResult, String>> },
@@ -623,8 +624,20 @@ impl SessionActor {
         self.request_result(|reply| SessionCommand::Resize { cols, rows, reply })
     }
 
+    pub(crate) fn set_cell_size(&self, cell_width_px: u32, cell_height_px: u32) -> Result<(), String> {
+        self.request_result(|reply| SessionCommand::SetCellSize { cell_width_px, cell_height_px, reply })
+    }
+
     pub(crate) fn write_input(&self, bytes: Vec<u8>) -> Result<(), String> {
         self.request_result(|reply| SessionCommand::WriteInput { bytes, reply })
+    }
+
+    pub(crate) fn wheel(&self, event: SessionWheelEvent) -> Result<usize, String> {
+        self.request_result(|reply| SessionCommand::Wheel { event, reply })
+    }
+
+    pub(crate) fn mouse(&self, event: SessionMouseEvent) -> Result<usize, String> {
+        self.request_result(|reply| SessionCommand::Mouse { event, reply })
     }
 
     pub(crate) fn paste(&self, text: Vec<u8>) -> Result<usize, String> {
@@ -637,6 +650,18 @@ impl SessionActor {
 
     pub(crate) fn full_snapshot(&self) -> Result<TerminalSnapshot, String> {
         self.request_result(|reply| SessionCommand::FullSnapshot { reply })
+    }
+
+    pub(crate) fn render_update(&self) -> Result<TerminalRenderUpdate, String> {
+        self.request_result(|reply| SessionCommand::RenderUpdate { reply })
+    }
+
+    pub(crate) fn full_render_update(&self) -> Result<TerminalRenderUpdate, String> {
+        self.request_result(|reply| SessionCommand::FullRenderUpdate { reply })
+    }
+
+    pub(crate) fn mark_observed(&self, generation: u64) -> bool {
+        self.request(|reply| SessionCommand::MarkObserved { generation, reply }, false)
     }
 
     pub(crate) fn capture_text(&self) -> Result<String, String> {
@@ -923,6 +948,16 @@ fn session_actor_handle_command(
             sync_terminal_modes_and_wake(runtime, &mut state.observation, wake);
             let result = runtime.render_update(state.observation.dirty()).map(|mut update| {
                 state.observation.annotate_render_update(&mut update);
+                update
+            });
+            let _ = reply.send(result);
+        }
+        SessionCommand::FullRenderUpdate { reply } => {
+            session_actor_pump(runtime, state, wake);
+            sync_terminal_modes_and_wake(runtime, &mut state.observation, wake);
+            let result = runtime.render_update(DirtyState::Full).map(|mut update| {
+                update.render_generation = state.observation.render_generation;
+                update.dirty = DirtyState::Full;
                 update
             });
             let _ = reply.send(result);

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -1,7 +1,7 @@
 use std::io::{Error, ErrorKind, Read, Write};
 
 use http::{
-    header::{CONNECTION, CONTENT_LENGTH, CONTENT_TYPE},
+    header::{CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, UPGRADE},
     HeaderName, HeaderValue, Method, Request, Response, StatusCode, Uri, Version,
 };
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,7 @@ pub(crate) type HttpRequest = Request<Vec<u8>>;
 pub(crate) enum Route {
     Root,
     Health,
+    PacketConnect,
     Sessions,
     SessionDelete { id: String },
     SessionAttach { id: String },
@@ -464,6 +465,7 @@ pub(crate) fn route(request: &HttpRequest) -> Route {
     match (request.method(), path) {
         (&Method::GET, "/") => Route::Root,
         (&Method::GET, "/healthz") => Route::Health,
+        (&Method::POST, "/connect") => Route::PacketConnect,
         (&Method::GET, "/sessions") => Route::Sessions,
         _ => {
             let Some(rest) = path.strip_prefix("/sessions/") else {
@@ -515,7 +517,19 @@ pub(crate) fn write_no_content(writer: &mut impl Write) -> std::io::Result<()> {
 }
 
 pub(crate) fn write_switching_protocols(writer: &mut impl Write) -> std::io::Result<()> {
-    write!(writer, "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: cleat-attach/1\r\n\r\n")
+    write_switching_protocols_for(writer, "cleat-attach/1")
+}
+
+pub(crate) fn write_packet_switching_protocols(writer: &mut impl Write) -> std::io::Result<()> {
+    write_switching_protocols_for(writer, "cleat-packet/1")
+}
+
+fn write_switching_protocols_for(writer: &mut impl Write, upgrade: &str) -> std::io::Result<()> {
+    write!(writer, "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: {upgrade}\r\n\r\n")
+}
+
+pub(crate) fn request_has_upgrade_token(request: &HttpRequest, token: &str) -> bool {
+    request.headers().get(UPGRADE).and_then(|value| value.to_str().ok()).is_some_and(|value| value.eq_ignore_ascii_case(token))
 }
 
 pub(crate) fn write_error(writer: &mut impl Write, status: StatusCode, message: &str) -> std::io::Result<()> {
@@ -714,6 +728,7 @@ mod tests {
     fn routes_provider_critical_session_endpoints() {
         let cases = [
             ("GET", "/healthz", Route::Health),
+            ("POST", "/connect", Route::PacketConnect),
             ("GET", "/sessions", Route::Sessions),
             ("GET", "/sessions/alpha", Route::SessionInspect { id: "alpha".to_string() }),
             ("DELETE", "/sessions/alpha", Route::SessionDelete { id: "alpha".to_string() }),

--- a/crates/cleat/src/lib.rs
+++ b/crates/cleat/src/lib.rs
@@ -6,6 +6,7 @@ pub mod duration_parser;
 mod host;
 mod http_uds;
 pub mod keys;
+pub mod packet;
 pub mod platform;
 pub mod protocol;
 pub mod provider;

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -144,6 +144,64 @@ impl PacketFrame {
     }
 }
 
+pub struct PacketClient<S> {
+    stream: S,
+    buffer: Vec<u8>,
+}
+
+impl<S: Read + Write> PacketClient<S> {
+    pub fn new(stream: S) -> Self {
+        Self { stream, buffer: Vec::new() }
+    }
+
+    pub fn open_channel(&mut self, channel: u32, session_id: &str) -> std::io::Result<()> {
+        self.write(CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL, &OpenChannel { channel, session_id: session_id.to_string() })
+    }
+
+    pub fn close_channel(&mut self, channel: u32, reason: Option<String>) -> std::io::Result<()> {
+        self.write(CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL, &CloseChannel { channel, reason })
+    }
+
+    pub fn ack(&mut self, channel: u32, generation: u64) -> std::io::Result<()> {
+        self.write(channel, MSG_SESSION_ACK, &Ack { generation })
+    }
+
+    pub fn input(&mut self, channel: u32, event: TerminalInputEvent) -> std::io::Result<()> {
+        self.write(channel, MSG_SESSION_INPUT, &Input { event })
+    }
+
+    pub fn resize(&mut self, channel: u32, cols: u16, rows: u16) -> std::io::Result<()> {
+        self.write(channel, MSG_SESSION_RESIZE, &Resize { cols, rows })
+    }
+
+    pub fn read_frame(&mut self) -> std::io::Result<PacketFrame> {
+        loop {
+            if let Some(frame) = PacketFrame::read_from_buffer(&mut self.buffer)? {
+                return Ok(frame);
+            }
+            let mut chunk = [0; 8192];
+            let n = self.stream.read(&mut chunk)?;
+            if n == 0 {
+                return Err(Error::new(ErrorKind::UnexpectedEof, "packet stream closed"));
+            }
+            self.buffer.extend_from_slice(&chunk[..n]);
+        }
+    }
+
+    pub fn read_render(&mut self, channel: u32) -> std::io::Result<RenderPacket> {
+        loop {
+            let frame = self.read_frame()?;
+            if frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER {
+                return frame.decode();
+            }
+        }
+    }
+
+    fn write<T: Serialize>(&mut self, channel: u32, msg_type: u8, value: &T) -> std::io::Result<()> {
+        PacketFrame::new(channel, msg_type, value)?.write(&mut self.stream)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -1,0 +1,192 @@
+use std::io::{Error, ErrorKind, Read, Write};
+
+use serde::{Deserialize, Serialize};
+
+use crate::provider::{TerminalInputEvent, TerminalRenderUpdate};
+
+pub const PROTOCOL_VERSION: u16 = 1;
+pub const CHANNEL_CONTROL: u32 = 0;
+
+pub const MSG_CONTROL_HELLO: u8 = 1;
+pub const MSG_CONTROL_DIRECTORY_SNAPSHOT: u8 = 2;
+pub const MSG_CONTROL_DIRECTORY_DELTA: u8 = 3;
+pub const MSG_CONTROL_OPEN_CHANNEL: u8 = 4;
+pub const MSG_CONTROL_CLOSE_CHANNEL: u8 = 5;
+pub const MSG_CONTROL_ERROR: u8 = 6;
+
+pub const MSG_SESSION_RENDER: u8 = 16;
+pub const MSG_SESSION_ACK: u8 = 17;
+pub const MSG_SESSION_INPUT: u8 = 18;
+pub const MSG_SESSION_RESIZE: u8 = 19;
+
+const HEADER_LEN: usize = 9;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlHello {
+    pub version: u16,
+    pub min_supported_version: u16,
+}
+
+impl ControlHello {
+    pub fn current() -> Self {
+        Self { version: PROTOCOL_VERSION, min_supported_version: PROTOCOL_VERSION }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectorySnapshot {
+    pub sessions: Vec<DirectoryEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectoryDelta {
+    pub upserted: Vec<DirectoryEntry>,
+    pub removed_session_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectoryEntry {
+    pub session_id: String,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpenChannel {
+    pub channel: u32,
+    pub session_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloseChannel {
+    pub channel: u32,
+    pub reason: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlError {
+    pub channel: u32,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RenderPacket {
+    pub update: TerminalRenderUpdate,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Ack {
+    pub generation: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Input {
+    pub event: TerminalInputEvent,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Resize {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PacketFrame {
+    pub channel: u32,
+    pub msg_type: u8,
+    pub payload: Vec<u8>,
+}
+
+impl PacketFrame {
+    pub fn new<T: Serialize>(channel: u32, msg_type: u8, value: &T) -> std::io::Result<Self> {
+        let payload = postcard::to_allocvec(value).map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
+        Ok(Self { channel, msg_type, payload })
+    }
+
+    pub fn decode<T: for<'de> Deserialize<'de>>(&self) -> std::io::Result<T> {
+        postcard::from_bytes(&self.payload).map_err(|err| Error::new(ErrorKind::InvalidData, err))
+    }
+
+    pub fn write(&self, writer: &mut impl Write) -> std::io::Result<()> {
+        let len =
+            u32::try_from(self.payload.len()).map_err(|_| Error::new(ErrorKind::InvalidInput, "packet payload exceeds u32 length"))?;
+        writer.write_all(&self.channel.to_le_bytes())?;
+        writer.write_all(&[self.msg_type])?;
+        writer.write_all(&len.to_le_bytes())?;
+        writer.write_all(&self.payload)
+    }
+
+    pub fn read(reader: &mut impl Read) -> std::io::Result<Self> {
+        let mut header = [0u8; HEADER_LEN];
+        reader.read_exact(&mut header)?;
+        let channel = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+        let msg_type = header[4];
+        let len = u32::from_le_bytes([header[5], header[6], header[7], header[8]]) as usize;
+        let mut payload = vec![0u8; len];
+        reader.read_exact(&mut payload)?;
+        Ok(Self { channel, msg_type, payload })
+    }
+
+    pub fn read_from_buffer(buffer: &mut Vec<u8>) -> std::io::Result<Option<Self>> {
+        if buffer.len() < HEADER_LEN {
+            return Ok(None);
+        }
+        let channel = u32::from_le_bytes([buffer[0], buffer[1], buffer[2], buffer[3]]);
+        let msg_type = buffer[4];
+        let len = u32::from_le_bytes([buffer[5], buffer[6], buffer[7], buffer[8]]) as usize;
+        let frame_len = HEADER_LEN.checked_add(len).ok_or_else(|| Error::new(ErrorKind::InvalidData, "packet length overflow"))?;
+        if buffer.len() < frame_len {
+            return Ok(None);
+        }
+        let payload = buffer[HEADER_LEN..frame_len].to_vec();
+        buffer.drain(..frame_len);
+        Ok(Some(Self { channel, msg_type, payload }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codec_round_trips_postcard_control_payloads() {
+        let hello = ControlHello::current();
+        let frame = PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_HELLO, &hello).expect("encode hello");
+        let mut bytes = Vec::new();
+        frame.write(&mut bytes).expect("write frame");
+
+        let decoded = PacketFrame::read(&mut bytes.as_slice()).expect("read frame");
+
+        assert_eq!(decoded.channel, CHANNEL_CONTROL);
+        assert_eq!(decoded.msg_type, MSG_CONTROL_HELLO);
+        assert_eq!(decoded.decode::<ControlHello>().expect("decode hello"), hello);
+    }
+
+    #[test]
+    fn buffer_reader_skips_unknown_message_payload_by_length() {
+        let unknown = PacketFrame { channel: CHANNEL_CONTROL, msg_type: 250, payload: vec![1, 2, 3, 4] };
+        let directory = DirectorySnapshot { sessions: vec![DirectoryEntry { session_id: "alpha".to_string(), cols: 80, rows: 24 }] };
+        let known = PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT, &directory).expect("encode directory");
+        let mut bytes = Vec::new();
+        unknown.write(&mut bytes).expect("write unknown");
+        known.write(&mut bytes).expect("write known");
+
+        let first = PacketFrame::read_from_buffer(&mut bytes).expect("read unknown").expect("unknown frame");
+        let second = PacketFrame::read_from_buffer(&mut bytes).expect("read known").expect("known frame");
+
+        assert_eq!(first.msg_type, 250);
+        assert_eq!(first.payload, vec![1, 2, 3, 4]);
+        assert_eq!(second.decode::<DirectorySnapshot>().expect("decode directory"), directory);
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn read_from_buffer_waits_for_complete_payload() {
+        let frame = PacketFrame { channel: 3, msg_type: 99, payload: vec![1, 2, 3] };
+        let mut bytes = Vec::new();
+        frame.write(&mut bytes).expect("write frame");
+        bytes.pop();
+
+        assert!(PacketFrame::read_from_buffer(&mut bytes).expect("read partial").is_none());
+    }
+}

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -20,6 +20,7 @@ pub const MSG_SESSION_INPUT: u8 = 18;
 pub const MSG_SESSION_RESIZE: u8 = 19;
 
 const HEADER_LEN: usize = 9;
+pub const MAX_PACKET_PAYLOAD_LEN: usize = 4 * 1024 * 1024;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ControlHello {
@@ -100,6 +101,9 @@ pub struct PacketFrame {
 impl PacketFrame {
     pub fn new<T: Serialize>(channel: u32, msg_type: u8, value: &T) -> std::io::Result<Self> {
         let payload = postcard::to_allocvec(value).map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
+        if payload.len() > MAX_PACKET_PAYLOAD_LEN {
+            return Err(Error::new(ErrorKind::InvalidInput, "packet payload exceeds maximum length"));
+        }
         Ok(Self { channel, msg_type, payload })
     }
 
@@ -122,6 +126,9 @@ impl PacketFrame {
         let channel = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
         let msg_type = header[4];
         let len = u32::from_le_bytes([header[5], header[6], header[7], header[8]]) as usize;
+        if len > MAX_PACKET_PAYLOAD_LEN {
+            return Err(Error::new(ErrorKind::InvalidData, "packet payload exceeds maximum length"));
+        }
         let mut payload = vec![0u8; len];
         reader.read_exact(&mut payload)?;
         Ok(Self { channel, msg_type, payload })
@@ -134,6 +141,9 @@ impl PacketFrame {
         let channel = u32::from_le_bytes([buffer[0], buffer[1], buffer[2], buffer[3]]);
         let msg_type = buffer[4];
         let len = u32::from_le_bytes([buffer[5], buffer[6], buffer[7], buffer[8]]) as usize;
+        if len > MAX_PACKET_PAYLOAD_LEN {
+            return Err(Error::new(ErrorKind::InvalidData, "packet payload exceeds maximum length"));
+        }
         let frame_len = HEADER_LEN.checked_add(len).ok_or_else(|| Error::new(ErrorKind::InvalidData, "packet length overflow"))?;
         if buffer.len() < frame_len {
             return Ok(None);
@@ -194,6 +204,12 @@ impl<S: Read + Write> PacketClient<S> {
             if frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER {
                 return frame.decode();
             }
+            if frame.channel == CHANNEL_CONTROL && frame.msg_type == MSG_CONTROL_ERROR {
+                let error = frame.decode::<ControlError>()?;
+                if error.channel == channel {
+                    return Err(Error::new(ErrorKind::InvalidData, error.message));
+                }
+            }
         }
     }
 
@@ -246,5 +262,33 @@ mod tests {
         bytes.pop();
 
         assert!(PacketFrame::read_from_buffer(&mut bytes).expect("read partial").is_none());
+    }
+
+    #[test]
+    fn oversized_packet_payload_is_rejected_before_allocation() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&CHANNEL_CONTROL.to_le_bytes());
+        bytes.push(MSG_CONTROL_HELLO);
+        bytes.extend_from_slice(&(MAX_PACKET_PAYLOAD_LEN as u32 + 1).to_le_bytes());
+
+        let err = PacketFrame::read(&mut bytes.as_slice()).expect_err("oversized frame rejected");
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+
+        let err = PacketFrame::read_from_buffer(&mut bytes).expect_err("oversized buffered frame rejected");
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn packet_client_read_render_surfaces_matching_control_error() {
+        let mut bytes = Vec::new();
+        PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_ERROR, &ControlError { channel: 7, message: "bad channel".to_string() })
+            .expect("encode error")
+            .write(&mut bytes)
+            .expect("write error");
+        let mut client = PacketClient::new(std::io::Cursor::new(bytes));
+
+        let err = client.read_render(7).expect_err("control error should surface");
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), "bad channel");
     }
 }

--- a/crates/cleat/src/provider.rs
+++ b/crates/cleat/src/provider.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use crate::vt::{self, ScreenGrid};
 
 bitflags::bitflags! {
-    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
     pub struct ProviderFeatures: u32 {
         const CELL_SNAPSHOTS = 1 << 0;
         const DAMAGE_ROWS = 1 << 1;
@@ -12,7 +14,7 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum DirtyState {
     #[default]
     Clean,
@@ -20,7 +22,7 @@ pub enum DirtyState {
     Full,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalSnapshot {
     pub cols: u16,
     pub rows: u16,
@@ -56,7 +58,7 @@ impl TerminalSnapshot {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalRenderUpdateOpKind {
     #[default]
     FullVisibleReplace,
@@ -64,7 +66,7 @@ pub enum TerminalRenderUpdateOpKind {
     ScrollCopy,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalRenderUpdateOp {
     pub kind: TerminalRenderUpdateOpKind,
     pub first_row: u16,
@@ -75,7 +77,7 @@ pub struct TerminalRenderUpdateOp {
     pub dst_row: u16,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalRenderRow {
     pub row: u16,
     pub col_count: u16,
@@ -90,13 +92,13 @@ pub struct TerminalRenderRow {
     pub dirty: bool,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalRenderCell {
     pub graphemes: Vec<u32>,
     pub style: TerminalRenderStyle,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalRenderStyle {
     pub flags: TerminalCellFlags,
     pub width: TerminalCellWidth,
@@ -116,14 +118,14 @@ pub struct TerminalRenderStyle {
     pub style_id: u16,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalStyleColor {
     pub tag: TerminalStyleColorTag,
     pub palette_index: u8,
     pub rgb: Option<TerminalRgb>,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalStyleColorTag {
     #[default]
     None,
@@ -131,7 +133,7 @@ pub enum TerminalStyleColorTag {
     Rgb,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalRenderUpdate {
     pub cols: u16,
     pub rows: u16,
@@ -148,7 +150,7 @@ pub struct TerminalRenderUpdate {
     pub image_placements: Vec<TerminalImagePlacement>,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalImageResource {
     pub image_id: u32,
     pub generation: u64,
@@ -161,7 +163,7 @@ pub struct TerminalImageResource {
 
 pub const TERMINAL_IMAGE_PLACEMENT_VIRTUAL: u32 = 1 << 0;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalImagePlacement {
     pub image_id: u32,
     pub generation: u64,
@@ -308,7 +310,7 @@ impl TerminalStyleColor {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalViewportKind {
     #[default]
     LiveNormal,
@@ -316,14 +318,14 @@ pub enum TerminalViewportKind {
     NormalScrollback,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalScrollbackExtent {
     pub normal_scrollback_rows: u64,
     pub live_rows: u16,
     pub alternate_screen: bool,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalScrollbarState {
     pub viewport_kind: TerminalViewportKind,
     pub total_rows: u64,
@@ -344,21 +346,21 @@ impl TerminalScrollbarState {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ViewportCommand {
     Top,
     Bottom,
     DeltaRows(i64),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ViewportCommandOutcome {
     Moved,
     NoOp,
     Unsupported,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalGeometry {
     pub cell_width_px: f32,
     pub cell_height_px: f32,
@@ -410,7 +412,7 @@ fn finite_or_zero(value: f32) -> f32 {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalCell {
     pub graphemes: Vec<u32>,
     pub fg: TerminalRgb,
@@ -441,7 +443,7 @@ impl TerminalCell {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalRgb {
     pub r: u8,
     pub g: u8,
@@ -455,7 +457,7 @@ impl TerminalRgb {
 }
 
 bitflags::bitflags! {
-    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
     pub struct TerminalCellFlags: u32 {
         const BOLD = 1 << 0;
         const ITALIC = 1 << 1;
@@ -503,7 +505,7 @@ impl TerminalCellFlags {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalCellWidth {
     #[default]
     Narrow,
@@ -523,7 +525,7 @@ impl TerminalCellWidth {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct TerminalCursor {
     pub col: u16,
     pub row: u16,
@@ -546,7 +548,7 @@ impl TerminalCursor {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalCursorStyle {
     Bar,
     #[default]
@@ -566,7 +568,7 @@ impl TerminalCursorStyle {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum TerminalInputEvent {
     Key(TerminalKeyEvent),
     Text(TerminalTextEvent),
@@ -577,7 +579,7 @@ pub enum TerminalInputEvent {
     RawBytes(Vec<u8>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalKeyEvent {
     pub key: TerminalKey,
     pub modifiers: TerminalModifiers,
@@ -587,7 +589,7 @@ pub struct TerminalKeyEvent {
     pub platform_keycode: u32,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalKeyAction {
     #[default]
     Press,
@@ -595,13 +597,13 @@ pub enum TerminalKeyAction {
     Release,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalKey {
     UnicodeScalar(u32),
     Named(TerminalNamedKey),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalNamedKey {
     Enter,
     Escape,
@@ -621,7 +623,7 @@ pub enum TerminalNamedKey {
 }
 
 bitflags::bitflags! {
-    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
     pub struct TerminalModifiers: u16 {
         const SHIFT = 1 << 0;
         const CTRL = 1 << 1;
@@ -630,12 +632,12 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalTextEvent {
     pub text: String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TerminalMouseEvent {
     pub kind: TerminalMouseEventKind,
     pub button: Option<TerminalMouseButton>,
@@ -649,7 +651,7 @@ pub struct TerminalMouseEvent {
     pub wheel_delta_y: f32,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalMouseEventKind {
     Press,
     Release,
@@ -657,7 +659,7 @@ pub enum TerminalMouseEventKind {
     Wheel,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TerminalMouseButton {
     Left,
     Middle,
@@ -667,7 +669,7 @@ pub enum TerminalMouseButton {
 }
 
 bitflags::bitflags! {
-    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
     pub struct TerminalMouseButtons: u16 {
         const LEFT = 1 << 0;
         const MIDDLE = 1 << 1;
@@ -677,17 +679,17 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalFocusEvent {
     pub focused: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalPasteEvent {
     pub text: String,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TerminalResizeEvent {
     pub cols: u16,
     pub rows: u16,
@@ -850,5 +852,165 @@ mod tests {
         assert!(matches!(mouse, TerminalInputEvent::Mouse(_)));
         assert!(matches!(paste, TerminalInputEvent::Paste(_)));
         assert!(matches!(raw, TerminalInputEvent::RawBytes(_)));
+    }
+
+    #[test]
+    fn postcard_round_trip_preserves_render_update_packet_fields() {
+        let update = TerminalRenderUpdate {
+            cols: 120,
+            rows: 40,
+            geometry: TerminalGeometry {
+                cell_width_px: 8.0,
+                cell_height_px: 16.0,
+                content_x_px: 1.0,
+                content_y_px: 2.0,
+                content_width_px: 960.0,
+                content_height_px: 640.0,
+            },
+            viewport_kind: TerminalViewportKind::NormalScrollback,
+            scrollback_offset_rows: 12,
+            scrollbar: TerminalScrollbarState::new(TerminalViewportKind::NormalScrollback, 200, 40, 12),
+            terminal_modes: vt::TerminalModeState {
+                active_alternate_screen: true,
+                application_cursor_keys: true,
+                alternate_scroll: true,
+                mouse_tracking: true,
+                mouse_tracking_mode: vt::MouseTrackingMode::Any,
+                mouse_report_format: vt::MouseReportFormat::SgrPixels,
+                mouse_sgr: true,
+                mouse_sgr_pixels: true,
+            },
+            render_generation: 42,
+            cursor: TerminalCursor {
+                col: 9,
+                row: 8,
+                visible: true,
+                style: TerminalCursorStyle::BlockHollow,
+                blink: true,
+                wide_tail: false,
+            },
+            dirty: DirtyState::Partial,
+            ops: vec![TerminalRenderUpdateOp {
+                kind: TerminalRenderUpdateOpKind::RowReplace,
+                first_row: 3,
+                row_count: 1,
+                col_count: 2,
+                rows: vec![TerminalRenderRow {
+                    row: 3,
+                    col_count: 2,
+                    cells: vec![TerminalRenderCell {
+                        graphemes: vec!['A' as u32, 0x0301],
+                        style: TerminalRenderStyle {
+                            flags: TerminalCellFlags::BOLD | TerminalCellFlags::UNDERLINE,
+                            width: TerminalCellWidth::Wide,
+                            resolved_fg: TerminalRgb { r: 1, g: 2, b: 3 },
+                            resolved_bg: TerminalRgb { r: 4, g: 5, b: 6 },
+                            fg_color: TerminalStyleColor::palette(7),
+                            bg_color: TerminalStyleColor::rgb(TerminalRgb { r: 8, g: 9, b: 10 }),
+                            underline_style: 2,
+                            underline_color: TerminalStyleColor::rgb(TerminalRgb { r: 11, g: 12, b: 13 }),
+                            protected: true,
+                            semantic: 4,
+                            has_hyperlink: true,
+                            hyperlink_id: 99,
+                            content_tag: 5,
+                            has_text: true,
+                            has_styling: true,
+                            style_id: 6,
+                        },
+                    }],
+                    wrap: true,
+                    wrap_continuation: true,
+                    has_graphemes: true,
+                    has_styling: true,
+                    has_hyperlink: true,
+                    semantic_prompt: 3,
+                    has_kitty_virtual_placeholder: true,
+                    dirty: true,
+                }],
+                src_row: 0,
+                dst_row: 3,
+            }],
+            image_resources: vec![TerminalImageResource {
+                image_id: 7,
+                generation: 9,
+                width_px: 100,
+                height_px: 50,
+                format: 1,
+                compression: 2,
+                data_len: 1234,
+            }],
+            image_placements: vec![TerminalImagePlacement {
+                image_id: 7,
+                generation: 9,
+                placement_id: 11,
+                z: -1,
+                viewport_col: 2,
+                viewport_row: 3,
+                grid_cols: 4,
+                grid_rows: 5,
+                pixel_width: 40,
+                pixel_height: 50,
+                source_x: 1,
+                source_y: 2,
+                source_width: 30,
+                source_height: 40,
+                x_offset_px: 6,
+                y_offset_px: 7,
+                flags: TERMINAL_IMAGE_PLACEMENT_VIRTUAL,
+            }],
+        };
+
+        let bytes = postcard::to_allocvec(&update).expect("serialize update");
+        let decoded: TerminalRenderUpdate = postcard::from_bytes(&bytes).expect("deserialize update");
+
+        assert_eq!(decoded, update);
+    }
+
+    #[test]
+    fn postcard_round_trip_preserves_snapshot_and_input_packets() {
+        let snapshot = TerminalSnapshot {
+            cols: 2,
+            rows: 1,
+            geometry: TerminalGeometry::from_cell_size(2, 1, 8.0, 16.0),
+            viewport_kind: TerminalViewportKind::LiveAlternate,
+            scrollback_offset_rows: 0,
+            scrollbar: TerminalScrollbarState::for_live_viewport(TerminalViewportKind::LiveAlternate, 1),
+            terminal_modes: vt::TerminalModeState { active_alternate_screen: true, ..vt::TerminalModeState::default() },
+            render_generation: 5,
+            cells: vec![TerminalCell {
+                graphemes: vec!['x' as u32],
+                fg: TerminalRgb { r: 1, g: 2, b: 3 },
+                bg: TerminalRgb { r: 4, g: 5, b: 6 },
+                underline_color: Some(TerminalRgb { r: 7, g: 8, b: 9 }),
+                flags: TerminalCellFlags::ITALIC | TerminalCellFlags::STRIKETHROUGH,
+                underline_style: 1,
+                width: TerminalCellWidth::Narrow,
+                protected: true,
+                semantic: 2,
+                has_hyperlink: true,
+            }],
+            cursor: TerminalCursor { col: 1, row: 0, visible: true, style: TerminalCursorStyle::Bar, blink: false, wide_tail: false },
+            dirty: DirtyState::Full,
+            dirty_rows: vec![0],
+        };
+        let input = TerminalInputEvent::Mouse(TerminalMouseEvent {
+            kind: TerminalMouseEventKind::Wheel,
+            button: None,
+            buttons: TerminalMouseButtons::LEFT | TerminalMouseButtons::RIGHT,
+            modifiers: TerminalModifiers::SHIFT | TerminalModifiers::CTRL,
+            cell_col: 1,
+            cell_row: 2,
+            x_px: 8.5,
+            y_px: 16.25,
+            wheel_delta_x: 1.0,
+            wheel_delta_y: -2.0,
+        });
+
+        let snapshot_bytes = postcard::to_allocvec(&snapshot).expect("serialize snapshot");
+        let input_bytes = postcard::to_allocvec(&input).expect("serialize input");
+
+        assert_eq!(postcard::from_bytes::<TerminalSnapshot>(&snapshot_bytes).expect("deserialize snapshot"), snapshot);
+        assert_eq!(postcard::from_bytes::<TerminalInputEvent>(&input_bytes).expect("deserialize input"), input);
     }
 }

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -1,4 +1,5 @@
 use std::{
+    io::Write,
     path::Path,
     thread,
     time::{Duration, Instant, SystemTime},
@@ -438,6 +439,44 @@ impl SessionService {
             return Err(format!("missing session {id}"));
         }
         watch_foreground(&self.layout, id)
+    }
+
+    pub fn connect_packets(
+        &self,
+        id: &str,
+    ) -> Result<(crate::packet::PacketClient<SessionStream>, crate::packet::DirectorySnapshot), String> {
+        if !self.layout.root().join(id).exists() {
+            return Err(format!("missing session {id}"));
+        }
+
+        let socket_path = session_socket_path(self.layout.root(), id);
+        let mut stream = connect_session_socket(&socket_path)?;
+        write!(
+            stream,
+            "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Length: 0\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n"
+        )
+        .map_err(|err| format!("write packet upgrade request: {err}"))?;
+        let response = http_uds::read_response_head(&mut stream).map_err(|err| format!("read packet upgrade response: {err}"))?;
+        if response.status != StatusCode::SWITCHING_PROTOCOLS {
+            return Err(format!("unexpected packet response: {}", response.status));
+        }
+
+        let mut client = crate::packet::PacketClient::new(stream);
+        let hello = client.read_frame().map_err(|err| format!("read packet hello: {err}"))?;
+        if hello.channel != crate::packet::CHANNEL_CONTROL || hello.msg_type != crate::packet::MSG_CONTROL_HELLO {
+            return Err("packet stream did not start with control hello".to_string());
+        }
+        let hello = hello.decode::<crate::packet::ControlHello>().map_err(|err| format!("decode packet hello: {err}"))?;
+        if hello.version != crate::packet::PROTOCOL_VERSION {
+            return Err(format!("unsupported packet protocol version {}", hello.version));
+        }
+
+        let directory = client.read_frame().map_err(|err| format!("read packet directory: {err}"))?;
+        if directory.channel != crate::packet::CHANNEL_CONTROL || directory.msg_type != crate::packet::MSG_CONTROL_DIRECTORY_SNAPSHOT {
+            return Err("packet stream did not send a directory snapshot after hello".to_string());
+        }
+        let directory = directory.decode::<crate::packet::DirectorySnapshot>().map_err(|err| format!("decode packet directory: {err}"))?;
+        Ok((client, directory))
     }
 
     pub fn inspect(&self, id: &str) -> Result<crate::protocol::InspectResult, String> {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(unix), allow(dead_code, unused_imports))]
 
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     fs,
     io::{self, Read, Write},
     path::{Path, PathBuf},
@@ -16,10 +16,12 @@ use std::{
 use http::StatusCode;
 
 use crate::{
-    host::actor::{RawOutputTap, SessionActor},
+    host::actor::{RawOutputTap, SessionActor, SessionMouseEvent, SessionWheelEvent},
     http_uds,
     packet::{
-        ControlHello, DirectoryEntry, DirectorySnapshot, PacketFrame, CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_HELLO,
+        Ack, CloseChannel, ControlError, ControlHello, DirectoryEntry, DirectorySnapshot, Input, OpenChannel, PacketFrame, RenderPacket,
+        Resize, CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL, MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_ERROR, MSG_CONTROL_HELLO,
+        MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT, MSG_SESSION_RENDER, MSG_SESSION_RESIZE,
     },
     platform::{
         daemon::{is_session_daemon_alive, spawn_daemon_process},
@@ -30,6 +32,7 @@ use crate::{
         terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
     protocol::Frame,
+    provider::{DirtyState, TerminalInputEvent, TerminalKey, TerminalMouseButton, TerminalMouseEventKind, TerminalNamedKey},
     runtime::{RuntimeLayout, SessionMetadata, TerminalSize},
     vt::{self, ScreenGrid, VtEngine, VtEngineKind},
 };
@@ -655,7 +658,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
 
         did_work |= drain_raw_output_tap(root, id, &actor, &mut raw_output_tap, &mut active_client, &mut watchers)?;
         drain_watcher_inputs(&mut watchers);
-        drain_packet_client_inputs(&mut packet_clients);
+        did_work |= service_packet_clients(&actor, id, &mut packet_clients)?;
 
         if active_client.is_some() {
             let mut client_disconnected = false;
@@ -702,6 +705,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
             did_work = true;
         }
         flush_watchers(&mut watchers);
+        push_due_packet_renders(&actor, &mut packet_clients)?;
         flush_packet_clients(&mut packet_clients);
 
         // Evaluate pending waits on each loop tick.
@@ -1244,12 +1248,17 @@ struct PacketClient {
     pending_output: Vec<u8>,
     input_reader: ActiveClientReader,
     input_buffer: Vec<u8>,
+    channels: HashMap<u32, PacketSessionChannel>,
+}
+
+struct PacketSessionChannel {
+    in_flight_generation: Option<u64>,
 }
 
 impl PacketClient {
     fn new(stream: SessionStream) -> Result<Self, String> {
         let input_reader = ActiveClientReader::new(&stream)?;
-        Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new() })
+        Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new(), channels: HashMap::new() })
     }
 
     fn enqueue_control<T: serde::Serialize>(&mut self, msg_type: u8, value: &T) -> Result<(), String> {
@@ -1305,12 +1314,217 @@ impl PacketClient {
     }
 }
 
-fn drain_packet_client_inputs(packet_clients: &mut Vec<PacketClient>) {
-    let mut ignored = VecDeque::new();
-    packet_clients.retain_mut(|client| {
-        ignored.clear();
-        client.drain_input_frames(&mut ignored, Duration::ZERO).unwrap_or_default()
-    });
+fn service_packet_clients(actor: &SessionActor, daemon_id: &str, packet_clients: &mut Vec<PacketClient>) -> Result<bool, String> {
+    let mut did_work = false;
+    let mut index = 0;
+    while index < packet_clients.len() {
+        let mut pending = VecDeque::new();
+        let connected = packet_clients[index]
+            .drain_input_frames(&mut pending, Duration::ZERO)
+            .map_err(|err| format!("read packet client frame: {err}"))?;
+        if !connected {
+            packet_clients.swap_remove(index);
+            did_work = true;
+            continue;
+        }
+
+        while let Some(frame) = pending.pop_front() {
+            did_work = true;
+            handle_packet_frame(actor, daemon_id, &mut packet_clients[index], frame)?;
+        }
+        index += 1;
+    }
+    Ok(did_work)
+}
+
+fn handle_packet_frame(actor: &SessionActor, daemon_id: &str, client: &mut PacketClient, frame: PacketFrame) -> Result<(), String> {
+    match (frame.channel, frame.msg_type) {
+        (CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL) => {
+            let open = frame.decode::<OpenChannel>().map_err(|err| format!("decode open-channel packet: {err}"))?;
+            open_packet_channel(actor, daemon_id, client, open)?;
+        }
+        (CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL) => {
+            let close = frame.decode::<CloseChannel>().map_err(|err| format!("decode close-channel packet: {err}"))?;
+            client.channels.remove(&close.channel);
+        }
+        (channel, MSG_SESSION_ACK) if channel != CHANNEL_CONTROL => {
+            let ack = frame.decode::<Ack>().map_err(|err| format!("decode ack packet: {err}"))?;
+            if let Some(session_channel) = client.channels.get_mut(&channel) {
+                session_channel.in_flight_generation = None;
+                actor.mark_observed(ack.generation);
+            }
+        }
+        (channel, MSG_SESSION_INPUT) if channel != CHANNEL_CONTROL => {
+            let input = frame.decode::<Input>().map_err(|err| format!("decode input packet: {err}"))?;
+            if client.channels.contains_key(&channel) {
+                route_packet_input_event(actor, input.event)?;
+            }
+        }
+        (channel, MSG_SESSION_RESIZE) if channel != CHANNEL_CONTROL => {
+            let resize = frame.decode::<Resize>().map_err(|err| format!("decode resize packet: {err}"))?;
+            if client.channels.contains_key(&channel) {
+                actor.resize(resize.cols, resize.rows)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn open_packet_channel(actor: &SessionActor, daemon_id: &str, client: &mut PacketClient, open: OpenChannel) -> Result<(), String> {
+    if open.channel == CHANNEL_CONTROL {
+        client.enqueue_control(MSG_CONTROL_ERROR, &ControlError {
+            channel: open.channel,
+            message: "session channel must be non-zero".to_string(),
+        })?;
+        return Ok(());
+    }
+    if open.session_id != daemon_id {
+        client.enqueue_control(MSG_CONTROL_ERROR, &ControlError {
+            channel: open.channel,
+            message: format!("unknown session {}", open.session_id),
+        })?;
+        return Ok(());
+    }
+
+    let update = actor.full_render_update()?;
+    let generation = update.render_generation;
+    client.enqueue_frame(
+        &PacketFrame::new(open.channel, MSG_SESSION_RENDER, &RenderPacket { update })
+            .map_err(|err| format!("encode initial render packet: {err}"))?,
+    )?;
+    client.channels.insert(open.channel, PacketSessionChannel { in_flight_generation: Some(generation) });
+    Ok(())
+}
+
+fn push_due_packet_renders(actor: &SessionActor, packet_clients: &mut Vec<PacketClient>) -> Result<(), String> {
+    if actor.observation().dirty() == DirtyState::Clean {
+        return Ok(());
+    }
+
+    for client in packet_clients {
+        let due_channels: Vec<u32> =
+            client.channels.iter().filter_map(|(channel, session)| session.in_flight_generation.is_none().then_some(*channel)).collect();
+        for channel in due_channels {
+            if actor.observation().dirty() == DirtyState::Clean {
+                return Ok(());
+            }
+            let update = actor.render_update()?;
+            let generation = update.render_generation;
+            client.enqueue_frame(
+                &PacketFrame::new(channel, MSG_SESSION_RENDER, &RenderPacket { update })
+                    .map_err(|err| format!("encode render packet: {err}"))?,
+            )?;
+            if let Some(session_channel) = client.channels.get_mut(&channel) {
+                session_channel.in_flight_generation = Some(generation);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn route_packet_input_event(actor: &SessionActor, event: TerminalInputEvent) -> Result<(), String> {
+    match event {
+        TerminalInputEvent::Text(event) => actor.write_input(event.text.into_bytes()),
+        TerminalInputEvent::Paste(event) => actor.paste(event.text.into_bytes()).map(|_| ()),
+        TerminalInputEvent::RawBytes(bytes) => actor.write_input(bytes),
+        TerminalInputEvent::Resize(event) => {
+            actor.resize(event.cols, event.rows)?;
+            if event.cell_width_px.is_finite()
+                && event.cell_height_px.is_finite()
+                && event.cell_width_px > 0.0
+                && event.cell_height_px > 0.0
+            {
+                actor.set_cell_size(event.cell_width_px.round() as u32, event.cell_height_px.round() as u32)?;
+            }
+            Ok(())
+        }
+        TerminalInputEvent::Mouse(event) => route_packet_mouse_event(actor, event),
+        TerminalInputEvent::Key(event) => actor.write_input(packet_key_event_bytes(event)),
+        TerminalInputEvent::Focus(_) => Ok(()),
+    }
+}
+
+fn route_packet_mouse_event(actor: &SessionActor, event: crate::provider::TerminalMouseEvent) -> Result<(), String> {
+    let modifiers = vt::MouseModifiers {
+        shift: event.modifiers.contains(crate::provider::TerminalModifiers::SHIFT),
+        ctrl: event.modifiers.contains(crate::provider::TerminalModifiers::CTRL),
+        alt: event.modifiers.contains(crate::provider::TerminalModifiers::ALT),
+    };
+    if event.kind == TerminalMouseEventKind::Wheel {
+        actor.wheel(SessionWheelEvent {
+            modifiers,
+            cell_col: event.cell_col,
+            cell_row: event.cell_row,
+            x_px: event.x_px,
+            y_px: event.y_px,
+            wheel_delta_x: event.wheel_delta_x,
+            wheel_delta_y: event.wheel_delta_y,
+        })?;
+        return Ok(());
+    }
+
+    let action = match event.kind {
+        TerminalMouseEventKind::Press => vt::MouseAction::Press,
+        TerminalMouseEventKind::Release => vt::MouseAction::Release,
+        TerminalMouseEventKind::Move => vt::MouseAction::Motion,
+        TerminalMouseEventKind::Wheel => unreachable!("wheel handled above"),
+    };
+    actor.mouse(SessionMouseEvent {
+        action,
+        button: event.button.and_then(packet_mouse_button),
+        any_button_pressed: !event.buttons.is_empty(),
+        modifiers,
+        x_px: event.x_px,
+        y_px: event.y_px,
+    })?;
+    Ok(())
+}
+
+fn packet_mouse_button(button: TerminalMouseButton) -> Option<vt::MouseButton> {
+    match button {
+        TerminalMouseButton::Left => Some(vt::MouseButton::Left),
+        TerminalMouseButton::Middle => Some(vt::MouseButton::Middle),
+        TerminalMouseButton::Right => Some(vt::MouseButton::Right),
+        TerminalMouseButton::Back | TerminalMouseButton::Forward => None,
+    }
+}
+
+fn packet_key_event_bytes(event: crate::provider::TerminalKeyEvent) -> Vec<u8> {
+    if let Some(text) = event.generated_text {
+        return text.into_bytes();
+    }
+    match event.key {
+        TerminalKey::UnicodeScalar(codepoint) => char::from_u32(codepoint).map(|ch| ch.to_string().into_bytes()).unwrap_or_default(),
+        TerminalKey::Named(key) => packet_named_key_bytes(key),
+    }
+}
+
+fn packet_named_key_bytes(key: TerminalNamedKey) -> Vec<u8> {
+    match key {
+        TerminalNamedKey::Enter => b"\r".to_vec(),
+        TerminalNamedKey::Escape => b"\x1b".to_vec(),
+        TerminalNamedKey::Backspace => b"\x7f".to_vec(),
+        TerminalNamedKey::Tab => b"\t".to_vec(),
+        TerminalNamedKey::Delete => b"\x1b[3~".to_vec(),
+        TerminalNamedKey::Insert => b"\x1b[2~".to_vec(),
+        TerminalNamedKey::Home => b"\x1b[H".to_vec(),
+        TerminalNamedKey::End => b"\x1b[F".to_vec(),
+        TerminalNamedKey::PageUp => b"\x1b[5~".to_vec(),
+        TerminalNamedKey::PageDown => b"\x1b[6~".to_vec(),
+        TerminalNamedKey::ArrowUp => b"\x1b[A".to_vec(),
+        TerminalNamedKey::ArrowDown => b"\x1b[B".to_vec(),
+        TerminalNamedKey::ArrowLeft => b"\x1b[D".to_vec(),
+        TerminalNamedKey::ArrowRight => b"\x1b[C".to_vec(),
+        TerminalNamedKey::Function(n) => match n {
+            1 => b"\x1bOP".to_vec(),
+            2 => b"\x1bOQ".to_vec(),
+            3 => b"\x1bOR".to_vec(),
+            4 => b"\x1bOS".to_vec(),
+            5..=12 => format!("\x1b[{}~", u16::from(n) + 10).into_bytes(),
+            _ => Vec::new(),
+        },
+    }
 }
 
 fn flush_packet_clients(packet_clients: &mut Vec<PacketClient>) {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -32,7 +32,9 @@ use crate::{
         terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
     protocol::Frame,
-    provider::{DirtyState, TerminalInputEvent, TerminalKey, TerminalMouseButton, TerminalMouseEventKind, TerminalNamedKey},
+    provider::{
+        DirtyState, TerminalInputEvent, TerminalKey, TerminalMouseButton, TerminalMouseEventKind, TerminalNamedKey, TerminalRenderUpdate,
+    },
     runtime::{RuntimeLayout, SessionMetadata, TerminalSize},
     vt::{self, ScreenGrid, VtEngine, VtEngineKind},
 };
@@ -592,6 +594,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
     let mut active_client: Option<ActiveClient> = None;
     let mut watchers: Vec<ActiveClient> = Vec::new();
     let mut packet_clients: Vec<PacketClient> = Vec::new();
+    let mut packet_render_cache = PacketRenderCache::default();
     let mut had_foreground_client = false;
     let mut pending_waits: Vec<PendingWait> = Vec::new();
     let mut pending_expects: Vec<PendingExpect> = Vec::new();
@@ -658,7 +661,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
 
         did_work |= drain_raw_output_tap(root, id, &actor, &mut raw_output_tap, &mut active_client, &mut watchers)?;
         drain_watcher_inputs(&mut watchers);
-        did_work |= service_packet_clients(&actor, id, &mut packet_clients)?;
+        did_work |= service_packet_clients(&actor, id, &mut packet_clients, &mut packet_render_cache)?;
 
         if active_client.is_some() {
             let mut client_disconnected = false;
@@ -705,7 +708,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
             did_work = true;
         }
         flush_watchers(&mut watchers);
-        push_due_packet_renders(&actor, &mut packet_clients)?;
+        push_due_packet_renders(&actor, &mut packet_clients, &mut packet_render_cache)?;
         flush_packet_clients(&mut packet_clients);
 
         // Evaluate pending waits on each loop tick.
@@ -1253,6 +1256,26 @@ struct PacketClient {
 
 struct PacketSessionChannel {
     in_flight_generation: Option<u64>,
+    last_sent_generation: u64,
+}
+
+#[derive(Default)]
+struct PacketRenderCache {
+    latest: Option<TerminalRenderUpdate>,
+}
+
+impl PacketRenderCache {
+    fn store(&mut self, update: TerminalRenderUpdate) {
+        self.latest = Some(update);
+    }
+
+    fn latest_generation(&self) -> Option<u64> {
+        self.latest.as_ref().map(|update| update.render_generation)
+    }
+
+    fn latest(&self) -> Option<&TerminalRenderUpdate> {
+        self.latest.as_ref()
+    }
 }
 
 impl PacketClient {
@@ -1314,7 +1337,12 @@ impl PacketClient {
     }
 }
 
-fn service_packet_clients(actor: &SessionActor, daemon_id: &str, packet_clients: &mut Vec<PacketClient>) -> Result<bool, String> {
+fn service_packet_clients(
+    actor: &SessionActor,
+    daemon_id: &str,
+    packet_clients: &mut Vec<PacketClient>,
+    render_cache: &mut PacketRenderCache,
+) -> Result<bool, String> {
     let mut did_work = false;
     let mut index = 0;
     while index < packet_clients.len() {
@@ -1330,18 +1358,24 @@ fn service_packet_clients(actor: &SessionActor, daemon_id: &str, packet_clients:
 
         while let Some(frame) = pending.pop_front() {
             did_work = true;
-            handle_packet_frame(actor, daemon_id, &mut packet_clients[index], frame)?;
+            handle_packet_frame(actor, daemon_id, &mut packet_clients[index], frame, render_cache)?;
         }
         index += 1;
     }
     Ok(did_work)
 }
 
-fn handle_packet_frame(actor: &SessionActor, daemon_id: &str, client: &mut PacketClient, frame: PacketFrame) -> Result<(), String> {
+fn handle_packet_frame(
+    actor: &SessionActor,
+    daemon_id: &str,
+    client: &mut PacketClient,
+    frame: PacketFrame,
+    render_cache: &mut PacketRenderCache,
+) -> Result<(), String> {
     match (frame.channel, frame.msg_type) {
         (CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL) => {
             let open = frame.decode::<OpenChannel>().map_err(|err| format!("decode open-channel packet: {err}"))?;
-            open_packet_channel(actor, daemon_id, client, open)?;
+            open_packet_channel(actor, daemon_id, client, open, render_cache)?;
         }
         (CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL) => {
             let close = frame.decode::<CloseChannel>().map_err(|err| format!("decode close-channel packet: {err}"))?;
@@ -1350,8 +1384,10 @@ fn handle_packet_frame(actor: &SessionActor, daemon_id: &str, client: &mut Packe
         (channel, MSG_SESSION_ACK) if channel != CHANNEL_CONTROL => {
             let ack = frame.decode::<Ack>().map_err(|err| format!("decode ack packet: {err}"))?;
             if let Some(session_channel) = client.channels.get_mut(&channel) {
-                session_channel.in_flight_generation = None;
-                actor.mark_observed(ack.generation);
+                if session_channel.in_flight_generation == Some(ack.generation) {
+                    session_channel.in_flight_generation = None;
+                    actor.mark_observed(ack.generation);
+                }
             }
         }
         (channel, MSG_SESSION_INPUT) if channel != CHANNEL_CONTROL => {
@@ -1371,7 +1407,13 @@ fn handle_packet_frame(actor: &SessionActor, daemon_id: &str, client: &mut Packe
     Ok(())
 }
 
-fn open_packet_channel(actor: &SessionActor, daemon_id: &str, client: &mut PacketClient, open: OpenChannel) -> Result<(), String> {
+fn open_packet_channel(
+    actor: &SessionActor,
+    daemon_id: &str,
+    client: &mut PacketClient,
+    open: OpenChannel,
+    render_cache: &mut PacketRenderCache,
+) -> Result<(), String> {
     if open.channel == CHANNEL_CONTROL {
         client.enqueue_control(MSG_CONTROL_ERROR, &ControlError {
             channel: open.channel,
@@ -1389,34 +1431,51 @@ fn open_packet_channel(actor: &SessionActor, daemon_id: &str, client: &mut Packe
 
     let update = actor.full_render_update()?;
     let generation = update.render_generation;
+    render_cache.store(update.clone());
     client.enqueue_frame(
         &PacketFrame::new(open.channel, MSG_SESSION_RENDER, &RenderPacket { update })
             .map_err(|err| format!("encode initial render packet: {err}"))?,
     )?;
-    client.channels.insert(open.channel, PacketSessionChannel { in_flight_generation: Some(generation) });
+    client.channels.insert(open.channel, PacketSessionChannel { in_flight_generation: Some(generation), last_sent_generation: generation });
     Ok(())
 }
 
-fn push_due_packet_renders(actor: &SessionActor, packet_clients: &mut Vec<PacketClient>) -> Result<(), String> {
-    if actor.observation().dirty() == DirtyState::Clean {
+fn push_due_packet_renders(
+    actor: &SessionActor,
+    packet_clients: &mut Vec<PacketClient>,
+    render_cache: &mut PacketRenderCache,
+) -> Result<(), String> {
+    if !packet_clients.iter().any(|client| !client.channels.is_empty()) {
         return Ok(());
     }
 
+    if actor.observation().dirty() != DirtyState::Clean {
+        render_cache.store(actor.render_update()?);
+    }
+
+    let Some(latest_generation) = render_cache.latest_generation() else {
+        return Ok(());
+    };
+    let Some(update) = render_cache.latest().cloned() else {
+        return Ok(());
+    };
+
     for client in packet_clients {
-        let due_channels: Vec<u32> =
-            client.channels.iter().filter_map(|(channel, session)| session.in_flight_generation.is_none().then_some(*channel)).collect();
+        let due_channels: Vec<u32> = client
+            .channels
+            .iter()
+            .filter_map(|(channel, session)| {
+                (session.in_flight_generation.is_none() && session.last_sent_generation < latest_generation).then_some(*channel)
+            })
+            .collect();
         for channel in due_channels {
-            if actor.observation().dirty() == DirtyState::Clean {
-                return Ok(());
-            }
-            let update = actor.render_update()?;
-            let generation = update.render_generation;
             client.enqueue_frame(
-                &PacketFrame::new(channel, MSG_SESSION_RENDER, &RenderPacket { update })
+                &PacketFrame::new(channel, MSG_SESSION_RENDER, &RenderPacket { update: update.clone() })
                     .map_err(|err| format!("encode render packet: {err}"))?,
             )?;
             if let Some(session_channel) = client.channels.get_mut(&channel) {
-                session_channel.in_flight_generation = Some(generation);
+                session_channel.in_flight_generation = Some(latest_generation);
+                session_channel.last_sent_generation = latest_generation;
             }
         }
     }

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1450,7 +1450,12 @@ fn push_due_packet_renders(
     }
 
     if actor.observation().dirty() != DirtyState::Clean {
-        render_cache.store(actor.render_update()?);
+        let update = if has_packet_channel_lagging_cached_generation(packet_clients, render_cache) {
+            actor.full_render_update()?
+        } else {
+            actor.render_update()?
+        };
+        render_cache.store(update);
     }
 
     let Some(latest_generation) = render_cache.latest_generation() else {
@@ -1480,6 +1485,13 @@ fn push_due_packet_renders(
         }
     }
     Ok(())
+}
+
+fn has_packet_channel_lagging_cached_generation(packet_clients: &[PacketClient], render_cache: &PacketRenderCache) -> bool {
+    let Some(latest_generation) = render_cache.latest_generation() else {
+        return false;
+    };
+    packet_clients.iter().flat_map(|client| client.channels.values()).any(|session| session.last_sent_generation < latest_generation)
 }
 
 fn route_packet_input_event(actor: &SessionActor, event: TerminalInputEvent) -> Result<(), String> {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -18,6 +18,9 @@ use http::StatusCode;
 use crate::{
     host::actor::{RawOutputTap, SessionActor},
     http_uds,
+    packet::{
+        ControlHello, DirectoryEntry, DirectorySnapshot, PacketFrame, CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_HELLO,
+    },
     platform::{
         daemon::{is_session_daemon_alive, spawn_daemon_process},
         ipc::{
@@ -585,6 +588,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
     let mut raw_output_tap = actor.subscribe_raw_output()?;
     let mut active_client: Option<ActiveClient> = None;
     let mut watchers: Vec<ActiveClient> = Vec::new();
+    let mut packet_clients: Vec<PacketClient> = Vec::new();
     let mut had_foreground_client = false;
     let mut pending_waits: Vec<PendingWait> = Vec::new();
     let mut pending_expects: Vec<PendingExpect> = Vec::new();
@@ -635,6 +639,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                         actor: &actor,
                         active_client: &mut active_client,
                         watchers: &mut watchers,
+                        packet_clients: &mut packet_clients,
                         had_foreground_client: &mut had_foreground_client,
                         pending_waits: &mut pending_waits,
                         pending_expects: &mut pending_expects,
@@ -650,6 +655,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
 
         did_work |= drain_raw_output_tap(root, id, &actor, &mut raw_output_tap, &mut active_client, &mut watchers)?;
         drain_watcher_inputs(&mut watchers);
+        drain_packet_client_inputs(&mut packet_clients);
 
         if active_client.is_some() {
             let mut client_disconnected = false;
@@ -696,6 +702,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
             did_work = true;
         }
         flush_watchers(&mut watchers);
+        flush_packet_clients(&mut packet_clients);
 
         // Evaluate pending waits on each loop tick.
         // Write errors are intentionally discarded — the client may have disconnected.
@@ -801,6 +808,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                 let _ = client.flush_pending_output();
             }
             flush_watchers(&mut watchers);
+            flush_packet_clients(&mut packet_clients);
             should_keep_session_dir = actor.should_keep_session_dir().unwrap_or(should_keep_session_dir);
             break;
         }
@@ -829,6 +837,7 @@ struct HttpRequestState<'a> {
     actor: &'a SessionActor,
     active_client: &'a mut Option<ActiveClient>,
     watchers: &'a mut Vec<ActiveClient>,
+    packet_clients: &'a mut Vec<PacketClient>,
     had_foreground_client: &'a mut bool,
     pending_waits: &'a mut Vec<PendingWait>,
     pending_expects: &'a mut Vec<PendingExpect>,
@@ -885,6 +894,26 @@ fn handle_http_request(
             let result = state.actor.inspect(state.active_client.is_some(), state.watchers.len())?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::SessionListResponse { sessions: vec![result] })
                 .map_err(|err| format!("write HTTP sessions response: {err}"))
+        }
+        http_uds::Route::PacketConnect => {
+            if !http_uds::request_has_upgrade_token(&request, "cleat-packet/1") {
+                http_uds::write_error(stream, StatusCode::BAD_REQUEST, "missing Upgrade: cleat-packet/1")
+                    .map_err(|err| format!("write HTTP packet upgrade error: {err}"))?;
+                return Ok(());
+            }
+
+            let inspect = state.actor.inspect(state.active_client.is_some(), state.watchers.len())?;
+            http_uds::write_packet_switching_protocols(stream).map_err(|err| format!("write HTTP packet upgrade response: {err}"))?;
+            let packet_stream = stream.try_clone().map_err(|err| format!("clone HTTP packet stream: {err}"))?;
+            #[cfg(unix)]
+            set_stream_nonblocking(&packet_stream, true).map_err(|err| format!("set HTTP packet stream nonblocking: {err}"))?;
+            let mut client = PacketClient::new(packet_stream)?;
+            client.enqueue_control(MSG_CONTROL_HELLO, &ControlHello::current())?;
+            client.enqueue_control(MSG_CONTROL_DIRECTORY_SNAPSHOT, &DirectorySnapshot {
+                sessions: vec![DirectoryEntry { session_id: inspect.session.id, cols: inspect.terminal.cols, rows: inspect.terminal.rows }],
+            })?;
+            state.packet_clients.push(client);
+            Ok(())
         }
         http_uds::Route::SessionInspect { id } if id == daemon_id => {
             let result = state.actor.inspect(state.active_client.is_some(), state.watchers.len())?;
@@ -1208,6 +1237,84 @@ fn http_input_key_bytes(key: http_uds::KeyRequest) -> Vec<u8> {
             http_uds::NamedKey::ArrowLeft => b"\x1b[D".to_vec(),
         },
     }
+}
+
+struct PacketClient {
+    stream: SessionStream,
+    pending_output: Vec<u8>,
+    input_reader: ActiveClientReader,
+    input_buffer: Vec<u8>,
+}
+
+impl PacketClient {
+    fn new(stream: SessionStream) -> Result<Self, String> {
+        let input_reader = ActiveClientReader::new(&stream)?;
+        Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new() })
+    }
+
+    fn enqueue_control<T: serde::Serialize>(&mut self, msg_type: u8, value: &T) -> Result<(), String> {
+        let frame = PacketFrame::new(CHANNEL_CONTROL, msg_type, value).map_err(|err| format!("encode packet control frame: {err}"))?;
+        self.enqueue_frame(&frame)
+    }
+
+    fn enqueue_frame(&mut self, frame: &PacketFrame) -> Result<(), String> {
+        let mut encoded = Vec::new();
+        frame.write(&mut encoded).map_err(|err| format!("buffer packet frame: {err}"))?;
+        if self.pending_output.len().saturating_add(encoded.len()) > MAX_PENDING_CLIENT_OUTPUT_BYTES {
+            return Err(format!("packet client output backlog exceeded {} bytes", MAX_PENDING_CLIENT_OUTPUT_BYTES));
+        }
+        self.pending_output.extend_from_slice(&encoded);
+        Ok(())
+    }
+
+    fn drain_input_frames(&mut self, pending: &mut VecDeque<PacketFrame>, timeout: Duration) -> Result<bool, std::io::Error> {
+        let mut first_poll = true;
+        loop {
+            let chunk = if first_poll {
+                first_poll = false;
+                self.input_reader.poll_timeout(&mut self.stream, timeout)?
+            } else {
+                self.input_reader.poll(&mut self.stream)?
+            };
+            match chunk {
+                Some(bytes) if bytes.is_empty() => return Ok(false),
+                Some(bytes) => self.input_buffer.extend_from_slice(&bytes),
+                None => break,
+            }
+        }
+
+        while let Some(frame) = PacketFrame::read_from_buffer(&mut self.input_buffer)? {
+            pending.push_back(frame);
+        }
+        Ok(true)
+    }
+
+    fn flush_pending_output(&mut self) -> Result<bool, String> {
+        while !self.pending_output.is_empty() {
+            match self.stream.write(&self.pending_output) {
+                Ok(0) => return Ok(false),
+                Ok(n) => {
+                    self.pending_output.drain(..n);
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(err) if is_graceful_socket_shutdown(&err) => return Ok(false),
+                Err(err) => return Err(format!("flush packet client output: {err}")),
+            }
+        }
+        Ok(true)
+    }
+}
+
+fn drain_packet_client_inputs(packet_clients: &mut Vec<PacketClient>) {
+    let mut ignored = VecDeque::new();
+    packet_clients.retain_mut(|client| {
+        ignored.clear();
+        client.drain_input_frames(&mut ignored, Duration::ZERO).unwrap_or_default()
+    });
+}
+
+fn flush_packet_clients(packet_clients: &mut Vec<PacketClient>) {
+    packet_clients.retain_mut(|client| client.flush_pending_output().unwrap_or(false));
 }
 
 struct ActiveClient {

--- a/crates/cleat/src/vt/mod.rs
+++ b/crates/cleat/src/vt/mod.rs
@@ -18,7 +18,7 @@ use crate::provider::{
     ViewportCommand, ViewportCommandOutcome,
 };
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ClientCapabilities {
     pub color_level: ColorLevel,
@@ -35,7 +35,7 @@ impl ClientCapabilities {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ColorLevel {
     Sixteen,
     Ansi256,
@@ -43,14 +43,14 @@ pub enum ColorLevel {
     TrueColor,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Rgb {
     pub r: u8,
     pub g: u8,
     pub b: u8,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalColors {
     pub default_foreground: Option<Rgb>,
     pub default_background: Option<Rgb>,
@@ -58,7 +58,7 @@ pub struct TerminalColors {
 }
 
 bitflags::bitflags! {
-    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
     pub struct CellFlags: u16 {
         const BOLD          = 1 << 0;
         const ITALIC        = 1 << 1;
@@ -72,7 +72,7 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum CellWidth {
     #[default]
     Narrow,
@@ -81,7 +81,7 @@ pub enum CellWidth {
     SpacerHead,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct ResolvedCell {
     pub graphemes: Vec<u32>,
     pub fg: Rgb,
@@ -95,7 +95,7 @@ pub struct ResolvedCell {
     pub has_hyperlink: bool,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum CursorStyle {
     Bar,
     #[default]
@@ -104,7 +104,7 @@ pub enum CursorStyle {
     BlockHollow,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct CursorState {
     pub col: u16,
     pub row: u16,
@@ -114,7 +114,7 @@ pub struct CursorState {
     pub wide_tail: bool,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct ScreenGrid {
     pub cells: Vec<ResolvedCell>,
     pub cols: u16,
@@ -157,7 +157,7 @@ impl ScreenGrid {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MouseTrackingMode {
     #[default]
     None,
@@ -167,7 +167,7 @@ pub enum MouseTrackingMode {
     Any,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MouseReportFormat {
     #[default]
     Legacy,
@@ -175,7 +175,7 @@ pub enum MouseReportFormat {
     SgrPixels,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TerminalModeState {
     pub active_alternate_screen: bool,
     pub application_cursor_keys: bool,
@@ -220,7 +220,7 @@ impl VtEngineKind {
 }
 
 /// Backend-neutral mouse event action.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MouseAction {
     Press,
     Release,
@@ -229,7 +229,7 @@ pub enum MouseAction {
 
 /// Backend-neutral mouse button identity (named, not numbered: the wire
 /// button codes differ between Cleat and Ghostty and are resolved per backend).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MouseButton {
     Left,
     Middle,
@@ -243,7 +243,7 @@ pub enum MouseButton {
 }
 
 /// Keyboard modifiers relevant to mouse encoding.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MouseModifiers {
     pub shift: bool,
     pub ctrl: bool,

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -14,6 +14,7 @@ fn help_lists_expected_subcommands() {
     assert_eq!(subcommands, vec![
         "attach",
         "watch",
+        "packets",
         "launch",
         "list",
         "capture",
@@ -33,6 +34,12 @@ fn help_lists_expected_subcommands() {
         "expect"
     ]);
     assert!(!subcommands.contains(&"create".to_string()), "create should not be visible in help");
+}
+
+#[test]
+fn packets_command_parses() {
+    let cli = Cli::try_parse_from(["cleat", "packets", "demo", "--count", "3"]).expect("packets parses");
+    assert_eq!(cli.command, Command::Packets { id: "demo".into(), count: 3 });
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -748,6 +748,35 @@ fn packet_render_ack_enforces_one_in_flight_and_coalesces_slow_clients() {
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
+fn packets_command_prints_render_summaries() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(
+            Some("alpha".into()),
+            Some(VtEngineKind::Ghostty),
+            None,
+            Some("sh -c 'sleep 1; printf \"\\033[?1003h\"; sleep 30'".into()),
+            false,
+        )
+        .expect("create alpha");
+    let cli = Cli::try_parse_from(["cleat", "packets", "alpha", "--count", "2"]).expect("parse packets");
+
+    let output = cli::execute(cli, &service).expect("execute packets").expect("packets output");
+    let lines: Vec<_> = output.lines().collect();
+
+    assert_eq!(lines.len(), 2);
+    assert!(lines[0].contains("gen="), "{output}");
+    assert!(lines[0].contains("ops="), "{output}");
+    assert!(lines[0].contains("mode_changes=initial"), "{output}");
+    assert!(lines[1].contains("mode_changes="), "{output}");
+    assert!(lines[1].contains("mouse_tracking=true"), "{output}");
+    assert!(lines[1].contains("rows=0"), "{output}");
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
 fn capture_returns_text_for_ghostty_sessions() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -15,6 +15,9 @@ use clap::Parser;
 use cleat::session::foreground_path;
 use cleat::{
     cli::{self, Cli, ExecResult},
+    packet::{
+        ControlHello, DirectorySnapshot, PacketFrame, CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_HELLO, PROTOCOL_VERSION,
+    },
     protocol::{Frame, SessionInfo},
     provider::ProviderFeatures,
     provider_ffi::{
@@ -67,6 +70,18 @@ fn http_attach_stream(root: &std::path::Path, id: &str, cols: u16, rows: u16, ca
 
 fn http_watch_stream(root: &std::path::Path, id: &str, cols: u16, rows: u16, capabilities: ClientCapabilities) -> UnixStream {
     http_upgrade_stream(root, id, "watch", cols, rows, capabilities)
+}
+
+fn http_packet_stream(root: &std::path::Path, id: &str) -> UnixStream {
+    let socket_path = session_socket_path(root, id);
+    let mut stream = UnixStream::connect(&socket_path).expect("connect session socket");
+    write!(stream, "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Length: 0\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n",)
+        .expect("write packet upgrade request");
+
+    let response = read_http_response_head(&mut stream);
+    assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{response}");
+    assert!(response.contains("Upgrade: cleat-packet/1\r\n"), "{response}");
+    stream
 }
 
 fn http_upgrade_stream(
@@ -546,6 +561,31 @@ fn create_respawns_over_a_stale_crashed_daemon() {
     assert_eq!(sessions.len(), 1, "exactly one live session after respawn");
     assert_eq!(sessions[0].id, id);
     service.kill(id).expect("kill respawned session");
+}
+
+#[test]
+fn packet_connect_emits_hello_and_directory_snapshot() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create alpha");
+
+    let mut stream = http_packet_stream(temp.path(), "alpha");
+    stream.set_read_timeout(Some(Duration::from_secs(2))).expect("set read timeout");
+
+    let hello_frame = PacketFrame::read(&mut stream).expect("read hello");
+    let directory_frame = PacketFrame::read(&mut stream).expect("read directory");
+
+    assert_eq!(hello_frame.channel, CHANNEL_CONTROL);
+    assert_eq!(hello_frame.msg_type, MSG_CONTROL_HELLO);
+    assert_eq!(hello_frame.decode::<ControlHello>().expect("decode hello").version, PROTOCOL_VERSION);
+    assert_eq!(directory_frame.channel, CHANNEL_CONTROL);
+    assert_eq!(directory_frame.msg_type, MSG_CONTROL_DIRECTORY_SNAPSHOT);
+    assert_eq!(directory_frame.decode::<DirectorySnapshot>().expect("decode directory").sessions, vec![cleat::packet::DirectoryEntry {
+        session_id: "alpha".to_string(),
+        cols: 80,
+        rows: 24
+    }]);
 }
 
 #[cfg(feature = "ghostty-vt")]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -736,6 +736,7 @@ fn packet_render_ack_enforces_one_in_flight_and_coalesces_slow_clients() {
     std::thread::sleep(Duration::from_millis(500));
     packet_input(&mut stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "a".to_string() }));
     let first = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    packet_ack(&mut stream, 1, initial.render_generation);
     packet_input(&mut stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "b".to_string() }));
     expect_no_packet(&mut stream, Duration::from_millis(120));
 
@@ -744,6 +745,40 @@ fn packet_render_ack_enforces_one_in_flight_and_coalesces_slow_clients() {
     assert!(coalesced.render_generation > first.render_generation);
     packet_ack(&mut stream, 1, coalesced.render_generation);
     expect_no_packet(&mut stream, Duration::from_millis(120));
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn packet_concurrent_channels_receive_same_dirty_generation() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(Some("alpha".into()), Some(VtEngineKind::Ghostty), None, Some("sh -c 'stty raw; exec cat'".into()), false)
+        .expect("create alpha");
+
+    let mut first_stream = http_packet_stream(temp.path(), "alpha");
+    let _hello = PacketFrame::read(&mut first_stream).expect("read first hello");
+    let _directory = PacketFrame::read(&mut first_stream).expect("read first directory");
+    packet_open_channel(&mut first_stream, 1, "alpha");
+    let first_initial = read_packet_render(&mut first_stream, 1, Duration::from_secs(2));
+    packet_ack(&mut first_stream, 1, first_initial.render_generation);
+
+    let mut second_stream = http_packet_stream(temp.path(), "alpha");
+    let _hello = PacketFrame::read(&mut second_stream).expect("read second hello");
+    let _directory = PacketFrame::read(&mut second_stream).expect("read second directory");
+    packet_open_channel(&mut second_stream, 1, "alpha");
+    let second_initial = read_packet_render(&mut second_stream, 1, Duration::from_secs(2));
+    packet_ack(&mut second_stream, 1, second_initial.render_generation);
+
+    std::thread::sleep(Duration::from_millis(500));
+    packet_input(&mut first_stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "x".to_string() }));
+    let first_update = read_packet_render(&mut first_stream, 1, Duration::from_secs(2));
+    let second_update = read_packet_render(&mut second_stream, 1, Duration::from_secs(2));
+
+    assert_eq!(first_update.render_generation, second_update.render_generation);
+    assert!(!first_update.ops.is_empty(), "first viewer should receive row content");
+    assert!(!second_update.ops.is_empty(), "second viewer should receive row content");
 }
 
 #[cfg(feature = "ghostty-vt")]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -783,6 +783,47 @@ fn packet_concurrent_channels_receive_same_dirty_generation() {
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
+fn packet_lagging_channel_receives_cached_generation_after_session_goes_clean() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(Some("alpha".into()), Some(VtEngineKind::Ghostty), None, Some("sh -c 'stty raw; exec cat'".into()), false)
+        .expect("create alpha");
+
+    let mut fast_stream = http_packet_stream(temp.path(), "alpha");
+    let _hello = PacketFrame::read(&mut fast_stream).expect("read fast hello");
+    let _directory = PacketFrame::read(&mut fast_stream).expect("read fast directory");
+    packet_open_channel(&mut fast_stream, 1, "alpha");
+    let fast_initial = read_packet_render(&mut fast_stream, 1, Duration::from_secs(2));
+    packet_ack(&mut fast_stream, 1, fast_initial.render_generation);
+
+    let mut slow_stream = http_packet_stream(temp.path(), "alpha");
+    let _hello = PacketFrame::read(&mut slow_stream).expect("read slow hello");
+    let _directory = PacketFrame::read(&mut slow_stream).expect("read slow directory");
+    packet_open_channel(&mut slow_stream, 1, "alpha");
+    let slow_initial = read_packet_render(&mut slow_stream, 1, Duration::from_secs(2));
+
+    std::thread::sleep(Duration::from_millis(500));
+    packet_input(&mut fast_stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "y".to_string() }));
+    let fast_update = loop {
+        let update = read_packet_render(&mut fast_stream, 1, Duration::from_secs(2));
+        if !update.ops.is_empty() {
+            break update;
+        }
+        packet_ack(&mut fast_stream, 1, update.render_generation);
+    };
+    packet_ack(&mut fast_stream, 1, fast_update.render_generation);
+
+    packet_ack(&mut slow_stream, 1, slow_initial.render_generation);
+    let slow_update = read_packet_render(&mut slow_stream, 1, Duration::from_secs(2));
+
+    assert_eq!(slow_update.render_generation, fast_update.render_generation);
+    assert!(!slow_update.ops.is_empty(), "lagging viewer should receive cached row content after fast ack");
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
 fn packets_command_prints_render_summaries() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -30,6 +30,11 @@ use cleat::{
     session::{daemon_pid_path, session_socket_path},
     vt::{self, ClientCapabilities, ColorLevel, VtEngineKind},
 };
+#[cfg(feature = "ghostty-vt")]
+use cleat::{
+    packet::{Ack, Input, OpenChannel, RenderPacket, MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT, MSG_SESSION_RENDER},
+    provider::{TerminalInputEvent, TerminalPasteEvent, TerminalRenderUpdate, TerminalTextEvent},
+};
 
 fn service_for(path: &std::path::Path) -> SessionService {
     SessionService::new(RuntimeLayout::new(path.to_path_buf()))
@@ -82,6 +87,72 @@ fn http_packet_stream(root: &std::path::Path, id: &str) -> UnixStream {
     assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{response}");
     assert!(response.contains("Upgrade: cleat-packet/1\r\n"), "{response}");
     stream
+}
+
+#[cfg(feature = "ghostty-vt")]
+fn packet_write<T: serde::Serialize>(stream: &mut UnixStream, channel: u32, msg_type: u8, value: &T) {
+    PacketFrame::new(channel, msg_type, value).expect("encode packet frame").write(stream).expect("write packet frame");
+}
+
+#[cfg(feature = "ghostty-vt")]
+fn packet_open_channel(stream: &mut UnixStream, channel: u32, session_id: &str) {
+    packet_write(stream, CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL, &OpenChannel { channel, session_id: session_id.to_string() });
+}
+
+#[cfg(feature = "ghostty-vt")]
+fn packet_ack(stream: &mut UnixStream, channel: u32, generation: u64) {
+    packet_write(stream, channel, MSG_SESSION_ACK, &Ack { generation });
+}
+
+#[cfg(feature = "ghostty-vt")]
+fn packet_input(stream: &mut UnixStream, channel: u32, event: TerminalInputEvent) {
+    packet_write(stream, channel, MSG_SESSION_INPUT, &Input { event });
+}
+
+#[cfg(feature = "ghostty-vt")]
+fn read_packet_render(stream: &mut UnixStream, channel: u32, timeout: Duration) -> TerminalRenderUpdate {
+    stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
+    let deadline = Instant::now() + timeout;
+    let mut buffer = Vec::new();
+    while Instant::now() < deadline {
+        while let Some(frame) = PacketFrame::read_from_buffer(&mut buffer).expect("parse packet buffer") {
+            if frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER {
+                return frame.decode::<RenderPacket>().expect("decode render packet").update;
+            }
+        }
+        let mut chunk = [0; 4096];
+        match stream.read(&mut chunk) {
+            Ok(0) => panic!("packet stream closed while waiting for render packet"),
+            Ok(n) => buffer.extend_from_slice(&chunk[..n]),
+            Err(err) if packet_read_would_wait(&err) => {}
+            Err(err) => panic!("read packet frame: {err}"),
+        }
+    }
+    panic!("timed out waiting for render packet on channel {channel}");
+}
+
+#[cfg(feature = "ghostty-vt")]
+fn expect_no_packet(stream: &mut UnixStream, timeout: Duration) {
+    stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
+    let deadline = Instant::now() + timeout;
+    let mut buffer = Vec::new();
+    while Instant::now() < deadline {
+        if let Some(frame) = PacketFrame::read_from_buffer(&mut buffer).expect("parse packet buffer") {
+            panic!("unexpected packet frame: {frame:?}");
+        }
+        let mut chunk = [0; 4096];
+        match stream.read(&mut chunk) {
+            Ok(0) => return,
+            Ok(n) => buffer.extend_from_slice(&chunk[..n]),
+            Err(err) if packet_read_would_wait(&err) => {}
+            Err(err) => panic!("read packet frame: {err}"),
+        }
+    }
+}
+
+#[cfg(feature = "ghostty-vt")]
+fn packet_read_would_wait(err: &std::io::Error) -> bool {
+    matches!(err.kind(), std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut) || err.raw_os_error() == Some(libc::EINVAL)
 }
 
 fn http_upgrade_stream(
@@ -586,6 +657,93 @@ fn packet_connect_emits_hello_and_directory_snapshot() {
         cols: 80,
         rows: 24
     }]);
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn packet_channel_initial_render_and_packet_input_flow() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(Some("alpha".into()), Some(VtEngineKind::Ghostty), None, Some("sh -c 'stty raw; exec cat'".into()), false)
+        .expect("create alpha");
+
+    let mut stream = http_packet_stream(temp.path(), "alpha");
+    let _hello = PacketFrame::read(&mut stream).expect("read hello");
+    let _directory = PacketFrame::read(&mut stream).expect("read directory");
+
+    packet_open_channel(&mut stream, 1, "alpha");
+    let initial = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    assert_eq!(initial.dirty, cleat::provider::DirtyState::Full);
+    assert!(!initial.ops.is_empty());
+    packet_ack(&mut stream, 1, initial.render_generation);
+
+    std::thread::sleep(Duration::from_millis(500));
+    packet_input(&mut stream, 1, TerminalInputEvent::Paste(TerminalPasteEvent { text: "packet paste".to_string() }));
+    let update = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    assert!(update.render_generation > initial.render_generation);
+    assert!(!update.ops.is_empty());
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn packet_mode_only_change_produces_zero_row_ops() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(
+            Some("alpha".into()),
+            Some(VtEngineKind::Ghostty),
+            None,
+            Some("sh -c 'sleep 1; printf \"\\033[?1003h\"; sleep 30'".into()),
+            false,
+        )
+        .expect("create alpha");
+
+    let mut stream = http_packet_stream(temp.path(), "alpha");
+    let _hello = PacketFrame::read(&mut stream).expect("read hello");
+    let _directory = PacketFrame::read(&mut stream).expect("read directory");
+    packet_open_channel(&mut stream, 1, "alpha");
+    let initial = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    packet_ack(&mut stream, 1, initial.render_generation);
+
+    let update = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+
+    assert!(update.terminal_modes.mouse_tracking);
+    assert_eq!(update.terminal_modes.mouse_tracking_mode, vt::MouseTrackingMode::Any);
+    assert!(update.ops.is_empty(), "mode-only packet should not carry row ops: {:?}", update.ops);
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn packet_render_ack_enforces_one_in_flight_and_coalesces_slow_clients() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(Some("alpha".into()), Some(VtEngineKind::Ghostty), None, Some("sh -c 'stty raw; exec cat'".into()), false)
+        .expect("create alpha");
+
+    let mut stream = http_packet_stream(temp.path(), "alpha");
+    let _hello = PacketFrame::read(&mut stream).expect("read hello");
+    let _directory = PacketFrame::read(&mut stream).expect("read directory");
+    packet_open_channel(&mut stream, 1, "alpha");
+    let initial = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    packet_ack(&mut stream, 1, initial.render_generation);
+
+    std::thread::sleep(Duration::from_millis(500));
+    packet_input(&mut stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "a".to_string() }));
+    let first = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    packet_input(&mut stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "b".to_string() }));
+    expect_no_packet(&mut stream, Duration::from_millis(120));
+
+    packet_ack(&mut stream, 1, first.render_generation);
+    let coalesced = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    assert!(coalesced.render_generation > first.render_generation);
+    packet_ack(&mut stream, 1, coalesced.render_generation);
+    expect_no_packet(&mut stream, Duration::from_millis(120));
 }
 
 #[cfg(feature = "ghostty-vt")]


### PR DESCRIPTION
Fixes #99. Phase 2 of the daemon-mode/M:N arc — this is the wire uishell daemon mode talks; remote/tunneled follows by forwarding the socket.

Implemented by a cleat-hosted codex from the locked scoping plan on the issue (four commits, each independently green on all four gates).

## Commits

1. `packet: serialize render packet types` — serde derives across the packet types + postcard; round-trip tests. Zero behavior change.
2. `packet: add connect handshake` — framing codec (`[u32 channel][u8 type][u32 len]` + postcard payloads), `/connect` + `Upgrade: cleat-packet/1`, hello/version, channel-0 directory snapshot (single session today; #100/#101 add entries, not protocol).
3. `packet: stream session render channels` — subscribe → initial full-dirty packet → generation/ack flow with the **one-un-acked-packet-in-flight** rule (slow clients get coalesced state, never a queue; the actor is unblockable by construction); input/resize routed to actor commands.
4. `packet: add debug client command` — `cleat packets <id> [--count N]`: connects, subscribes, prints packet summaries. The acceptance probe and the seed of the uishell daemon backend.

## Live acceptance (run against this branch before this PR)

```
gen=2 ops=1 full=1 rows=0 changed_rows=24 mode_changes=initial
gen=3 ops=3 full=0 rows=3  changed_rows=3  mode_changes=none            # echo → 3-row delta
gen=5 ops=2 full=0 rows=2  changed_rows=2  mode_changes=mouse_tracking=true,mouse_mode=Any
```

Push-driven (no client polling), row-level deltas, mode changes ride the packet per the frontend-state principle, and the gen 3→5 skip is the in-flight coalescing working.

## Notes

- Image resources travel as descriptors only (bytes = #103, constrained by #102).
- Push cadence rides the 10 ms servicing tick; wake-driven servicing is a noted later refinement.
- Byte-relay attach/watch unchanged, side-by-side per CONTEXT 'Client connection shapes'.