### PR TITLE
[codex] M:N hosting: named daemons, multi-session daemons, grace-period linger

### DIFF
--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -6,9 +6,9 @@ use crate::{
     http_uds,
     keys::encode_send_keys,
     protocol::{WaitCondition, WaitStatus},
-    runtime::{SessionMetadata, TerminalSize},
+    runtime::{TerminalSize, DEFAULT_DAEMON_NAME},
     server::{EndBound, FallbackReason, SessionService, StartBound},
-    vt::{Rgb, TerminalColors, VtEngineKind},
+    vt::VtEngineKind,
 };
 
 #[derive(Debug, Parser)]
@@ -33,6 +33,9 @@ use crate::{
 pub struct Cli {
     #[arg(long, hide = true)]
     pub runtime_root: Option<PathBuf>,
+
+    #[arg(long, global = true, default_value = DEFAULT_DAEMON_NAME, value_parser = parse_runtime_name)]
+    pub server: String,
 
     #[command(subcommand)]
     pub command: Command,
@@ -404,28 +407,7 @@ resolved through the live daemon socket. \n\
         json: bool,
     },
     #[command(hide = true)]
-    Serve {
-        #[arg(long)]
-        id: String,
-        #[arg(long, value_enum, default_value_t = crate::vt::default_vt_engine_kind())]
-        vt: VtEngineKind,
-        #[arg(long)]
-        cmd: Option<String>,
-        #[arg(long)]
-        cwd: Option<PathBuf>,
-        #[arg(long, value_name = "COLSxROWS", value_parser = parse_terminal_size)]
-        size: Option<TerminalSize>,
-        // Internal: the daemon spawner passes the already-resolved value as a
-        // presence flag, so there is no default-on / env handling here.
-        #[arg(long)]
-        record: bool,
-        #[arg(long, hide = true, value_parser = parse_rgb)]
-        color_foreground: Option<Rgb>,
-        #[arg(long, hide = true, value_parser = parse_rgb)]
-        color_background: Option<Rgb>,
-        #[arg(long, hide = true, value_parser = parse_rgb)]
-        color_cursor: Option<Rgb>,
-    },
+    Serve,
 }
 
 /// Uses `command()` instead of `Cli::parse()` so --help renders the workflow
@@ -476,6 +458,11 @@ impl ExecResult {
 }
 
 pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
+    let service = match service.with_daemon(cli.server.clone()) {
+        Ok(service) => service,
+        Err(err) => return ExecResult::Err(err),
+    };
+    let service = &service;
     match cli.command {
         Command::Attach { id, no_create, vt, cwd, cmd, record } => {
             // Windows can provide basic sessions through ConPTY plus the
@@ -615,7 +602,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                     }
                 }
                 (None, Some(id)) => {
-                    let cast_path = service.layout_root().join(&id).join(crate::recording::CAST_FILE_NAME);
+                    let cast_path = service.session_dir(&id).join(crate::recording::CAST_FILE_NAME);
                     if !cast_path.exists() {
                         return ExecResult::Err(format!("replay: no recording for session {id}"));
                     }
@@ -764,25 +751,10 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
         Command::Expect { id, text, since, since_marker, timeout, json } => {
             execute_expect(service, id, text, since, since_marker, timeout, json)
         }
-        Command::Serve { id, vt, cmd, cwd, size, record, color_foreground, color_background, color_cursor } => {
-            let session = SessionMetadata {
-                id,
-                vt_engine: vt,
-                cwd,
-                cmd,
-                record,
-                initial_size: size.unwrap_or_default(),
-                colors: TerminalColors {
-                    default_foreground: color_foreground,
-                    default_background: color_background,
-                    default_cursor: color_cursor,
-                },
-            };
-            match service.serve(&session) {
-                Ok(()) => ExecResult::Ok(None),
-                Err(e) => ExecResult::Err(e),
-            }
-        }
+        Command::Serve => match service.serve() {
+            Ok(()) => ExecResult::Ok(None),
+            Err(e) => ExecResult::Err(e),
+        },
     }
 }
 
@@ -1068,17 +1040,6 @@ fn parse_signal_target(target: &str) -> Result<crate::protocol::SignalTarget, St
     }
 }
 
-fn parse_rgb(value: &str) -> Result<Rgb, String> {
-    let value = value.strip_prefix('#').unwrap_or(value);
-    if value.len() != 6 {
-        return Err("RGB colors must use six hex digits".to_string());
-    }
-    let r = u8::from_str_radix(&value[0..2], 16).map_err(|err| format!("parse red channel: {err}"))?;
-    let g = u8::from_str_radix(&value[2..4], 16).map_err(|err| format!("parse green channel: {err}"))?;
-    let b = u8::from_str_radix(&value[4..6], 16).map_err(|err| format!("parse blue channel: {err}"))?;
-    Ok(Rgb { r, g, b })
-}
-
 fn parse_terminal_size(value: &str) -> Result<TerminalSize, String> {
     let (cols, rows) =
         value.split_once('x').or_else(|| value.split_once('X')).ok_or_else(|| "size must be formatted as COLSxROWS".to_string())?;
@@ -1088,6 +1049,11 @@ fn parse_terminal_size(value: &str) -> Result<TerminalSize, String> {
         return Err("size dimensions must be greater than zero".to_string());
     }
     Ok(TerminalSize { cols, rows })
+}
+
+fn parse_runtime_name(value: &str) -> Result<String, String> {
+    crate::runtime::validate_runtime_name(value)?;
+    Ok(value.to_string())
 }
 
 fn parse_positive_usize(value: &str) -> Result<usize, String> {

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -25,6 +25,7 @@ pub(crate) enum Route {
     Health,
     PacketConnect,
     Sessions,
+    SessionCreate,
     SessionDelete { id: String },
     SessionAttach { id: String },
     SessionWatch { id: String },
@@ -201,6 +202,11 @@ pub(crate) struct SignalRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct SessionListResponse {
     pub sessions: Vec<crate::protocol::InspectResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct CreateSessionResponse {
+    pub session: crate::runtime::SessionMetadata,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -467,6 +473,7 @@ pub(crate) fn route(request: &HttpRequest) -> Route {
         (&Method::GET, "/healthz") => Route::Health,
         (&Method::POST, "/connect") => Route::PacketConnect,
         (&Method::GET, "/sessions") => Route::Sessions,
+        (&Method::POST, "/sessions") => Route::SessionCreate,
         _ => {
             let Some(rest) = path.strip_prefix("/sessions/") else {
                 return Route::NotFound;
@@ -730,6 +737,7 @@ mod tests {
             ("GET", "/healthz", Route::Health),
             ("POST", "/connect", Route::PacketConnect),
             ("GET", "/sessions", Route::Sessions),
+            ("POST", "/sessions", Route::SessionCreate),
             ("GET", "/sessions/alpha", Route::SessionInspect { id: "alpha".to_string() }),
             ("DELETE", "/sessions/alpha", Route::SessionDelete { id: "alpha".to_string() }),
             ("POST", "/sessions/alpha/attach", Route::SessionAttach { id: "alpha".to_string() }),

--- a/crates/cleat/src/platform/daemon.rs
+++ b/crates/cleat/src/platform/daemon.rs
@@ -6,60 +6,28 @@ use std::{
 
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 
-use crate::{
-    platform::process,
-    runtime::SessionMetadata,
-    vt::{Rgb, TerminalColors},
-};
+use crate::platform::process;
 
 const PID_NAME: &str = "daemon.pid";
 
-pub fn daemon_pid_path(root: &Path, id: &str) -> PathBuf {
-    root.join(id).join(PID_NAME)
+pub fn daemon_pid_path(root: &Path, daemon_name: &str) -> PathBuf {
+    root.join(daemon_name).join(PID_NAME)
 }
 
-pub fn spawn_daemon_process(root: &Path, session: &SessionMetadata) -> Result<(), String> {
+pub fn spawn_daemon_process(root: &Path, daemon_name: &str) -> Result<(), String> {
     let exe = resolve_cleat_executable()?;
     let mut command = Command::new(exe);
-    command.arg("--runtime-root").arg(root).arg("serve").arg("--id").arg(&session.id).arg("--vt").arg(session.vt_engine.as_str());
-    command.arg("--size").arg(session.initial_size.to_string());
-    if let Some(cmd) = &session.cmd {
-        command.arg("--cmd").arg(cmd);
-    }
-    if let Some(cwd) = &session.cwd {
-        command.arg("--cwd").arg(cwd);
-    }
-    if session.record {
-        command.arg("--record");
-    }
-    add_color_args(&mut command, session.colors);
+    command.arg("--runtime-root").arg(root).arg("--server").arg(daemon_name).arg("serve");
     command.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
-    let child = command.spawn().map_err(|err| format!("spawn session daemon for {}: {err}", session.id))?;
-    fs::write(daemon_pid_path(root, &session.id), child.id().to_string()).map_err(|err| format!("write daemon pid: {err}"))?;
+    command.spawn().map_err(|err| format!("spawn daemon {daemon_name}: {err}"))?;
     Ok(())
-}
-
-fn add_color_args(command: &mut Command, colors: TerminalColors) {
-    if let Some(color) = colors.default_foreground {
-        command.arg("--color-foreground").arg(format_rgb_arg(color));
-    }
-    if let Some(color) = colors.default_background {
-        command.arg("--color-background").arg(format_rgb_arg(color));
-    }
-    if let Some(color) = colors.default_cursor {
-        command.arg("--color-cursor").arg(format_rgb_arg(color));
-    }
-}
-
-fn format_rgb_arg(color: Rgb) -> String {
-    format!("{:02x}{:02x}{:02x}", color.r, color.g, color.b)
 }
 
 /// Returns true if the daemon is alive, or if no PID file exists yet because
 /// the daemon may still be starting. Returns false only for a definitive stale
 /// PID file.
-pub fn is_session_daemon_alive(root: &Path, id: &str) -> bool {
-    let pid_path = daemon_pid_path(root, id);
+pub fn is_session_daemon_alive(root: &Path, daemon_name: &str) -> bool {
+    let pid_path = daemon_pid_path(root, daemon_name);
     let Ok(contents) = fs::read_to_string(&pid_path) else {
         return true;
     };
@@ -69,8 +37,8 @@ pub fn is_session_daemon_alive(root: &Path, id: &str) -> bool {
     is_expected_cleat_process(pid)
 }
 
-pub fn terminate_session_daemon_if_expected(root: &Path, id: &str) {
-    let pid_path = daemon_pid_path(root, id);
+pub fn terminate_session_daemon_if_expected(root: &Path, daemon_name: &str) {
+    let pid_path = daemon_pid_path(root, daemon_name);
     let Ok(Some(pid)) = fs::read_to_string(&pid_path).map(|value| value.trim().parse::<i32>().ok()) else {
         return;
     };

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -19,7 +19,7 @@ use crate::{
         TerminalViewportKind, ViewportCommand, ViewportCommandOutcome, TERMINAL_IMAGE_PLACEMENT_VIRTUAL,
     },
     runtime::{RuntimeLayout, TerminalSize},
-    session::{ensure_session_started, session_socket_path, SessionStartOptions},
+    session::{ensure_session_started, SessionStartOptions},
     session_runtime::SessionRuntime,
     vt::{self, Rgb, TerminalColors, VtEngineKind},
 };
@@ -1699,7 +1699,7 @@ fn create_in_process_session(provider: &CleatProvider, desc: CleatSessionDesc) -
     let cols = desc.cols.max(1);
     let rows = desc.rows.max(1);
     metadata.initial_size = TerminalSize { cols, rows };
-    let session_dir = layout.root().join(&metadata.id);
+    let session_dir = layout.session_dir(&metadata.id);
     let initial_geometry = TerminalGeometry::from_cell_size(cols, rows, desc.cell_width_px, desc.cell_height_px);
     let (cell_width_px, cell_height_px) = geometry_cell_size_to_backend(initial_geometry);
     let wake = provider.wake.clone();
@@ -1795,7 +1795,7 @@ fn daemon_snapshot(session: &mut DaemonSession) -> Result<TerminalSnapshot, Stri
 }
 
 fn daemon_request(session: &DaemonSession, method: Method, path: &str, body: &[u8]) -> Result<http_uds::HttpResponse, String> {
-    let socket_path = session_socket_path(&session.runtime_root, &session.id);
+    let socket_path = RuntimeLayout::new(session.runtime_root.clone()).socket_path();
     let mut stream = connect_session_stream(&socket_path)?;
     http_uds::write_request(&mut stream, method, path, body).map_err(|err| format!("write HTTP request: {err}"))?;
     http_uds::read_response(&mut stream).map_err(|err| format!("read HTTP response: {err}"))

--- a/crates/cleat/src/runtime.rs
+++ b/crates/cleat/src/runtime.rs
@@ -8,10 +8,12 @@ use uuid::Uuid;
 use crate::vt::{TerminalColors, VtEngineKind};
 
 const SESSION_ROOT_DIR: &str = "cleat";
+const SESSIONS_DIR: &str = "sessions";
+pub const DEFAULT_DAEMON_NAME: &str = "default";
 pub const DEFAULT_TERMINAL_COLS: u16 = 80;
 pub const DEFAULT_TERMINAL_ROWS: u16 = 24;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TerminalSize {
     pub cols: u16,
     pub rows: u16,
@@ -29,7 +31,7 @@ impl fmt::Display for TerminalSize {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SessionMetadata {
     pub id: String,
     pub vt_engine: VtEngineKind,
@@ -43,6 +45,7 @@ pub struct SessionMetadata {
 #[derive(Debug, Clone)]
 pub struct RuntimeLayout {
     root: PathBuf,
+    daemon_name: String,
 }
 
 impl RuntimeLayout {
@@ -54,19 +57,58 @@ impl RuntimeLayout {
                 env::var_os("TMPDIR"),
                 env::temp_dir(),
             ),
+            daemon_name: DEFAULT_DAEMON_NAME.to_string(),
         }
     }
 
     pub fn new(root: PathBuf) -> Self {
-        Self { root }
+        Self { root, daemon_name: DEFAULT_DAEMON_NAME.to_string() }
+    }
+
+    pub fn with_daemon(mut self, daemon_name: String) -> Result<Self, String> {
+        validate_runtime_name(&daemon_name)?;
+        self.daemon_name = daemon_name;
+        Ok(self)
     }
 
     pub fn root(&self) -> &Path {
         &self.root
     }
 
+    pub fn daemon_name(&self) -> &str {
+        &self.daemon_name
+    }
+
+    pub fn daemon_dir(&self) -> PathBuf {
+        self.root.join(&self.daemon_name)
+    }
+
+    pub fn sessions_dir(&self) -> PathBuf {
+        self.daemon_dir().join(SESSIONS_DIR)
+    }
+
+    pub fn session_dir(&self, id: &str) -> PathBuf {
+        self.sessions_dir().join(id)
+    }
+
+    pub fn socket_path(&self) -> PathBuf {
+        self.daemon_dir().join("socket")
+    }
+
+    pub fn daemon_pid_path(&self) -> PathBuf {
+        self.daemon_dir().join("daemon.pid")
+    }
+
+    pub fn foreground_path(&self, id: &str) -> PathBuf {
+        self.session_dir(id).join("foreground")
+    }
+
     pub fn ensure_root(&self) -> Result<(), String> {
         fs::create_dir_all(&self.root).map_err(|err| format!("create runtime root {}: {err}", self.root.display()))
+    }
+
+    pub fn ensure_daemon_dirs(&self) -> Result<(), String> {
+        fs::create_dir_all(self.sessions_dir()).map_err(|err| format!("create daemon directory {}: {err}", self.daemon_dir().display()))
     }
 
     pub fn create_session(
@@ -76,28 +118,39 @@ impl RuntimeLayout {
         cwd: Option<PathBuf>,
         cmd: Option<String>,
     ) -> Result<SessionMetadata, String> {
-        self.ensure_root()?;
+        self.ensure_daemon_dirs()?;
 
         let id = id.unwrap_or_else(|| format!("session-{}", Uuid::new_v4()));
-        let dir = self.root.join(&id);
+        validate_runtime_name(&id)?;
+        let dir = self.session_dir(&id);
         fs::create_dir_all(&dir).map_err(|err| format!("create session dir {}: {err}", dir.display()))?;
-        Ok(SessionMetadata {
-            id,
-            vt_engine,
-            cwd,
-            cmd,
-            record: false,
-            initial_size: TerminalSize::default(),
-            colors: TerminalColors::default(),
-        })
+        Ok(self.session_metadata(id, vt_engine, cwd, cmd))
+    }
+
+    pub fn session_metadata(&self, id: String, vt_engine: VtEngineKind, cwd: Option<PathBuf>, cmd: Option<String>) -> SessionMetadata {
+        SessionMetadata { id, vt_engine, cwd, cmd, record: false, initial_size: TerminalSize::default(), colors: TerminalColors::default() }
     }
 
     pub fn remove_session(&self, id: &str) -> Result<(), String> {
-        let dir = self.root.join(id);
+        let dir = self.session_dir(id);
         if !dir.exists() {
             return Ok(());
         }
         fs::remove_dir_all(&dir).map_err(|err| format!("remove session dir {}: {err}", dir.display()))
+    }
+}
+
+pub fn validate_runtime_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("name must not be empty".to_string());
+    }
+    if name == "." || name == ".." {
+        return Err(format!("invalid filesystem-safe name: {name}"));
+    }
+    if name.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')) {
+        Ok(())
+    } else {
+        Err(format!("invalid filesystem-safe name: {name}"))
     }
 }
 

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -2,26 +2,18 @@ use std::{
     io::Write,
     path::Path,
     thread,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 
 use http::{Method, StatusCode};
 use serde::de::DeserializeOwned;
 
-const EMPTY_SESSION_DIR_GRACE: Duration = Duration::from_secs(2);
-
 use crate::{
     http_uds,
-    platform::{
-        daemon::{daemon_pid_path, is_session_daemon_alive, terminate_session_daemon_if_expected},
-        ipc::{set_stream_read_timeout, try_connect_session_stream, SessionStream},
-    },
+    platform::ipc::{set_stream_read_timeout, try_connect_session_stream, SessionStream},
     protocol::{SessionInfo, SessionStatus},
     runtime::{RuntimeLayout, TerminalSize},
-    session::{
-        attach_foreground, ensure_session_started, foreground_path, run_session_daemon, session_socket_path, watch_foreground,
-        ForegroundAttach, SessionStartOptions,
-    },
+    session::{attach_foreground, ensure_session_started, run_session_daemon, watch_foreground, ForegroundAttach, SessionStartOptions},
     vt::VtEngineKind,
 };
 
@@ -75,8 +67,16 @@ impl SessionService {
         Self::new(RuntimeLayout::discover())
     }
 
+    pub fn with_daemon(&self, daemon_name: String) -> Result<Self, String> {
+        Ok(Self::new(self.layout.clone().with_daemon(daemon_name)?))
+    }
+
     pub fn layout_root(&self) -> &std::path::Path {
         self.layout.root()
+    }
+
+    pub fn session_dir(&self, id: &str) -> std::path::PathBuf {
+        self.layout.session_dir(id)
     }
 
     pub fn create(
@@ -135,60 +135,36 @@ impl SessionService {
             if !path.is_dir() {
                 continue;
             }
-            let id = match path.file_name().and_then(|n| n.to_str()) {
+            let daemon_name = match path.file_name().and_then(|n| n.to_str()) {
                 Some(name) => name.to_string(),
                 None => continue,
             };
-            let socket_path = session_socket_path(self.layout.root(), &id);
-            if !socket_path.exists() {
-                if session_dir_is_stale_empty(&path, EMPTY_SESSION_DIR_GRACE) {
-                    let _ = self.layout.remove_session(&id);
-                }
+            if !path.join("sessions").is_dir() {
                 continue;
             }
-            if !daemon_pid_path(self.layout.root(), &id).exists()
-                && !crate::recreate::session_is_recreatable(&path)
-                && session_dir_contains_only(&path, &socket_path)
-                && session_socket_is_stale(&socket_path)
-            {
-                let _ = self.layout.remove_session(&id);
+            let daemon_service = self.with_daemon(daemon_name)?;
+            if !daemon_service.layout.socket_path().exists() || session_socket_is_stale(&daemon_service.layout.socket_path()) {
                 continue;
             }
-            if !is_session_daemon_alive(self.layout.root(), &id) {
-                // Stale daemon. Only garbage-collect it if there is nothing to
-                // recreate from; a crashed session with a recording survives so a
-                // later create/attach can respawn it from its prior output.
-                if !crate::recreate::session_is_recreatable(&path) {
-                    let _ = self.layout.remove_session(&id);
-                }
-                continue;
-            }
-            match self.inspect(&id) {
+            match daemon_service.http_json_daemon::<_, http_uds::SessionListResponse>(Method::GET, "/sessions", &()) {
                 Ok(result) => {
-                    let status =
-                        if has_controller_attachment(&result.attachments) { SessionStatus::Attached } else { SessionStatus::Detached };
-                    sessions.push(SessionInfo {
-                        id: result.session.id,
-                        vt_engine: parse_vt_engine_kind(&result.session.vt_engine),
-                        vt_engine_status: result.session.vt_engine_status,
-                        functional_vt_available: result.session.functional_vt_available,
-                        cwd: result.session.cwd,
-                        cmd: result.session.cmd,
-                        status,
-                        error: None,
-                    });
+                    for result in result.sessions {
+                        let status =
+                            if has_controller_attachment(&result.attachments) { SessionStatus::Attached } else { SessionStatus::Detached };
+                        sessions.push(SessionInfo {
+                            id: result.session.id,
+                            vt_engine: parse_vt_engine_kind(&result.session.vt_engine),
+                            vt_engine_status: result.session.vt_engine_status,
+                            functional_vt_available: result.session.functional_vt_available,
+                            cwd: result.session.cwd,
+                            cmd: result.session.cmd,
+                            status,
+                            error: None,
+                        });
+                    }
                 }
                 Err(err) => {
-                    sessions.push(SessionInfo {
-                        id,
-                        vt_engine: crate::vt::default_vt_engine_kind(),
-                        vt_engine_status: String::new(),
-                        functional_vt_available: false,
-                        cwd: None,
-                        cmd: None,
-                        status: SessionStatus::Detached,
-                        error: Some(err),
-                    });
+                    sessions.extend(list_preserved_sessions_with_error(&daemon_service.layout, err)?);
                 }
             }
         }
@@ -201,25 +177,16 @@ impl SessionService {
     }
 
     pub fn kill_with_purge(&self, id: &str, purge: bool) -> Result<(), String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
-        let pid_path = daemon_pid_path(self.layout.root(), id);
-        let socket_path = session_socket_path(self.layout.root(), id);
-        if socket_path.exists() && self.http_no_content(id, Method::DELETE, &format!("/sessions/{id}"), &()).is_ok() {
-            if pid_path.exists() {
-                self.wait_for_session_shutdown(id);
-            }
-            if !self.layout.root().join(id).exists() {
+        if self.layout.socket_path().exists() && self.http_no_content(id, Method::DELETE, &format!("/sessions/{id}"), &()).is_ok() {
+            self.wait_for_session_shutdown(id);
+            if !self.layout.session_dir(id).exists() {
                 return Ok(());
             }
         }
-        terminate_session_daemon_if_expected(self.layout.root(), id);
-        self.wait_for_session_shutdown(id);
-        if !self.layout.root().join(id).exists() {
-            return Ok(());
-        }
-        if purge || !crate::recreate::session_is_recreatable(&self.layout.root().join(id)) {
+        if purge || !crate::recreate::session_is_recreatable(&self.layout.session_dir(id)) {
             self.layout.remove_session(id)
         } else {
             self.remove_volatile_session_files(id);
@@ -229,10 +196,7 @@ impl SessionService {
 
     fn wait_for_session_shutdown(&self, id: &str) {
         for _ in 0..50 {
-            if !self.layout.root().join(id).exists()
-                || !daemon_pid_path(self.layout.root(), id).exists()
-                || !is_session_daemon_alive(self.layout.root(), id)
-            {
+            if !self.layout.session_dir(id).exists() || self.inspect(id).is_err() {
                 break;
             }
             thread::sleep(Duration::from_millis(20));
@@ -240,13 +204,11 @@ impl SessionService {
     }
 
     fn remove_volatile_session_files(&self, id: &str) {
-        let _ = std::fs::remove_file(session_socket_path(self.layout.root(), id));
-        let _ = std::fs::remove_file(daemon_pid_path(self.layout.root(), id));
-        let _ = std::fs::remove_file(foreground_path(self.layout.root(), id));
+        let _ = std::fs::remove_file(self.layout.foreground_path(id));
     }
 
     pub fn detach(&self, id: &str) -> Result<(), String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
 
@@ -254,7 +216,7 @@ impl SessionService {
     }
 
     pub fn capture(&self, id: &str) -> Result<String, String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
 
@@ -325,7 +287,7 @@ impl SessionService {
     }
 
     fn capture_slice_inner(&self, id: &str, start: StartBound, end: EndBound) -> Result<(String, SliceOutcome), String> {
-        let cast_path = self.layout.root().join(id).join(crate::recording::CAST_FILE_NAME);
+        let cast_path = self.layout.session_dir(id).join(crate::recording::CAST_FILE_NAME);
         if !cast_path.exists() {
             return Err(format!("no recording for session {id}"));
         }
@@ -338,7 +300,7 @@ impl SessionService {
     }
 
     pub fn send_keys(&self, id: &str, bytes: &[u8]) -> Result<(), String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
 
@@ -346,7 +308,7 @@ impl SessionService {
     }
 
     pub fn send_keys_with_mark(&self, id: &str, bytes: &[u8], marker_name: &str) -> Result<u64, String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         let response: http_uds::MarkResponse =
@@ -358,7 +320,7 @@ impl SessionService {
     }
 
     pub(crate) fn send_input(&self, id: &str, input: &http_uds::InputRequest) -> Result<(), String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
 
@@ -366,7 +328,7 @@ impl SessionService {
     }
 
     pub(crate) fn send_paste_with_mark(&self, id: &str, text: &str, marker_name: &str) -> Result<u64, String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
 
@@ -388,15 +350,11 @@ impl SessionService {
     ) -> Result<(SessionInfo, ForegroundAttach), String> {
         let session = if no_create {
             let id = name.ok_or_else(|| "attach --no-create requires a session id".to_string())?;
-            let socket_path = session_socket_path(self.layout.root(), &id);
-            if !socket_path.exists() {
+            if !self.layout.session_dir(&id).exists() {
                 return Err(format!("missing session {id}"));
             }
-            if !is_session_daemon_alive(self.layout.root(), &id) {
-                // The daemon crashed. --no-create forbids respawning, so report it
-                // as stale. Preserve a recoverable recording (a later attach without
-                // --no-create recreates from it); only remove a non-recreatable husk.
-                if crate::recreate::session_is_recreatable(&self.layout.root().join(&id)) {
+            if self.inspect(&id).is_err() {
+                if crate::recreate::session_is_recreatable(&self.layout.session_dir(&id)) {
                     return Err(format!("session {id} has a stale daemon (use attach without --no-create to recreate)"));
                 }
                 let _ = self.layout.remove_session(&id);
@@ -435,7 +393,7 @@ impl SessionService {
     }
 
     pub fn watch(&self, id: &str) -> Result<ForegroundAttach, String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         watch_foreground(&self.layout, id)
@@ -445,11 +403,11 @@ impl SessionService {
         &self,
         id: &str,
     ) -> Result<(crate::packet::PacketClient<SessionStream>, crate::packet::DirectorySnapshot), String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
 
-        let socket_path = session_socket_path(self.layout.root(), id);
+        let socket_path = self.layout.socket_path();
         let mut stream = connect_session_socket(&socket_path)?;
         write!(
             stream,
@@ -480,14 +438,14 @@ impl SessionService {
     }
 
     pub fn inspect(&self, id: &str) -> Result<crate::protocol::InspectResult, String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         self.http_json(id, Method::GET, &format!("/sessions/{id}"), &())
     }
 
     pub fn signal(&self, id: &str, signal: i32, target: crate::protocol::SignalTarget) -> Result<(), String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         self.http_no_content(id, Method::POST, &format!("/sessions/{id}/signal"), &http_uds::SignalRequest {
@@ -505,7 +463,7 @@ impl SessionService {
     }
 
     fn mark_impl(&self, id: &str, name: Option<&str>) -> Result<u64, String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         let response: http_uds::MarkResponse =
@@ -514,7 +472,7 @@ impl SessionService {
     }
 
     pub fn resolve_marker(&self, id: &str, name: &str) -> Result<u64, String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         let response: http_uds::MarkResponse =
@@ -525,7 +483,7 @@ impl SessionService {
     }
 
     pub fn resolve_next_marker_after(&self, id: &str, after: u64) -> Result<Option<u64>, String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         let response: http_uds::ResolveNextMarkerResponse =
@@ -536,7 +494,7 @@ impl SessionService {
     }
 
     pub fn record(&self, id: &str, enable: bool) -> Result<(), String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         self.http_no_content(id, Method::POST, &format!("/sessions/{id}/record"), &http_uds::RecordRequest { enable })
@@ -548,7 +506,7 @@ impl SessionService {
         conditions: Vec<crate::protocol::WaitCondition>,
         timeout_ms: u64,
     ) -> Result<(crate::protocol::WaitStatus, u64), String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         let conditions = conditions.into_iter().map(wait_condition_to_http).collect();
@@ -563,7 +521,7 @@ impl SessionService {
     }
 
     pub fn expect(&self, id: &str, text: &str, since_offset: u64, timeout_ms: u64) -> Result<(crate::protocol::WaitStatus, u64), String> {
-        if !self.layout.root().join(id).exists() {
+        if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
         let response: http_uds::WaitResultResponse = self.http_json_with_read_timeout(
@@ -576,8 +534,8 @@ impl SessionService {
         Ok((wait_status_from_http(response.status), response.elapsed_ms))
     }
 
-    pub fn serve(&self, session: &crate::runtime::SessionMetadata) -> Result<(), String> {
-        run_session_daemon(self.layout.root(), session)
+    pub fn serve(&self) -> Result<(), String> {
+        run_session_daemon(self.layout.root(), self.layout.daemon_name())
     }
 
     fn http_json<T: serde::Serialize, R: DeserializeOwned>(&self, id: &str, method: Method, path: &str, body: &T) -> Result<R, String> {
@@ -616,15 +574,23 @@ impl SessionService {
         self.http_request_with_read_timeout(id, method, path, body, None)
     }
 
+    fn http_json_daemon<T: serde::Serialize, R: DeserializeOwned>(&self, method: Method, path: &str, body: &T) -> Result<R, String> {
+        let response = self.http_request_with_read_timeout("", method, path, body, None)?;
+        if response.status != StatusCode::OK {
+            return Err(http_error_message(response));
+        }
+        serde_json::from_slice(&response.body).map_err(|err| format!("parse HTTP response: {err}"))
+    }
+
     fn http_request_with_read_timeout<T: serde::Serialize>(
         &self,
-        id: &str,
+        _id: &str,
         method: Method,
         path: &str,
         body: &T,
         read_timeout: Option<Duration>,
     ) -> Result<http_uds::HttpResponse, String> {
-        let socket_path = session_socket_path(self.layout.root(), id);
+        let socket_path = self.layout.socket_path();
         let mut stream = connect_session_socket(&socket_path)?;
         if let Some(timeout) = read_timeout {
             set_stream_read_timeout(&stream, Some(timeout))?;
@@ -639,40 +605,36 @@ impl SessionService {
     }
 }
 
-fn session_dir_is_empty(path: &Path) -> bool {
-    std::fs::read_dir(path).map(|mut entries| entries.next().is_none()).unwrap_or(false)
-}
-
-fn session_dir_is_stale_empty(path: &Path, grace: Duration) -> bool {
-    if !session_dir_is_empty(path) {
-        return false;
-    }
-    std::fs::metadata(path)
-        .and_then(|metadata| metadata.modified())
-        .ok()
-        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
-        .is_some_and(|age| age >= grace)
-}
-
-fn session_dir_contains_only(path: &Path, expected: &Path) -> bool {
-    let Ok(entries) = std::fs::read_dir(path) else {
-        return false;
-    };
-    let mut count = 0;
-    for entry in entries {
-        let Ok(entry) = entry else {
-            return false;
-        };
-        count += 1;
-        if entry.path() != expected {
-            return false;
-        }
-    }
-    count == 1
-}
-
 fn session_socket_is_stale(socket_path: &Path) -> bool {
     try_connect_session_stream(socket_path).is_err()
+}
+
+fn list_preserved_sessions_with_error(layout: &RuntimeLayout, err: String) -> Result<Vec<SessionInfo>, String> {
+    let mut sessions = Vec::new();
+    let entries = std::fs::read_dir(layout.sessions_dir()).map_err(|read_err| {
+        format!("read daemon sessions directory {} after inspect failure ({err}): {read_err}", layout.sessions_dir().display())
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|read_err| format!("read daemon session entry: {read_err}"))?;
+        let path = entry.path();
+        if !path.is_dir() || !crate::recreate::session_is_recreatable(&path) {
+            continue;
+        }
+        let Some(id) = path.file_name().and_then(|name| name.to_str()).map(str::to_string) else {
+            continue;
+        };
+        sessions.push(SessionInfo {
+            id,
+            vt_engine: crate::vt::default_vt_engine_kind(),
+            vt_engine_status: String::new(),
+            functional_vt_available: false,
+            cwd: None,
+            cmd: None,
+            status: SessionStatus::Detached,
+            error: Some(err.clone()),
+        });
+    }
+    Ok(sessions)
 }
 
 /// Resolve start and end bounds into byte offsets against a cast file without
@@ -789,17 +751,16 @@ fn connect_session_socket(socket_path: &Path) -> Result<SessionStream, String> {
 #[cfg(all(test, unix))]
 mod tests {
     use std::{
-        ffi::CString,
         fs,
-        os::unix::{ffi::OsStrExt, net::UnixListener},
+        os::unix::net::UnixListener,
         path::Path,
         process::Command,
         sync::mpsc,
         thread,
-        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+        time::{Duration, Instant},
     };
 
-    use super::{SessionService, EMPTY_SESSION_DIR_GRACE};
+    use super::SessionService;
     use crate::{
         http_uds::{self, read_http_request_for_test},
         protocol::{WaitCondition, WaitStatus},
@@ -807,12 +768,19 @@ mod tests {
         session::{daemon_pid_path, session_socket_path},
     };
 
+    fn create_test_session_dir(root: &Path, id: &str) -> std::path::PathBuf {
+        let layout = RuntimeLayout::new(root.to_path_buf());
+        layout.ensure_daemon_dirs().expect("create daemon dirs");
+        let session_dir = layout.session_dir(id);
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        session_dir
+    }
+
     #[test]
     fn kill_does_not_signal_unrelated_process_from_stale_pid_file() {
         let temp = tempfile::tempdir().expect("tempdir");
         let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-        let session_dir = temp.path().join("alpha");
-        fs::create_dir_all(&session_dir).expect("create session dir");
+        let _session_dir = create_test_session_dir(temp.path(), "alpha");
 
         let mut child = Command::new("sleep").arg("30").spawn().expect("spawn sleep");
         fs::write(daemon_pid_path(temp.path(), "alpha"), child.id().to_string()).expect("write pid");
@@ -840,8 +808,7 @@ mod tests {
     fn send_keys_posts_http_request_to_session_socket() {
         let temp = tempfile::tempdir().expect("tempdir");
         let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-        let session_dir = temp.path().join("alpha");
-        fs::create_dir_all(&session_dir).expect("create session dir");
+        let _session_dir = create_test_session_dir(temp.path(), "alpha");
 
         let socket_path = session_socket_path(temp.path(), "alpha");
         let listener = UnixListener::bind(&socket_path).expect("bind socket");
@@ -867,8 +834,7 @@ mod tests {
     fn send_input_posts_http_request_to_session_socket() {
         let temp = tempfile::tempdir().expect("tempdir");
         let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-        let session_dir = temp.path().join("alpha");
-        fs::create_dir_all(&session_dir).expect("create session dir");
+        let _session_dir = create_test_session_dir(temp.path(), "alpha");
 
         let socket_path = session_socket_path(temp.path(), "alpha");
         let listener = UnixListener::bind(&socket_path).expect("bind socket");
@@ -894,8 +860,7 @@ mod tests {
     fn send_paste_with_mark_posts_http_request_to_session_socket() {
         let temp = tempfile::tempdir().expect("tempdir");
         let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-        let session_dir = temp.path().join("alpha");
-        fs::create_dir_all(&session_dir).expect("create session dir");
+        let _session_dir = create_test_session_dir(temp.path(), "alpha");
 
         let socket_path = session_socket_path(temp.path(), "alpha");
         let listener = UnixListener::bind(&socket_path).expect("bind socket");
@@ -926,8 +891,7 @@ mod tests {
     fn kill_deletes_session_over_http_when_socket_is_available() {
         let temp = tempfile::tempdir().expect("tempdir");
         let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-        let session_dir = temp.path().join("alpha");
-        fs::create_dir_all(&session_dir).expect("create session dir");
+        let session_dir = create_test_session_dir(temp.path(), "alpha");
 
         let socket_path = session_socket_path(temp.path(), "alpha");
         let listener = UnixListener::bind(&socket_path).expect("bind socket");
@@ -953,8 +917,7 @@ mod tests {
     fn kill_purge_preserved_recording_without_socket_returns_promptly() {
         let temp = tempfile::tempdir().expect("tempdir");
         let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-        let session_dir = temp.path().join("alpha");
-        fs::create_dir_all(&session_dir).expect("create session dir");
+        let session_dir = create_test_session_dir(temp.path(), "alpha");
         fs::write(session_dir.join(crate::recording::CAST_FILE_NAME), b"{\"version\":3}\n").expect("write cast");
 
         let started = Instant::now();
@@ -968,8 +931,7 @@ mod tests {
     fn detach_posts_http_request_to_session_socket() {
         let temp = tempfile::tempdir().expect("tempdir");
         let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-        let session_dir = temp.path().join("alpha");
-        fs::create_dir_all(&session_dir).expect("create session dir");
+        let _session_dir = create_test_session_dir(temp.path(), "alpha");
 
         let socket_path = session_socket_path(temp.path(), "alpha");
         let listener = UnixListener::bind(&socket_path).expect("bind socket");
@@ -994,8 +956,7 @@ mod tests {
     fn wait_posts_http_request_to_session_socket() {
         let temp = tempfile::tempdir().expect("tempdir");
         let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-        let session_dir = temp.path().join("alpha");
-        fs::create_dir_all(&session_dir).expect("create session dir");
+        let _session_dir = create_test_session_dir(temp.path(), "alpha");
 
         let socket_path = session_socket_path(temp.path(), "alpha");
         let listener = UnixListener::bind(&socket_path).expect("bind socket");
@@ -1033,8 +994,7 @@ mod tests {
     fn expect_posts_http_request_to_session_socket() {
         let temp = tempfile::tempdir().expect("tempdir");
         let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-        let session_dir = temp.path().join("alpha");
-        fs::create_dir_all(&session_dir).expect("create session dir");
+        let _session_dir = create_test_session_dir(temp.path(), "alpha");
 
         let socket_path = session_socket_path(temp.path(), "alpha");
         let listener = UnixListener::bind(&socket_path).expect("bind socket");
@@ -1059,148 +1019,5 @@ mod tests {
         assert_eq!(result, (WaitStatus::Timeout, 500));
         assert!(request.starts_with("POST /sessions/alpha/expect HTTP/1.1\r\n"), "{request}");
         assert!(request.ends_with(r#"{"text":"DONE","since_offset":123,"timeout_ms":500}"#), "{request}");
-    }
-
-    #[test]
-    fn list_includes_sessions_with_inspect_failure() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-
-        // Create a session directory with a live socket that accepts but immediately closes
-        // the connection, simulating a daemon that doesn't respond to inspect.
-        let session_dir = temp.path().join("broken-session");
-        fs::create_dir_all(&session_dir).expect("create session dir");
-        let socket_path = session_socket_path(temp.path(), "broken-session");
-        let listener = UnixListener::bind(&socket_path).expect("bind socket");
-        // Spawn a thread that accepts and immediately drops connections (simulates broken daemon).
-        thread::spawn(move || {
-            while let Ok((stream, _)) = listener.accept() {
-                drop(stream);
-            }
-        });
-        fs::write(daemon_pid_path(temp.path(), "broken-session"), std::process::id().to_string()).expect("write pid");
-
-        let sessions = service.list().expect("list sessions");
-        assert_eq!(sessions.len(), 1, "broken session should appear in list");
-        assert_eq!(sessions[0].id, "broken-session");
-        assert!(sessions[0].error.is_some(), "should have error field set");
-    }
-
-    #[test]
-    fn list_skips_and_cleans_up_stale_sessions() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-
-        // Create a session directory with a socket file and a PID file pointing to a dead process.
-        let session_dir = temp.path().join("stale-session");
-        fs::create_dir_all(&session_dir).expect("create session dir");
-        let socket_path = session_socket_path(temp.path(), "stale-session");
-        // Create a socket file that nobody is listening on, then drop the listener.
-        let listener = UnixListener::bind(&socket_path).expect("bind socket");
-        drop(listener);
-        // Write a PID that doesn't exist.
-        fs::write(daemon_pid_path(temp.path(), "stale-session"), "999999999").expect("write pid");
-
-        let sessions = service.list().expect("list sessions");
-        assert!(sessions.is_empty(), "stale session should not appear in list");
-        assert!(!session_dir.exists(), "stale session directory should be cleaned up");
-    }
-
-    #[test]
-    fn list_cleans_up_socket_only_session_without_pid_file() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-
-        let session_dir = temp.path().join("socket-only");
-        fs::create_dir_all(&session_dir).expect("create session dir");
-        let socket_path = session_socket_path(temp.path(), "socket-only");
-        fs::write(&socket_path, b"stale socket placeholder").expect("write stale socket placeholder");
-
-        let sessions = service.list().expect("list sessions");
-        assert!(sessions.is_empty(), "socket-only husk should not appear in list");
-        assert!(!session_dir.exists(), "socket-only husk should be cleaned up");
-    }
-
-    #[test]
-    fn list_preserves_socket_only_session_when_socket_is_connectable() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-
-        let session_dir = temp.path().join("starting-session");
-        fs::create_dir_all(&session_dir).expect("create session dir");
-        let socket_path = session_socket_path(temp.path(), "starting-session");
-        let listener = UnixListener::bind(&socket_path).expect("bind socket");
-        let reader = thread::spawn(move || {
-            for _ in 0..2 {
-                let Ok((stream, _)) = listener.accept() else {
-                    break;
-                };
-                drop(stream);
-            }
-        });
-
-        let sessions = service.list().expect("list sessions");
-        assert_eq!(sessions.len(), 1, "connectable no-pid socket should be treated as starting");
-        assert_eq!(sessions[0].id, "starting-session");
-        assert!(sessions[0].error.is_some(), "inspect failure should be reported while preserving the directory");
-        assert!(session_dir.exists(), "connectable no-pid socket should not be cleaned up as a husk");
-
-        reader.join().expect("join reader");
-    }
-
-    #[test]
-    fn list_cleans_up_empty_session_directory() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-
-        let session_dir = temp.path().join("empty-session");
-        fs::create_dir_all(&session_dir).expect("create session dir");
-        set_mtime_ago(&session_dir, EMPTY_SESSION_DIR_GRACE + Duration::from_secs(1));
-
-        let sessions = service.list().expect("list sessions");
-        assert!(sessions.is_empty(), "empty session dir should not appear in list");
-        assert!(!session_dir.exists(), "empty session dir should be cleaned up");
-    }
-
-    #[test]
-    fn list_preserves_young_empty_session_directory() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-
-        let session_dir = temp.path().join("starting-empty-session");
-        fs::create_dir_all(&session_dir).expect("create session dir");
-
-        let sessions = service.list().expect("list sessions");
-        assert!(sessions.is_empty(), "young empty session dir should not appear in list");
-        assert!(session_dir.exists(), "young empty session dir should be allowed to finish starting");
-    }
-
-    #[test]
-    fn list_preserves_stale_sessions_that_have_a_recording() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-
-        // A crashed daemon: stale socket + dead PID, but a recording survives.
-        let session_dir = temp.path().join("crashed-session");
-        fs::create_dir_all(&session_dir).expect("create session dir");
-        let socket_path = session_socket_path(temp.path(), "crashed-session");
-        let listener = UnixListener::bind(&socket_path).expect("bind socket");
-        drop(listener);
-        fs::write(daemon_pid_path(temp.path(), "crashed-session"), "999999999").expect("write pid");
-        fs::write(session_dir.join(crate::recording::CAST_FILE_NAME), b"{\"version\":3}\n").expect("write cast");
-
-        let sessions = service.list().expect("list sessions");
-        assert!(sessions.is_empty(), "stale session should not appear in list");
-        assert!(session_dir.exists(), "a recreatable session directory must survive the stale sweep");
-    }
-
-    fn set_mtime_ago(path: &Path, age: Duration) {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("system time after epoch");
-        let target = now.checked_sub(age).expect("age before now");
-        let timeval = libc::timeval { tv_sec: target.as_secs() as libc::time_t, tv_usec: target.subsec_micros() as libc::suseconds_t };
-        let times = [timeval, timeval];
-        let c_path = CString::new(path.as_os_str().as_bytes()).expect("path without nul");
-        let rc = unsafe { libc::utimes(c_path.as_ptr(), times.as_ptr()) };
-        assert_eq!(rc, 0, "set mtime for {}", path.display());
     }
 }

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -26,8 +26,8 @@ use crate::{
     platform::{
         daemon::{is_session_daemon_alive, spawn_daemon_process},
         ipc::{
-            bind_session_listener, connect_session_stream, session_socket_path as platform_session_socket_path, set_listener_nonblocking,
-            set_stream_nonblocking, set_stream_read_timeout, set_stream_write_timeout, shutdown_stream, SessionStream,
+            bind_session_listener, connect_session_stream, set_listener_nonblocking, set_stream_nonblocking, set_stream_read_timeout,
+            set_stream_write_timeout, shutdown_stream, try_connect_session_stream, SessionStream,
         },
         terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
@@ -39,7 +39,6 @@ use crate::{
     vt::{self, ScreenGrid, VtEngine, VtEngineKind},
 };
 
-const FOREGROUND_NAME: &str = "foreground";
 const DETACH_CLEANUP_SEQUENCE: &[u8] =
     b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[<u\x1b[r\x1b[0m\x1b[?25h\x1b[2J\x1b[H\x1b[?1049l";
 const REATTACH_CLEAR_SEQUENCE: &[u8] = b"\x1b[2J\x1b[H";
@@ -241,54 +240,27 @@ pub fn ensure_session_started(
     cmd: Option<String>,
     options: SessionStartOptions,
 ) -> Result<SessionMetadata, String> {
-    // If a named session directory already exists with a live socket, reuse it.
-    if let Some(ref id_str) = id {
-        let socket_path = session_socket_path(layout.root(), id_str);
-        if socket_path.exists() {
-            if is_session_daemon_alive(layout.root(), id_str) {
-                // Daemon is running — return the id. The caller should use inspect()
-                // if it needs the session's actual config.
-                let vt_engine = vt_engine.unwrap_or_else(vt::default_vt_engine_kind);
-                return Ok(SessionMetadata {
-                    id: id_str.clone(),
-                    vt_engine,
-                    cwd,
-                    cmd,
-                    record: options.record,
-                    initial_size: options.initial_size,
-                    colors: options.colors,
-                });
-            }
-            // Stale socket from a crashed daemon. Remove it so the respawned daemon
-            // binds cleanly and wait_for_socket waits for the new listener rather
-            // than returning on the leftover file. The session directory and its
-            // recording survive, so falling through to the create path recreates
-            // the session from its prior output (see recreate::seed_engine_from_cast).
-            //
-            // A removal failure other than "already gone" (e.g. a permissions
-            // problem) would otherwise surface downstream as an opaque socket-bind
-            // error (EADDRINUSE), so report the real cause here instead.
-            match fs::remove_file(&socket_path) {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                Err(err) => return Err(format!("remove stale session socket {}: {err}", socket_path.display())),
-            }
-        }
-    }
-
-    // Create a new session and spawn the daemon.
     let vt_engine = vt_engine.unwrap_or_else(vt::default_vt_engine_kind);
     vt_engine.ensure_available()?;
-    let mut session = layout.create_session(id, vt_engine, cwd, cmd)?;
+    let id = id.unwrap_or_else(|| format!("session-{}", uuid::Uuid::new_v4()));
+    crate::runtime::validate_runtime_name(&id)?;
+    let mut session = layout.session_metadata(id, vt_engine, cwd, cmd);
     session.record = options.record;
     session.initial_size = options.initial_size;
     session.colors = options.colors;
 
-    let socket_path = session_socket_path(layout.root(), &session.id);
-    spawn_daemon_process(layout.root(), &session)?;
-    wait_for_socket(&socket_path)?;
-
-    Ok(session)
+    ensure_daemon_started(layout)?;
+    let mut stream = connect_session_stream(&layout.socket_path())?;
+    let body = serde_json::to_vec(&session).map_err(|err| format!("serialize session create request: {err}"))?;
+    http_uds::write_request(&mut stream, http::Method::POST, "/sessions", &body)
+        .map_err(|err| format!("write session create request: {err}"))?;
+    let response = http_uds::read_response(&mut stream).map_err(|err| format!("read session create response: {err}"))?;
+    if response.status != StatusCode::OK {
+        return Err(http_error_message(http_uds::HttpResponse { status: response.status, body: response.body }));
+    }
+    let response: http_uds::CreateSessionResponse =
+        serde_json::from_slice(&response.body).map_err(|err| format!("parse session create response: {err}"))?;
+    Ok(response.session)
 }
 
 pub fn attach_foreground(layout: &RuntimeLayout, id: &str) -> Result<ForegroundAttach, String> {
@@ -300,7 +272,7 @@ pub fn watch_foreground(layout: &RuntimeLayout, id: &str) -> Result<ForegroundAt
 }
 
 fn connect_foreground_upgrade(layout: &RuntimeLayout, id: &str, role: &str) -> Result<ForegroundAttach, String> {
-    let socket_path = session_socket_path(layout.root(), id);
+    let socket_path = layout.socket_path();
     let deadline = Instant::now() + Duration::from_millis(250);
     loop {
         let mut stream = connect_session_stream(&socket_path)?;
@@ -327,15 +299,17 @@ fn connect_foreground_upgrade(layout: &RuntimeLayout, id: &str, role: &str) -> R
 }
 
 pub fn session_socket_path(root: &Path, id: &str) -> PathBuf {
-    platform_session_socket_path(root, id)
+    let _ = id;
+    RuntimeLayout::new(root.to_path_buf()).socket_path()
 }
 
 pub fn daemon_pid_path(root: &Path, id: &str) -> PathBuf {
-    crate::platform::daemon::daemon_pid_path(root, id)
+    let _ = id;
+    RuntimeLayout::new(root.to_path_buf()).daemon_pid_path()
 }
 
 pub fn foreground_path(root: &Path, id: &str) -> PathBuf {
-    root.join(id).join(FOREGROUND_NAME)
+    RuntimeLayout::new(root.to_path_buf()).foreground_path(id)
 }
 
 fn default_vt_engine(session: &SessionMetadata) -> Result<Box<dyn VtEngine>, String> {
@@ -550,7 +524,7 @@ fn write_http_wait_result(stream: &mut SessionStream, status: crate::protocol::W
 }
 
 fn enqueue_output_chunk(
-    root: &Path,
+    layout: &RuntimeLayout,
     id: &str,
     actor: &SessionActor,
     active_client: &mut Option<ActiveClient>,
@@ -560,7 +534,7 @@ fn enqueue_output_chunk(
     let frame = Frame::Output(chunk);
     if let Some(client) = active_client.as_mut() {
         if client.enqueue_frame(&frame).is_err() {
-            let _ = fs::remove_file(foreground_path(root, id));
+            let _ = fs::remove_file(layout.foreground_path(id));
             let _ = actor.record_detach();
             let _ = actor.set_client_presence(false);
             *active_client = None;
@@ -570,7 +544,7 @@ fn enqueue_output_chunk(
 }
 
 fn drain_raw_output_tap(
-    root: &Path,
+    layout: &RuntimeLayout,
     id: &str,
     actor: &SessionActor,
     raw_output_tap: &mut RawOutputTap,
@@ -582,7 +556,7 @@ fn drain_raw_output_tap(
         match raw_output_tap.try_recv() {
             Ok(chunk) => {
                 drained = true;
-                enqueue_output_chunk(root, id, actor, active_client, watchers, chunk);
+                enqueue_output_chunk(layout, id, actor, active_client, watchers, chunk);
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => return Ok(drained),
             Err(std::sync::mpsc::TryRecvError::Disconnected) => {
@@ -606,21 +580,28 @@ fn flush_watchers(watchers: &mut Vec<ActiveClient>) {
 }
 
 #[cfg(any(unix, windows))]
-pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), String> {
-    let id = &session.id;
-    let session_dir = root.join(id);
-    fs::create_dir_all(&session_dir).map_err(|err| format!("create session dir {}: {err}", session_dir.display()))?;
-    let socket_path = session_socket_path(root, id);
-    if socket_path.exists() {
-        let _ = fs::remove_file(&socket_path);
-    }
-
-    let listener = bind_session_listener(&socket_path)?;
+pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> {
+    let layout = RuntimeLayout::new(root.to_path_buf()).with_daemon(daemon_name.to_string())?;
+    layout.ensure_daemon_dirs()?;
+    let socket_path = layout.socket_path();
+    let listener = match bind_session_listener(&socket_path) {
+        Ok(listener) => listener,
+        Err(first_err) => {
+            if try_connect_session_stream(&socket_path).is_ok() {
+                return Ok(());
+            }
+            match fs::remove_file(&socket_path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(format!("remove stale daemon socket {}: {err}", socket_path.display())),
+            }
+            bind_session_listener(&socket_path).map_err(|second_err| format!("{first_err}; after stale cleanup: {second_err}"))?
+        }
+    };
     set_listener_nonblocking(&listener, true)?;
-    fs::write(daemon_pid_path(root, id), std::process::id().to_string()).map_err(|err| format!("write daemon pid: {err}"))?;
+    fs::write(layout.daemon_pid_path(), std::process::id().to_string()).map_err(|err| format!("write daemon pid: {err}"))?;
 
     let mut sessions = HashMap::new();
-    sessions.insert(id.clone(), HostedSession::spawn(session_dir.clone(), session.clone())?);
     let mut packet_clients: Vec<PacketClient> = Vec::new();
     let mut exited_session: Option<(String, bool)> = None;
 
@@ -641,16 +622,15 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                     {
                         set_stream_nonblocking(&stream, true).map_err(|err| format!("set accepted stream nonblocking: {err}"))?;
                     }
-                    set_stream_write_timeout(&stream, Some(SESSION_HTTP_RESPONSE_WRITE_DEADLINE))?;
+                    let _ = set_stream_write_timeout(&stream, Some(SESSION_HTTP_RESPONSE_WRITE_DEADLINE));
                     let request = {
                         let mut reader = HttpHandshakeReader::new(&mut stream, SESSION_HTTP_HANDSHAKE_DEADLINE);
                         let mut prefix = [0; 5];
                         if let Err(err) = reader.read_exact(&mut prefix) {
-                            let _ = Frame::Error(format!("failed to read request: {err}")).write(&mut stream);
+                            let _ = err;
                             continue;
                         }
                         if !http_uds::looks_like_http_prefix(&prefix) {
-                            let _ = Frame::Error("session daemon requires HTTP requests".to_string()).write(&mut stream);
                             continue;
                         }
                         match http_uds::read_request_with_prefix(&mut reader, &prefix) {
@@ -666,8 +646,8 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                         }
                     };
 
-                    let mut http_state = HttpRequestState { sessions: &mut sessions, packet_clients: &mut packet_clients };
-                    if let Err(err) = handle_http_request(root, id, &mut stream, request, &mut http_state) {
+                    let mut http_state = HttpRequestState { layout: &layout, sessions: &mut sessions, packet_clients: &mut packet_clients };
+                    if let Err(err) = handle_http_request(root, daemon_name, &mut stream, request, &mut http_state) {
                         let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &err);
                     }
                 }
@@ -682,9 +662,9 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
             let Some(hosted) = sessions.get_mut(&session_id) else {
                 continue;
             };
-            did_work |= service_hosted_session(root, &session_id, hosted, &mut packet_clients)?;
+            did_work |= service_hosted_session(&layout, &session_id, hosted, &mut packet_clients)?;
             if hosted.actor.exit_code()?.is_some() {
-                let should_keep_session_dir = finish_exited_session(root, &session_id, hosted, &mut packet_clients)?;
+                let should_keep_session_dir = finish_exited_session(&layout, &session_id, hosted, &mut packet_clients)?;
                 exited_session = Some((session_id, should_keep_session_dir));
                 break;
             }
@@ -692,8 +672,12 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
 
         flush_packet_clients(&mut packet_clients);
 
-        if exited_session.is_some() {
-            break;
+        if let Some((session_id, should_keep_session_dir)) = exited_session.take() {
+            cleanup_exited_session(&layout, &session_id, should_keep_session_dir);
+            sessions.remove(&session_id);
+            if sessions.is_empty() {
+                break;
+            }
         }
 
         if !did_work {
@@ -701,26 +685,29 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
         }
     }
 
-    let (id, should_keep_session_dir) = exited_session.unwrap_or_else(|| (id.clone(), session.record));
-    let session_dir = root.join(&id);
     let _ = fs::remove_file(&socket_path);
-    let _ = fs::remove_file(daemon_pid_path(root, &id));
-    let _ = fs::remove_file(foreground_path(root, &id));
-    if !should_keep_session_dir {
-        let _ = fs::remove_dir_all(&session_dir);
-    }
+    let _ = fs::remove_file(layout.daemon_pid_path());
     Ok(())
 }
 
+fn cleanup_exited_session(layout: &RuntimeLayout, id: &str, should_keep_session_dir: bool) {
+    let session_dir = layout.session_dir(id);
+    let _ = fs::remove_file(layout.foreground_path(id));
+    if !should_keep_session_dir {
+        let _ = fs::remove_dir_all(&session_dir);
+    }
+}
+
 fn service_hosted_session(
-    root: &Path,
+    layout: &RuntimeLayout,
     id: &str,
     hosted: &mut HostedSession,
     packet_clients: &mut Vec<PacketClient>,
 ) -> Result<bool, String> {
     let mut did_work = false;
 
-    did_work |= drain_raw_output_tap(root, id, &hosted.actor, &mut hosted.raw_output_tap, &mut hosted.active_client, &mut hosted.watchers)?;
+    did_work |=
+        drain_raw_output_tap(layout, id, &hosted.actor, &mut hosted.raw_output_tap, &mut hosted.active_client, &mut hosted.watchers)?;
     drain_watcher_inputs(&mut hosted.watchers);
 
     if hosted.active_client.is_some() {
@@ -748,7 +735,7 @@ fn service_hosted_session(
         }
 
         if client_disconnected && hosted.active_client.is_some() {
-            let _ = fs::remove_file(foreground_path(root, id));
+            let _ = fs::remove_file(layout.foreground_path(id));
             hosted.actor.record_detach()?;
             hosted.actor.set_client_presence(false)?;
             hosted.active_client = None;
@@ -761,7 +748,7 @@ fn service_hosted_session(
         None => true,
     };
     if !client_writable {
-        let _ = fs::remove_file(foreground_path(root, id));
+        let _ = fs::remove_file(layout.foreground_path(id));
         hosted.actor.record_detach()?;
         hosted.actor.set_client_presence(false)?;
         hosted.active_client = None;
@@ -771,7 +758,7 @@ fn service_hosted_session(
     push_due_packet_renders(id, &hosted.actor, packet_clients, &mut hosted.packet_render_cache)?;
 
     service_pending_waits(&hosted.actor, &mut hosted.pending_waits);
-    service_pending_expects(root, id, &hosted.actor, &mut hosted.pending_expects)?;
+    service_pending_expects(layout, id, &hosted.actor, &mut hosted.pending_expects)?;
     hosted.actor.flush_recording()?;
 
     Ok(did_work)
@@ -832,13 +819,18 @@ fn service_pending_waits(actor: &SessionActor, pending_waits: &mut Vec<PendingWa
     });
 }
 
-fn service_pending_expects(root: &Path, id: &str, actor: &SessionActor, pending_expects: &mut Vec<PendingExpect>) -> Result<(), String> {
+fn service_pending_expects(
+    layout: &RuntimeLayout,
+    id: &str,
+    actor: &SessionActor,
+    pending_expects: &mut Vec<PendingExpect>,
+) -> Result<(), String> {
     if pending_expects.is_empty() {
         return Ok(());
     }
 
     actor.flush_recording()?;
-    let cast_path = root.join(id).join(crate::recording::CAST_FILE_NAME);
+    let cast_path = layout.session_dir(id).join(crate::recording::CAST_FILE_NAME);
     pending_expects.retain_mut(|expect| {
         let elapsed = expect.registered_at.elapsed();
         let elapsed_ms = elapsed.as_millis() as u64;
@@ -868,12 +860,12 @@ fn service_pending_expects(root: &Path, id: &str, actor: &SessionActor, pending_
 }
 
 fn finish_exited_session(
-    root: &Path,
+    layout: &RuntimeLayout,
     id: &str,
     hosted: &mut HostedSession,
     packet_clients: &mut Vec<PacketClient>,
 ) -> Result<bool, String> {
-    drain_raw_output_tap(root, id, &hosted.actor, &mut hosted.raw_output_tap, &mut hosted.active_client, &mut hosted.watchers)?;
+    drain_raw_output_tap(layout, id, &hosted.actor, &mut hosted.raw_output_tap, &mut hosted.active_client, &mut hosted.watchers)?;
     for mut wait in hosted.pending_waits.drain(..) {
         let elapsed_ms = wait.registered_at.elapsed().as_millis() as u64;
         let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::SessionGone, elapsed_ms);
@@ -896,6 +888,7 @@ pub fn run_session_daemon(_root: &Path, _session: &SessionMetadata) -> Result<()
 }
 
 struct HttpRequestState<'a> {
+    layout: &'a RuntimeLayout,
     sessions: &'a mut HashMap<String, HostedSession>,
     packet_clients: &'a mut Vec<PacketClient>,
 }
@@ -930,7 +923,7 @@ impl Read for HttpHandshakeReader<'_> {
 }
 
 fn handle_http_request(
-    root: &Path,
+    _root: &Path,
     daemon_id: &str,
     stream: &mut SessionStream,
     request: http_uds::HttpRequest,
@@ -955,6 +948,20 @@ fn handle_http_request(
             sessions.sort_by(|a, b| a.session.id.cmp(&b.session.id));
             http_uds::write_json(stream, StatusCode::OK, &http_uds::SessionListResponse { sessions })
                 .map_err(|err| format!("write HTTP sessions response: {err}"))
+        }
+        http_uds::Route::SessionCreate => {
+            let session: SessionMetadata =
+                serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP session create request: {err}"))?;
+            crate::runtime::validate_runtime_name(&session.id)?;
+            session.vt_engine.ensure_available()?;
+            if !state.sessions.contains_key(&session.id) {
+                let session_dir = state.layout.session_dir(&session.id);
+                fs::create_dir_all(&session_dir).map_err(|err| format!("create session dir {}: {err}", session_dir.display()))?;
+                let hosted = HostedSession::spawn(session_dir, session.clone())?;
+                state.sessions.insert(session.id.clone(), hosted);
+            }
+            http_uds::write_json(stream, StatusCode::OK, &http_uds::CreateSessionResponse { session })
+                .map_err(|err| format!("write HTTP session create response: {err}"))
         }
         http_uds::Route::PacketConnect => {
             if !http_uds::request_has_upgrade_token(&request, "cleat-packet/1") {
@@ -1024,7 +1031,7 @@ fn handle_http_request(
                     client.enqueue_frame(&Frame::Output(payload))?;
                 }
             }
-            let _ = fs::write(foreground_path(root, &id), b"1");
+            let _ = fs::write(state.layout.foreground_path(&id), b"1");
             hosted.active_client = Some(client);
             hosted.had_foreground_client = true;
             hosted.actor.set_client_presence(true)?;
@@ -1056,7 +1063,7 @@ fn handle_http_request(
             let Some(hosted) = state.sessions.get_mut(&id) else {
                 return write_http_not_found(stream);
             };
-            let _ = fs::remove_file(foreground_path(root, &id));
+            let _ = fs::remove_file(state.layout.foreground_path(&id));
             if hosted.active_client.is_some() {
                 hosted.actor.record_detach()?;
             }
@@ -1076,7 +1083,7 @@ fn handle_http_request(
                 break 'expect Ok(());
             }
 
-            let cast_path = root.join(&id).join(crate::recording::CAST_FILE_NAME);
+            let cast_path = state.layout.session_dir(&id).join(crate::recording::CAST_FILE_NAME);
             hosted.actor.flush_recording()?;
             if cast_path.exists() {
                 if let Ok(events) = crate::cast_reader::read_output_since(&cast_path, body.since_offset) {
@@ -1849,12 +1856,39 @@ impl ActiveClientReader {
 fn wait_for_socket(path: &Path) -> Result<(), String> {
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {
-        if path.exists() {
+        if try_connect_session_stream(path).is_ok() {
             return Ok(());
         }
         thread::sleep(Duration::from_millis(20));
     }
     Err(format!("timed out waiting for socket {}", path.display()))
+}
+
+fn ensure_daemon_started(layout: &RuntimeLayout) -> Result<(), String> {
+    if try_connect_session_stream(&layout.socket_path()).is_ok() && is_session_daemon_alive(layout.root(), layout.daemon_name()) {
+        return Ok(());
+    }
+
+    if layout.socket_path().exists() && !is_session_daemon_alive(layout.root(), layout.daemon_name()) {
+        match fs::remove_file(layout.socket_path()) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(format!("remove stale daemon socket {}: {err}", layout.socket_path().display())),
+        }
+    }
+
+    layout.ensure_daemon_dirs()?;
+    spawn_daemon_process(layout.root(), layout.daemon_name())?;
+    wait_for_socket(&layout.socket_path())
+}
+
+fn http_error_message(response: http_uds::HttpResponse) -> String {
+    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&response.body) {
+        if let Some(message) = value.get("error").and_then(|value| value.as_str()) {
+            return message.to_string();
+        }
+    }
+    format!("HTTP request returned {}", response.status)
 }
 
 #[cfg(test)]
@@ -1880,7 +1914,9 @@ mod tests {
         use std::{fs, os::unix::net::UnixListener, sync::mpsc, thread, time::Duration};
 
         let temp = tempfile::tempdir().expect("tempdir");
-        fs::create_dir_all(temp.path().join("alpha")).expect("create session dir");
+        let layout = RuntimeLayout::new(temp.path().to_path_buf());
+        layout.ensure_daemon_dirs().expect("create daemon dirs");
+        fs::create_dir_all(layout.session_dir("alpha")).expect("create session dir");
         let socket_path = session_socket_path(temp.path(), "alpha");
         let listener = UnixListener::bind(&socket_path).expect("bind socket");
         let (tx, rx) = mpsc::channel();
@@ -1895,7 +1931,6 @@ mod tests {
                 .expect("write response");
         });
 
-        let layout = RuntimeLayout::new(temp.path().to_path_buf());
         let attach = attach_foreground(&layout, "alpha").expect("attach");
         drop(attach);
         let request = rx.recv_timeout(Duration::from_secs(1)).expect("receive request");

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -511,6 +511,40 @@ struct PendingExpect {
     registered_at: Instant,
 }
 
+struct HostedSession {
+    actor: SessionActor,
+    raw_output_tap: RawOutputTap,
+    active_client: Option<ActiveClient>,
+    watchers: Vec<ActiveClient>,
+    packet_render_cache: PacketRenderCache,
+    had_foreground_client: bool,
+    pending_waits: Vec<PendingWait>,
+    pending_expects: Vec<PendingExpect>,
+    should_keep_session_dir: bool,
+}
+
+impl HostedSession {
+    fn spawn(session_dir: PathBuf, session: SessionMetadata) -> Result<Self, String> {
+        let actor_session_dir = session_dir;
+        let actor_session = session.clone();
+        let actor = SessionActor::spawn(session.initial_size.rows, Arc::new(|| {}), move || {
+            crate::session_runtime::SessionRuntime::spawn(actor_session_dir, &actor_session, default_vt_engine(&actor_session)?)
+        })?;
+        let raw_output_tap = actor.subscribe_raw_output()?;
+        Ok(Self {
+            actor,
+            raw_output_tap,
+            active_client: None,
+            watchers: Vec::new(),
+            packet_render_cache: PacketRenderCache::default(),
+            had_foreground_client: false,
+            pending_waits: Vec::new(),
+            pending_expects: Vec::new(),
+            should_keep_session_dir: session.record,
+        })
+    }
+}
+
 fn write_http_wait_result(stream: &mut SessionStream, status: crate::protocol::WaitStatus, elapsed_ms: u64) -> std::io::Result<()> {
     http_uds::write_json(stream, StatusCode::OK, &http_uds::WaitResultResponse { status: wait_status_to_http(status), elapsed_ms })
 }
@@ -585,20 +619,11 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
     set_listener_nonblocking(&listener, true)?;
     fs::write(daemon_pid_path(root, id), std::process::id().to_string()).map_err(|err| format!("write daemon pid: {err}"))?;
 
-    let actor_session_dir = session_dir.clone();
-    let actor_session = session.clone();
-    let actor = SessionActor::spawn(session.initial_size.rows, Arc::new(|| {}), move || {
-        crate::session_runtime::SessionRuntime::spawn(actor_session_dir, &actor_session, default_vt_engine(&actor_session)?)
-    })?;
-    let mut raw_output_tap = actor.subscribe_raw_output()?;
-    let mut active_client: Option<ActiveClient> = None;
-    let mut watchers: Vec<ActiveClient> = Vec::new();
+    let mut sessions = HashMap::new();
+    sessions.insert(id.clone(), HostedSession::spawn(session_dir.clone(), session.clone())?);
     let mut packet_clients: Vec<PacketClient> = Vec::new();
-    let mut packet_render_cache = PacketRenderCache::default();
-    let mut had_foreground_client = false;
-    let mut pending_waits: Vec<PendingWait> = Vec::new();
-    let mut pending_expects: Vec<PendingExpect> = Vec::new();
-    let mut should_keep_session_dir = session.record;
+    let mut exited_session: Option<(String, bool)> = None;
+
     loop {
         let mut did_work = false;
 
@@ -641,15 +666,7 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
                         }
                     };
 
-                    let mut http_state = HttpRequestState {
-                        actor: &actor,
-                        active_client: &mut active_client,
-                        watchers: &mut watchers,
-                        packet_clients: &mut packet_clients,
-                        had_foreground_client: &mut had_foreground_client,
-                        pending_waits: &mut pending_waits,
-                        pending_expects: &mut pending_expects,
-                    };
+                    let mut http_state = HttpRequestState { sessions: &mut sessions, packet_clients: &mut packet_clients };
                     if let Err(err) = handle_http_request(root, id, &mut stream, request, &mut http_state) {
                         let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &err);
                     }
@@ -659,164 +676,23 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
             }
         }
 
-        did_work |= drain_raw_output_tap(root, id, &actor, &mut raw_output_tap, &mut active_client, &mut watchers)?;
-        drain_watcher_inputs(&mut watchers);
-        did_work |= service_packet_clients(&actor, id, &mut packet_clients, &mut packet_render_cache)?;
-
-        if active_client.is_some() {
-            let mut client_disconnected = false;
-            let mut pending = VecDeque::new();
-            if let Some(client) = active_client.as_mut() {
-                match client.drain_input_frames(&mut pending, Duration::ZERO) {
-                    Ok(true) => {}
-                    Ok(false) => client_disconnected = true,
-                    Err(err) => return Err(format!("read client frame: {err}")),
-                }
-            }
-
-            while let Some(frame) = pending.pop_front() {
-                did_work = true;
-                match frame {
-                    Frame::Input(bytes) => {
-                        actor.write_input(bytes)?;
-                    }
-                    Frame::Resize { cols, rows } => {
-                        actor.resize(cols, rows)?;
-                    }
-                    _ => {}
-                }
-            }
-
-            if client_disconnected && active_client.is_some() {
-                let _ = fs::remove_file(foreground_path(root, id));
-                actor.record_detach()?;
-                actor.set_client_presence(false)?;
-                active_client = None;
-                did_work = true;
+        did_work |= service_packet_clients(&mut sessions, &mut packet_clients)?;
+        let session_ids: Vec<String> = sessions.keys().cloned().collect();
+        for session_id in session_ids {
+            let Some(hosted) = sessions.get_mut(&session_id) else {
+                continue;
+            };
+            did_work |= service_hosted_session(root, &session_id, hosted, &mut packet_clients)?;
+            if hosted.actor.exit_code()?.is_some() {
+                let should_keep_session_dir = finish_exited_session(root, &session_id, hosted, &mut packet_clients)?;
+                exited_session = Some((session_id, should_keep_session_dir));
+                break;
             }
         }
 
-        let client_writable = match active_client.as_mut() {
-            Some(client) => client.flush_pending_output()?,
-            None => true,
-        };
-        if !client_writable {
-            let _ = fs::remove_file(foreground_path(root, id));
-            actor.record_detach()?;
-            actor.set_client_presence(false)?;
-            active_client = None;
-            did_work = true;
-        }
-        flush_watchers(&mut watchers);
-        push_due_packet_renders(&actor, &mut packet_clients, &mut packet_render_cache)?;
         flush_packet_clients(&mut packet_clients);
 
-        // Evaluate pending waits on each loop tick.
-        // Write errors are intentionally discarded — the client may have disconnected.
-        let screen_stable_fingerprint = if pending_waits.iter().any(|wait| wait.screen_stable.is_some()) {
-            actor.full_snapshot().ok().map(ScreenStableFingerprint::from_snapshot)
-        } else {
-            None
-        };
-        let now = Instant::now();
-        pending_waits.retain_mut(|wait| {
-            let elapsed = wait.registered_at.elapsed();
-            let elapsed_ms = elapsed.as_millis() as u64;
-
-            // Check timeout first
-            if elapsed_ms >= wait.timeout_ms {
-                let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Timeout, elapsed_ms);
-                return false;
-            }
-
-            if let (Some(state), Some(fingerprint)) = (wait.screen_stable.as_mut(), screen_stable_fingerprint.as_ref()) {
-                state.observe(fingerprint.clone(), now);
-            }
-
-            // Check conditions (OR semantics — any match wins)
-            for condition in &wait.conditions {
-                match condition {
-                    crate::protocol::WaitCondition::OutputIdle { quiet_ms } => {
-                        // Silence measured from max(registration_time, last_output_time)
-                        let silence_since = match actor.last_pty_output_at().ok().flatten() {
-                            Some(t) if t > wait.registered_at => t,
-                            _ => wait.registered_at,
-                        };
-                        let quiet_duration = silence_since.elapsed().as_millis() as u64;
-                        if quiet_duration >= *quiet_ms {
-                            let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
-                            return false;
-                        }
-                    }
-                    crate::protocol::WaitCondition::TextMatch { text } => {
-                        if actor.screen_contains(text.clone()).unwrap_or(false) {
-                            let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
-                            return false;
-                        }
-                    }
-                    crate::protocol::WaitCondition::ScreenStable { stable_ms } => {
-                        if let Some(state) = wait.screen_stable.as_ref() {
-                            let stable_duration_ms = state.stable_since.elapsed().as_millis() as u64;
-                            if stable_duration_ms >= *stable_ms {
-                                let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
-                                return false;
-                            }
-                        }
-                    }
-                }
-            }
-
-            true // keep waiting
-        });
-
-        // Evaluate pending expects by scanning the cast file for text matches.
-        if !pending_expects.is_empty() {
-            actor.flush_recording()?;
-            let cast_path = root.join(id).join(crate::recording::CAST_FILE_NAME);
-            pending_expects.retain_mut(|expect| {
-                let elapsed = expect.registered_at.elapsed();
-                let elapsed_ms = elapsed.as_millis() as u64;
-
-                if elapsed_ms >= expect.timeout_ms {
-                    let _ = write_http_wait_result(&mut expect.stream, crate::protocol::WaitStatus::Timeout, elapsed_ms);
-                    return false;
-                }
-
-                if cast_path.exists() {
-                    let file_size = std::fs::metadata(&cast_path).map(|m| m.len()).unwrap_or(0);
-                    if file_size > expect.last_checked_file_size {
-                        expect.last_checked_file_size = file_size;
-                        if let Ok(events) = crate::cast_reader::read_output_since(&cast_path, expect.since_offset) {
-                            let output: String = events.iter().map(|e| e.data.as_str()).collect();
-                            if output.contains(&expect.text) {
-                                let _ = write_http_wait_result(&mut expect.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
-                                return false;
-                            }
-                        }
-                    }
-                }
-
-                true
-            });
-        }
-        actor.flush_recording()?;
-
-        if actor.exit_code()?.is_some() {
-            drain_raw_output_tap(root, id, &actor, &mut raw_output_tap, &mut active_client, &mut watchers)?;
-            for mut wait in pending_waits.drain(..) {
-                let elapsed_ms = wait.registered_at.elapsed().as_millis() as u64;
-                let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::SessionGone, elapsed_ms);
-            }
-            for mut expect in pending_expects.drain(..) {
-                let elapsed_ms = expect.registered_at.elapsed().as_millis() as u64;
-                let _ = write_http_wait_result(&mut expect.stream, crate::protocol::WaitStatus::SessionGone, elapsed_ms);
-            }
-            if let Some(client) = active_client.as_mut() {
-                let _ = client.flush_pending_output();
-            }
-            flush_watchers(&mut watchers);
-            flush_packet_clients(&mut packet_clients);
-            should_keep_session_dir = actor.should_keep_session_dir().unwrap_or(should_keep_session_dir);
+        if exited_session.is_some() {
             break;
         }
 
@@ -825,14 +701,193 @@ pub fn run_session_daemon(root: &Path, session: &SessionMetadata) -> Result<(), 
         }
     }
 
-    let session_dir = root.join(id);
+    let (id, should_keep_session_dir) = exited_session.unwrap_or_else(|| (id.clone(), session.record));
+    let session_dir = root.join(&id);
     let _ = fs::remove_file(&socket_path);
-    let _ = fs::remove_file(daemon_pid_path(root, id));
-    let _ = fs::remove_file(foreground_path(root, id));
+    let _ = fs::remove_file(daemon_pid_path(root, &id));
+    let _ = fs::remove_file(foreground_path(root, &id));
     if !should_keep_session_dir {
         let _ = fs::remove_dir_all(&session_dir);
     }
     Ok(())
+}
+
+fn service_hosted_session(
+    root: &Path,
+    id: &str,
+    hosted: &mut HostedSession,
+    packet_clients: &mut Vec<PacketClient>,
+) -> Result<bool, String> {
+    let mut did_work = false;
+
+    did_work |= drain_raw_output_tap(root, id, &hosted.actor, &mut hosted.raw_output_tap, &mut hosted.active_client, &mut hosted.watchers)?;
+    drain_watcher_inputs(&mut hosted.watchers);
+
+    if hosted.active_client.is_some() {
+        let mut client_disconnected = false;
+        let mut pending = VecDeque::new();
+        if let Some(client) = hosted.active_client.as_mut() {
+            match client.drain_input_frames(&mut pending, Duration::ZERO) {
+                Ok(true) => {}
+                Ok(false) => client_disconnected = true,
+                Err(err) => return Err(format!("read client frame: {err}")),
+            }
+        }
+
+        while let Some(frame) = pending.pop_front() {
+            did_work = true;
+            match frame {
+                Frame::Input(bytes) => {
+                    hosted.actor.write_input(bytes)?;
+                }
+                Frame::Resize { cols, rows } => {
+                    hosted.actor.resize(cols, rows)?;
+                }
+                _ => {}
+            }
+        }
+
+        if client_disconnected && hosted.active_client.is_some() {
+            let _ = fs::remove_file(foreground_path(root, id));
+            hosted.actor.record_detach()?;
+            hosted.actor.set_client_presence(false)?;
+            hosted.active_client = None;
+            did_work = true;
+        }
+    }
+
+    let client_writable = match hosted.active_client.as_mut() {
+        Some(client) => client.flush_pending_output()?,
+        None => true,
+    };
+    if !client_writable {
+        let _ = fs::remove_file(foreground_path(root, id));
+        hosted.actor.record_detach()?;
+        hosted.actor.set_client_presence(false)?;
+        hosted.active_client = None;
+        did_work = true;
+    }
+    flush_watchers(&mut hosted.watchers);
+    push_due_packet_renders(id, &hosted.actor, packet_clients, &mut hosted.packet_render_cache)?;
+
+    service_pending_waits(&hosted.actor, &mut hosted.pending_waits);
+    service_pending_expects(root, id, &hosted.actor, &mut hosted.pending_expects)?;
+    hosted.actor.flush_recording()?;
+
+    Ok(did_work)
+}
+
+fn service_pending_waits(actor: &SessionActor, pending_waits: &mut Vec<PendingWait>) {
+    let screen_stable_fingerprint = if pending_waits.iter().any(|wait| wait.screen_stable.is_some()) {
+        actor.full_snapshot().ok().map(ScreenStableFingerprint::from_snapshot)
+    } else {
+        None
+    };
+    let now = Instant::now();
+    pending_waits.retain_mut(|wait| {
+        let elapsed = wait.registered_at.elapsed();
+        let elapsed_ms = elapsed.as_millis() as u64;
+
+        if elapsed_ms >= wait.timeout_ms {
+            let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Timeout, elapsed_ms);
+            return false;
+        }
+
+        if let (Some(state), Some(fingerprint)) = (wait.screen_stable.as_mut(), screen_stable_fingerprint.as_ref()) {
+            state.observe(fingerprint.clone(), now);
+        }
+
+        for condition in &wait.conditions {
+            match condition {
+                crate::protocol::WaitCondition::OutputIdle { quiet_ms } => {
+                    let silence_since = match actor.last_pty_output_at().ok().flatten() {
+                        Some(t) if t > wait.registered_at => t,
+                        _ => wait.registered_at,
+                    };
+                    let quiet_duration = silence_since.elapsed().as_millis() as u64;
+                    if quiet_duration >= *quiet_ms {
+                        let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
+                        return false;
+                    }
+                }
+                crate::protocol::WaitCondition::TextMatch { text } => {
+                    if actor.screen_contains(text.clone()).unwrap_or(false) {
+                        let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
+                        return false;
+                    }
+                }
+                crate::protocol::WaitCondition::ScreenStable { stable_ms } => {
+                    if let Some(state) = wait.screen_stable.as_ref() {
+                        let stable_duration_ms = state.stable_since.elapsed().as_millis() as u64;
+                        if stable_duration_ms >= *stable_ms {
+                            let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    });
+}
+
+fn service_pending_expects(root: &Path, id: &str, actor: &SessionActor, pending_expects: &mut Vec<PendingExpect>) -> Result<(), String> {
+    if pending_expects.is_empty() {
+        return Ok(());
+    }
+
+    actor.flush_recording()?;
+    let cast_path = root.join(id).join(crate::recording::CAST_FILE_NAME);
+    pending_expects.retain_mut(|expect| {
+        let elapsed = expect.registered_at.elapsed();
+        let elapsed_ms = elapsed.as_millis() as u64;
+
+        if elapsed_ms >= expect.timeout_ms {
+            let _ = write_http_wait_result(&mut expect.stream, crate::protocol::WaitStatus::Timeout, elapsed_ms);
+            return false;
+        }
+
+        if cast_path.exists() {
+            let file_size = std::fs::metadata(&cast_path).map(|m| m.len()).unwrap_or(0);
+            if file_size > expect.last_checked_file_size {
+                expect.last_checked_file_size = file_size;
+                if let Ok(events) = crate::cast_reader::read_output_since(&cast_path, expect.since_offset) {
+                    let output: String = events.iter().map(|e| e.data.as_str()).collect();
+                    if output.contains(&expect.text) {
+                        let _ = write_http_wait_result(&mut expect.stream, crate::protocol::WaitStatus::Ready, elapsed_ms);
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    });
+    Ok(())
+}
+
+fn finish_exited_session(
+    root: &Path,
+    id: &str,
+    hosted: &mut HostedSession,
+    packet_clients: &mut Vec<PacketClient>,
+) -> Result<bool, String> {
+    drain_raw_output_tap(root, id, &hosted.actor, &mut hosted.raw_output_tap, &mut hosted.active_client, &mut hosted.watchers)?;
+    for mut wait in hosted.pending_waits.drain(..) {
+        let elapsed_ms = wait.registered_at.elapsed().as_millis() as u64;
+        let _ = write_http_wait_result(&mut wait.stream, crate::protocol::WaitStatus::SessionGone, elapsed_ms);
+    }
+    for mut expect in hosted.pending_expects.drain(..) {
+        let elapsed_ms = expect.registered_at.elapsed().as_millis() as u64;
+        let _ = write_http_wait_result(&mut expect.stream, crate::protocol::WaitStatus::SessionGone, elapsed_ms);
+    }
+    if let Some(client) = hosted.active_client.as_mut() {
+        let _ = client.flush_pending_output();
+    }
+    flush_watchers(&mut hosted.watchers);
+    flush_packet_clients(packet_clients);
+    Ok(hosted.actor.should_keep_session_dir().unwrap_or(hosted.should_keep_session_dir))
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -841,13 +896,8 @@ pub fn run_session_daemon(_root: &Path, _session: &SessionMetadata) -> Result<()
 }
 
 struct HttpRequestState<'a> {
-    actor: &'a SessionActor,
-    active_client: &'a mut Option<ActiveClient>,
-    watchers: &'a mut Vec<ActiveClient>,
+    sessions: &'a mut HashMap<String, HostedSession>,
     packet_clients: &'a mut Vec<PacketClient>,
-    had_foreground_client: &'a mut bool,
-    pending_waits: &'a mut Vec<PendingWait>,
-    pending_expects: &'a mut Vec<PendingExpect>,
 }
 
 struct HttpHandshakeReader<'a> {
@@ -898,8 +948,12 @@ fn handle_http_request(
         )
         .map_err(|err| format!("write HTTP response: {err}")),
         http_uds::Route::Sessions => {
-            let result = state.actor.inspect(state.active_client.is_some(), state.watchers.len())?;
-            http_uds::write_json(stream, StatusCode::OK, &http_uds::SessionListResponse { sessions: vec![result] })
+            let mut sessions = Vec::new();
+            for hosted in state.sessions.values() {
+                sessions.push(hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?);
+            }
+            sessions.sort_by(|a, b| a.session.id.cmp(&b.session.id));
+            http_uds::write_json(stream, StatusCode::OK, &http_uds::SessionListResponse { sessions })
                 .map_err(|err| format!("write HTTP sessions response: {err}"))
         }
         http_uds::Route::PacketConnect => {
@@ -909,38 +963,54 @@ fn handle_http_request(
                 return Ok(());
             }
 
-            let inspect = state.actor.inspect(state.active_client.is_some(), state.watchers.len())?;
+            let mut directory_entries = Vec::new();
+            for hosted in state.sessions.values() {
+                let inspect = hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?;
+                directory_entries.push(DirectoryEntry {
+                    session_id: inspect.session.id,
+                    cols: inspect.terminal.cols,
+                    rows: inspect.terminal.rows,
+                });
+            }
+            directory_entries.sort_by(|a, b| a.session_id.cmp(&b.session_id));
             http_uds::write_packet_switching_protocols(stream).map_err(|err| format!("write HTTP packet upgrade response: {err}"))?;
             let packet_stream = stream.try_clone().map_err(|err| format!("clone HTTP packet stream: {err}"))?;
             #[cfg(unix)]
             set_stream_nonblocking(&packet_stream, true).map_err(|err| format!("set HTTP packet stream nonblocking: {err}"))?;
             let mut client = PacketClient::new(packet_stream)?;
             client.enqueue_control(MSG_CONTROL_HELLO, &ControlHello::current())?;
-            client.enqueue_control(MSG_CONTROL_DIRECTORY_SNAPSHOT, &DirectorySnapshot {
-                sessions: vec![DirectoryEntry { session_id: inspect.session.id, cols: inspect.terminal.cols, rows: inspect.terminal.rows }],
-            })?;
+            client.enqueue_control(MSG_CONTROL_DIRECTORY_SNAPSHOT, &DirectorySnapshot { sessions: directory_entries })?;
             state.packet_clients.push(client);
             Ok(())
         }
-        http_uds::Route::SessionInspect { id } if id == daemon_id => {
-            let result = state.actor.inspect(state.active_client.is_some(), state.watchers.len())?;
+        http_uds::Route::SessionInspect { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
+            let result = hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?;
             http_uds::write_json(stream, StatusCode::OK, &result).map_err(|err| format!("write HTTP inspect response: {err}"))
         }
-        http_uds::Route::SessionDelete { id } if id == daemon_id => {
-            state.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Leader)?;
+        http_uds::Route::SessionDelete { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
+            hosted.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Leader)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP delete response: {err}"))
         }
-        http_uds::Route::SessionAttach { id } if id == daemon_id => 'attach: {
+        http_uds::Route::SessionAttach { id } => 'attach: {
+            let Some(hosted) = state.sessions.get_mut(&id) else {
+                break 'attach write_http_not_found(stream);
+            };
             let body: http_uds::AttachRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP attach request: {err}"))?;
-            if state.active_client.is_some() {
+            if hosted.active_client.is_some() {
                 http_uds::write_error(stream, StatusCode::CONFLICT, "session already has a foreground client")
                     .map_err(|err| format!("write HTTP attach busy response: {err}"))?;
                 break 'attach Ok(());
             }
 
             let capabilities = attach_capabilities_from_http(body.capabilities);
-            let replay = state.actor.apply_attach_state(body.cols, body.rows, capabilities)?;
+            let replay = hosted.actor.apply_attach_state(body.cols, body.rows, capabilities)?;
             http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP attach upgrade response: {err}"))?;
             let attach_stream = stream.try_clone().map_err(|err| format!("clone HTTP attach stream: {err}"))?;
             #[cfg(unix)]
@@ -948,24 +1018,27 @@ fn handle_http_request(
             let mut client = ActiveClient::new(attach_stream)?;
             if let Some(payload) = replay {
                 if !payload.is_empty() {
-                    if *state.had_foreground_client {
+                    if hosted.had_foreground_client {
                         client.enqueue_frame(&Frame::Output(REATTACH_CLEAR_SEQUENCE.to_vec()))?;
                     }
                     client.enqueue_frame(&Frame::Output(payload))?;
                 }
             }
-            let _ = fs::write(foreground_path(root, daemon_id), b"1");
-            *state.active_client = Some(client);
-            *state.had_foreground_client = true;
-            state.actor.set_client_presence(true)?;
-            state.actor.record_attach()?;
+            let _ = fs::write(foreground_path(root, &id), b"1");
+            hosted.active_client = Some(client);
+            hosted.had_foreground_client = true;
+            hosted.actor.set_client_presence(true)?;
+            hosted.actor.record_attach()?;
             Ok(())
         }
-        http_uds::Route::SessionWatch { id } if id == daemon_id => {
+        http_uds::Route::SessionWatch { id } => {
+            let Some(hosted) = state.sessions.get_mut(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::AttachRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP watch request: {err}"))?;
             let capabilities = attach_capabilities_from_http(body.capabilities);
-            let replay = state.actor.replay_payload(capabilities)?;
+            let replay = hosted.actor.replay_payload(capabilities)?;
             http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP watch upgrade response: {err}"))?;
             let watch_stream = stream.try_clone().map_err(|err| format!("clone HTTP watch stream: {err}"))?;
             #[cfg(unix)]
@@ -976,29 +1049,35 @@ fn handle_http_request(
                     watcher.enqueue_frame(&Frame::Output(payload))?;
                 }
             }
-            state.watchers.push(watcher);
+            hosted.watchers.push(watcher);
             Ok(())
         }
-        http_uds::Route::SessionDetach { id } if id == daemon_id => {
-            let _ = fs::remove_file(foreground_path(root, daemon_id));
-            if state.active_client.is_some() {
-                state.actor.record_detach()?;
+        http_uds::Route::SessionDetach { id } => {
+            let Some(hosted) = state.sessions.get_mut(&id) else {
+                return write_http_not_found(stream);
+            };
+            let _ = fs::remove_file(foreground_path(root, &id));
+            if hosted.active_client.is_some() {
+                hosted.actor.record_detach()?;
             }
-            state.actor.set_client_presence(false)?;
-            *state.active_client = None;
+            hosted.actor.set_client_presence(false)?;
+            hosted.active_client = None;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP detach response: {err}"))
         }
-        http_uds::Route::SessionExpect { id } if id == daemon_id => 'expect: {
+        http_uds::Route::SessionExpect { id } => 'expect: {
+            let Some(hosted) = state.sessions.get_mut(&id) else {
+                break 'expect write_http_not_found(stream);
+            };
             let body: http_uds::ExpectRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP expect request: {err}"))?;
-            if !state.actor.recording_active()? {
+            if !hosted.actor.recording_active()? {
                 http_uds::write_error(stream, StatusCode::CONFLICT, "recording not active")
                     .map_err(|err| format!("write HTTP expect error: {err}"))?;
                 break 'expect Ok(());
             }
 
-            let cast_path = root.join(daemon_id).join(crate::recording::CAST_FILE_NAME);
-            state.actor.flush_recording()?;
+            let cast_path = root.join(&id).join(crate::recording::CAST_FILE_NAME);
+            hosted.actor.flush_recording()?;
             if cast_path.exists() {
                 if let Ok(events) = crate::cast_reader::read_output_since(&cast_path, body.since_offset) {
                     let output: String = events.iter().map(|event| event.data.as_str()).collect();
@@ -1020,7 +1099,7 @@ fn handle_http_request(
                 break 'expect Ok(());
             }
             let initial_file_size = std::fs::metadata(&cast_path).map(|metadata| metadata.len()).unwrap_or(0);
-            state.pending_expects.push(PendingExpect {
+            hosted.pending_expects.push(PendingExpect {
                 stream: pending_stream,
                 text: body.text,
                 since_offset: body.since_offset,
@@ -1030,105 +1109,150 @@ fn handle_http_request(
             });
             Ok(())
         }
-        http_uds::Route::SessionInput { id } if id == daemon_id => {
+        http_uds::Route::SessionInput { id } => {
+            let Some(hosted) = state.sessions.get_mut(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::InputRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP input request: {err}"))?;
             match body {
                 http_uds::InputRequest::Text { text } => {
-                    state.actor.write_input(text.into_bytes())?;
+                    hosted.actor.write_input(text.into_bytes())?;
                 }
                 http_uds::InputRequest::Paste { text } => {
-                    state.actor.paste(text.into_bytes())?;
+                    hosted.actor.paste(text.into_bytes())?;
                 }
                 http_uds::InputRequest::Key { key } => {
                     let bytes = http_input_key_bytes(key);
-                    state.actor.write_input(bytes)?;
+                    hosted.actor.write_input(bytes)?;
                 }
                 http_uds::InputRequest::RawBytes { bytes } => {
-                    state.actor.write_input(bytes)?;
+                    hosted.actor.write_input(bytes)?;
                 }
                 http_uds::InputRequest::Resize { cols, rows } => {
-                    state.actor.resize(cols, rows)?;
+                    hosted.actor.resize(cols, rows)?;
                 }
             }
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP input response: {err}"))
         }
-        http_uds::Route::SessionKeys { id } if id == daemon_id => {
+        http_uds::Route::SessionKeys { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::KeysRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP keys request: {err}"))?;
-            state.actor.write_input(body.bytes)?;
+            hosted.actor.write_input(body.bytes)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP keys response: {err}"))
         }
-        http_uds::Route::SessionKeysWithMark { id } if id == daemon_id => {
+        http_uds::Route::SessionKeysWithMark { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::KeysWithMarkRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP keys-with-mark request: {err}"))?;
-            let offset = state.actor.write_input_with_mark(body.bytes, body.marker_name)?;
+            let offset = hosted.actor.write_input_with_mark(body.bytes, body.marker_name)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
                 .map_err(|err| format!("write HTTP keys-with-mark response: {err}"))
         }
-        http_uds::Route::SessionPasteWithMark { id } if id == daemon_id => {
+        http_uds::Route::SessionPasteWithMark { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::PasteWithMarkRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP paste-with-mark request: {err}"))?;
-            let offset = state.actor.paste_with_mark(body.text.into_bytes(), body.marker_name)?;
+            let offset = hosted.actor.paste_with_mark(body.text.into_bytes(), body.marker_name)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
                 .map_err(|err| format!("write HTTP paste-with-mark response: {err}"))
         }
-        http_uds::Route::SessionRecord { id } if id == daemon_id => {
+        http_uds::Route::SessionRecord { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::RecordRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP record request: {err}"))?;
-            state.actor.set_recording(body.enable)?;
+            hosted.actor.set_recording(body.enable)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP record response: {err}"))
         }
-        http_uds::Route::SessionMark { id } if id == daemon_id => {
+        http_uds::Route::SessionMark { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::MarkRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP mark request: {err}"))?;
-            let offset = state.actor.mark(body.name)?;
+            let offset = hosted.actor.mark(body.name)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
                 .map_err(|err| format!("write HTTP mark response: {err}"))
         }
-        http_uds::Route::SessionResolveMarker { id } if id == daemon_id => {
+        http_uds::Route::SessionResolveMarker { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::ResolveMarkerRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP resolve-marker request: {err}"))?;
             let marker_name = body.name;
-            match state.actor.resolve_marker(marker_name.clone())? {
+            match hosted.actor.resolve_marker(marker_name.clone())? {
                 Some(offset) => http_uds::write_json(stream, StatusCode::OK, &http_uds::MarkResponse { offset })
                     .map_err(|err| format!("write HTTP resolve-marker response: {err}")),
                 None => http_uds::write_error(stream, StatusCode::NOT_FOUND, &format!("marker not found: {marker_name}"))
                     .map_err(|err| format!("write HTTP resolve-marker error: {err}")),
             }
         }
-        http_uds::Route::SessionResolveNextMarker { id } if id == daemon_id => {
+        http_uds::Route::SessionResolveNextMarker { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::ResolveNextMarkerRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP resolve-next-marker request: {err}"))?;
-            let offset = state.actor.resolve_next_marker_after(body.after)?;
+            let offset = hosted.actor.resolve_next_marker_after(body.after)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::ResolveNextMarkerResponse { offset })
                 .map_err(|err| format!("write HTTP resolve-next-marker response: {err}"))
         }
-        http_uds::Route::SessionResize { id } if id == daemon_id => {
+        http_uds::Route::SessionResize { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::ResizeRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP resize request: {err}"))?;
-            state.actor.resize(body.cols, body.rows)?;
+            hosted.actor.resize(body.cols, body.rows)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP resize response: {err}"))
         }
-        http_uds::Route::SessionScreen { id } if id == daemon_id => match state.actor.capture_text() {
-            Ok(text) => http_uds::write_json(stream, StatusCode::OK, &http_uds::ScreenResponse { text })
-                .map_err(|err| format!("write HTTP screen response: {err}")),
-            Err(err) => http_uds::write_error(stream, StatusCode::CONFLICT, &err).map_err(|err| format!("write HTTP screen error: {err}")),
-        },
-        http_uds::Route::SessionSignal { id } if id == daemon_id => {
+        http_uds::Route::SessionScreen { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
+            match hosted.actor.capture_text() {
+                Ok(text) => http_uds::write_json(stream, StatusCode::OK, &http_uds::ScreenResponse { text })
+                    .map_err(|err| format!("write HTTP screen response: {err}")),
+                Err(err) => {
+                    http_uds::write_error(stream, StatusCode::CONFLICT, &err).map_err(|err| format!("write HTTP screen error: {err}"))
+                }
+            }
+        }
+        http_uds::Route::SessionSignal { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
             let body: http_uds::SignalRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP signal request: {err}"))?;
-            state.actor.dispatch_signal(body.signal, signal_target_from_http(body.target))?;
+            hosted.actor.dispatch_signal(body.signal, signal_target_from_http(body.target))?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP signal response: {err}"))
         }
-        http_uds::Route::SessionSnapshot { id } if id == daemon_id => match state.actor.full_snapshot() {
-            Ok(snapshot) => http_uds::write_json(stream, StatusCode::OK, &http_uds::snapshot_response(snapshot))
-                .map_err(|err| format!("write HTTP snapshot response: {err}")),
-            Err(err) => {
-                http_uds::write_error(stream, StatusCode::CONFLICT, &err).map_err(|err| format!("write HTTP snapshot error: {err}"))
+        http_uds::Route::SessionSnapshot { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
+            match hosted.actor.full_snapshot() {
+                Ok(snapshot) => http_uds::write_json(stream, StatusCode::OK, &http_uds::snapshot_response(snapshot))
+                    .map_err(|err| format!("write HTTP snapshot response: {err}")),
+                Err(err) => {
+                    http_uds::write_error(stream, StatusCode::CONFLICT, &err).map_err(|err| format!("write HTTP snapshot error: {err}"))
+                }
             }
-        },
-        http_uds::Route::SessionWait { id } if id == daemon_id => 'wait: {
+        }
+        http_uds::Route::SessionWait { id } => 'wait: {
+            let Some(hosted) = state.sessions.get_mut(&id) else {
+                break 'wait write_http_not_found(stream);
+            };
             let body: http_uds::WaitRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP wait request: {err}"))?;
             let conditions: Vec<_> = body.conditions.into_iter().map(wait_condition_from_http).collect();
@@ -1142,7 +1266,7 @@ fn handle_http_request(
             let has_screen_stable =
                 conditions.iter().any(|condition| matches!(condition, crate::protocol::WaitCondition::ScreenStable { .. }));
             if has_text_match {
-                if let Err(err) = state.actor.validate_text_matching() {
+                if let Err(err) = hosted.actor.validate_text_matching() {
                     http_uds::write_error(stream, StatusCode::CONFLICT, &format!("text matching not supported: {err}"))
                         .map_err(|err| format!("write HTTP wait error: {err}"))?;
                     break 'wait Ok(());
@@ -1150,7 +1274,7 @@ fn handle_http_request(
             }
             let registered_at = Instant::now();
             let screen_stable = if has_screen_stable {
-                match state.actor.full_snapshot() {
+                match hosted.actor.full_snapshot() {
                     Ok(snapshot) => Some(ScreenStableState::new(ScreenStableFingerprint::from_snapshot(snapshot), registered_at)),
                     Err(err) => {
                         http_uds::write_error(stream, StatusCode::CONFLICT, &format!("screen stability not supported: {err}"))
@@ -1165,7 +1289,7 @@ fn handle_http_request(
             if has_text_match {
                 for condition in &conditions {
                     if let crate::protocol::WaitCondition::TextMatch { text } = condition {
-                        if state.actor.screen_contains(text.clone())? {
+                        if hosted.actor.screen_contains(text.clone())? {
                             http_uds::write_json(stream, StatusCode::OK, &http_uds::WaitResultResponse {
                                 status: http_uds::WaitStatusResponse::Ready,
                                 elapsed_ms: 0,
@@ -1183,7 +1307,7 @@ fn handle_http_request(
                     .map_err(|err| format!("write HTTP wait error: {err}"))?;
                 break 'wait Ok(());
             }
-            state.pending_waits.push(PendingWait {
+            hosted.pending_waits.push(PendingWait {
                 stream: pending_stream,
                 conditions,
                 screen_stable,
@@ -1196,6 +1320,10 @@ fn handle_http_request(
             http_uds::write_error(stream, StatusCode::NOT_FOUND, "not found").map_err(|err| format!("write HTTP not found response: {err}"))
         }
     }
+}
+
+fn write_http_not_found(stream: &mut SessionStream) -> Result<(), String> {
+    http_uds::write_error(stream, StatusCode::NOT_FOUND, "not found").map_err(|err| format!("write HTTP not found response: {err}"))
 }
 
 fn signal_target_from_http(target: http_uds::SignalTargetRequest) -> crate::protocol::SignalTarget {
@@ -1255,6 +1383,7 @@ struct PacketClient {
 }
 
 struct PacketSessionChannel {
+    session_id: String,
     in_flight_generation: Option<u64>,
     last_sent_generation: u64,
 }
@@ -1337,12 +1466,7 @@ impl PacketClient {
     }
 }
 
-fn service_packet_clients(
-    actor: &SessionActor,
-    daemon_id: &str,
-    packet_clients: &mut Vec<PacketClient>,
-    render_cache: &mut PacketRenderCache,
-) -> Result<bool, String> {
+fn service_packet_clients(sessions: &mut HashMap<String, HostedSession>, packet_clients: &mut Vec<PacketClient>) -> Result<bool, String> {
     let mut did_work = false;
     let mut index = 0;
     while index < packet_clients.len() {
@@ -1358,24 +1482,18 @@ fn service_packet_clients(
 
         while let Some(frame) = pending.pop_front() {
             did_work = true;
-            handle_packet_frame(actor, daemon_id, &mut packet_clients[index], frame, render_cache)?;
+            handle_packet_frame(sessions, &mut packet_clients[index], frame)?;
         }
         index += 1;
     }
     Ok(did_work)
 }
 
-fn handle_packet_frame(
-    actor: &SessionActor,
-    daemon_id: &str,
-    client: &mut PacketClient,
-    frame: PacketFrame,
-    render_cache: &mut PacketRenderCache,
-) -> Result<(), String> {
+fn handle_packet_frame(sessions: &mut HashMap<String, HostedSession>, client: &mut PacketClient, frame: PacketFrame) -> Result<(), String> {
     match (frame.channel, frame.msg_type) {
         (CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL) => {
             let open = frame.decode::<OpenChannel>().map_err(|err| format!("decode open-channel packet: {err}"))?;
-            open_packet_channel(actor, daemon_id, client, open, render_cache)?;
+            open_packet_channel(sessions, client, open)?;
         }
         (CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL) => {
             let close = frame.decode::<CloseChannel>().map_err(|err| format!("decode close-channel packet: {err}"))?;
@@ -1383,23 +1501,30 @@ fn handle_packet_frame(
         }
         (channel, MSG_SESSION_ACK) if channel != CHANNEL_CONTROL => {
             let ack = frame.decode::<Ack>().map_err(|err| format!("decode ack packet: {err}"))?;
+            let session_id = client.channels.get(&channel).map(|session| session.session_id.clone());
             if let Some(session_channel) = client.channels.get_mut(&channel) {
                 if session_channel.in_flight_generation == Some(ack.generation) {
                     session_channel.in_flight_generation = None;
-                    actor.mark_observed(ack.generation);
+                    if let Some(hosted) = session_id.and_then(|id| sessions.get(&id)) {
+                        hosted.actor.mark_observed(ack.generation);
+                    }
                 }
             }
         }
         (channel, MSG_SESSION_INPUT) if channel != CHANNEL_CONTROL => {
             let input = frame.decode::<Input>().map_err(|err| format!("decode input packet: {err}"))?;
-            if client.channels.contains_key(&channel) {
-                route_packet_input_event(actor, input.event)?;
+            if let Some(session_id) = client.channels.get(&channel).map(|session| session.session_id.clone()) {
+                if let Some(hosted) = sessions.get(&session_id) {
+                    route_packet_input_event(&hosted.actor, input.event)?;
+                }
             }
         }
         (channel, MSG_SESSION_RESIZE) if channel != CHANNEL_CONTROL => {
             let resize = frame.decode::<Resize>().map_err(|err| format!("decode resize packet: {err}"))?;
-            if client.channels.contains_key(&channel) {
-                actor.resize(resize.cols, resize.rows)?;
+            if let Some(session_id) = client.channels.get(&channel).map(|session| session.session_id.clone()) {
+                if let Some(hosted) = sessions.get(&session_id) {
+                    hosted.actor.resize(resize.cols, resize.rows)?;
+                }
             }
         }
         _ => {}
@@ -1407,13 +1532,7 @@ fn handle_packet_frame(
     Ok(())
 }
 
-fn open_packet_channel(
-    actor: &SessionActor,
-    daemon_id: &str,
-    client: &mut PacketClient,
-    open: OpenChannel,
-    render_cache: &mut PacketRenderCache,
-) -> Result<(), String> {
+fn open_packet_channel(sessions: &mut HashMap<String, HostedSession>, client: &mut PacketClient, open: OpenChannel) -> Result<(), String> {
     if open.channel == CHANNEL_CONTROL {
         client.enqueue_control(MSG_CONTROL_ERROR, &ControlError {
             channel: open.channel,
@@ -1421,36 +1540,42 @@ fn open_packet_channel(
         })?;
         return Ok(());
     }
-    if open.session_id != daemon_id {
+    let Some(hosted) = sessions.get_mut(&open.session_id) else {
         client.enqueue_control(MSG_CONTROL_ERROR, &ControlError {
             channel: open.channel,
             message: format!("unknown session {}", open.session_id),
         })?;
         return Ok(());
-    }
+    };
 
-    let update = actor.full_render_update()?;
+    let session_id = open.session_id;
+    let update = hosted.actor.full_render_update()?;
     let generation = update.render_generation;
-    render_cache.store(update.clone());
+    hosted.packet_render_cache.store(update.clone());
     client.enqueue_frame(
         &PacketFrame::new(open.channel, MSG_SESSION_RENDER, &RenderPacket { update })
             .map_err(|err| format!("encode initial render packet: {err}"))?,
     )?;
-    client.channels.insert(open.channel, PacketSessionChannel { in_flight_generation: Some(generation), last_sent_generation: generation });
+    client.channels.insert(open.channel, PacketSessionChannel {
+        session_id,
+        in_flight_generation: Some(generation),
+        last_sent_generation: generation,
+    });
     Ok(())
 }
 
 fn push_due_packet_renders(
+    session_id: &str,
     actor: &SessionActor,
     packet_clients: &mut Vec<PacketClient>,
     render_cache: &mut PacketRenderCache,
 ) -> Result<(), String> {
-    if !packet_clients.iter().any(|client| !client.channels.is_empty()) {
+    if !packet_clients.iter().any(|client| client.channels.values().any(|channel| channel.session_id == session_id)) {
         return Ok(());
     }
 
     if actor.observation().dirty() != DirtyState::Clean {
-        let update = if has_packet_channel_lagging_cached_generation(packet_clients, render_cache) {
+        let update = if has_packet_channel_lagging_cached_generation(session_id, packet_clients, render_cache) {
             actor.full_render_update()?
         } else {
             actor.render_update()?
@@ -1470,7 +1595,10 @@ fn push_due_packet_renders(
             .channels
             .iter()
             .filter_map(|(channel, session)| {
-                (session.in_flight_generation.is_none() && session.last_sent_generation < latest_generation).then_some(*channel)
+                (session.session_id == session_id
+                    && session.in_flight_generation.is_none()
+                    && session.last_sent_generation < latest_generation)
+                    .then_some(*channel)
             })
             .collect();
         for channel in due_channels {
@@ -1487,11 +1615,18 @@ fn push_due_packet_renders(
     Ok(())
 }
 
-fn has_packet_channel_lagging_cached_generation(packet_clients: &[PacketClient], render_cache: &PacketRenderCache) -> bool {
+fn has_packet_channel_lagging_cached_generation(
+    session_id: &str,
+    packet_clients: &[PacketClient],
+    render_cache: &PacketRenderCache,
+) -> bool {
     let Some(latest_generation) = render_cache.latest_generation() else {
         return false;
     };
-    packet_clients.iter().flat_map(|client| client.channels.values()).any(|session| session.last_sent_generation < latest_generation)
+    packet_clients
+        .iter()
+        .flat_map(|client| client.channels.values())
+        .any(|session| session.session_id == session_id && session.last_sent_generation < latest_generation)
 }
 
 fn route_packet_input_event(actor: &SessionActor, event: TerminalInputEvent) -> Result<(), String> {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -4,6 +4,7 @@ use std::{
     collections::{HashMap, VecDeque},
     fs,
     io::{self, Read, Write},
+    panic::{self, AssertUnwindSafe},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -605,6 +606,7 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
     let mut sessions = HashMap::new();
     let mut packet_clients: Vec<PacketClient> = Vec::new();
     let mut exited_session: Option<(String, bool)> = None;
+    let mut faulted_session: Option<String> = None;
     let mut idle_since = Some(Instant::now());
 
     loop {
@@ -667,19 +669,45 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
             let Some(hosted) = sessions.get_mut(&session_id) else {
                 continue;
             };
-            did_work |= service_hosted_session(&layout, &session_id, hosted, &mut packet_clients)?;
-            if hosted.actor.exit_code()?.is_some() {
-                let should_keep_session_dir = finish_exited_session(&layout, &session_id, hosted, &mut packet_clients)?;
-                exited_session = Some((session_id, should_keep_session_dir));
-                break;
+            let service_result = contain_session_unwind(&session_id, || -> Result<(bool, Option<bool>), String> {
+                maybe_panic_for_containment_test(&session_id);
+                let session_did_work = service_hosted_session(&layout, &session_id, hosted, &mut packet_clients)?;
+                let should_keep_session_dir = if hosted.actor.exit_code()?.is_some() {
+                    Some(finish_exited_session(&layout, &session_id, hosted, &mut packet_clients)?)
+                } else {
+                    None
+                };
+                Ok((session_did_work, should_keep_session_dir))
+            })?;
+            match service_result {
+                Some((session_did_work, Some(should_keep_session_dir))) => {
+                    did_work |= session_did_work;
+                    exited_session = Some((session_id, should_keep_session_dir));
+                    break;
+                }
+                Some((session_did_work, None)) => {
+                    did_work |= session_did_work;
+                }
+                None => {
+                    did_work = true;
+                    faulted_session = Some(session_id);
+                    break;
+                }
             }
         }
 
         flush_packet_clients(&mut packet_clients);
 
+        if let Some(session_id) = faulted_session.take() {
+            cleanup_exited_session(&layout, &session_id, true);
+            sessions.remove(&session_id);
+            remove_packet_channels_for_session(&session_id, &mut packet_clients);
+        }
+
         if let Some((session_id, should_keep_session_dir)) = exited_session.take() {
             cleanup_exited_session(&layout, &session_id, should_keep_session_dir);
             sessions.remove(&session_id);
+            remove_packet_channels_for_session(&session_id, &mut packet_clients);
         }
 
         if sessions.is_empty() {
@@ -699,6 +727,45 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
     let _ = fs::remove_file(&socket_path);
     let _ = fs::remove_file(layout.daemon_pid_path());
     Ok(())
+}
+
+fn contain_session_unwind<T, F>(id: &str, action: F) -> Result<Option<T>, String>
+where
+    F: FnOnce() -> Result<T, String>,
+{
+    match panic::catch_unwind(AssertUnwindSafe(action)) {
+        Ok(result) => result.map(Some),
+        Err(payload) => {
+            eprintln!("contained panic while servicing session {id}: {}", panic_payload_message(payload.as_ref()));
+            Ok(None)
+        }
+    }
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
+}
+
+fn remove_packet_channels_for_session(session_id: &str, packet_clients: &mut [PacketClient]) {
+    for client in packet_clients {
+        client.channels.retain(|_, channel| channel.session_id != session_id);
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn maybe_panic_for_containment_test(_session_id: &str) {}
+
+#[cfg(debug_assertions)]
+fn maybe_panic_for_containment_test(session_id: &str) {
+    if std::env::var("CLEAT_TEST_PANIC_SESSION_TICK").as_deref() == Ok(session_id) {
+        panic!("test-requested panic for session {session_id}");
+    }
 }
 
 fn cleanup_exited_session(layout: &RuntimeLayout, id: &str, should_keep_session_dir: bool) {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -44,6 +44,7 @@ const DETACH_CLEANUP_SEQUENCE: &[u8] =
 const REATTACH_CLEAR_SEQUENCE: &[u8] = b"\x1b[2J\x1b[H";
 const MAX_PENDING_CLIENT_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 const SESSION_DAEMON_SERVICING_TICK: Duration = Duration::from_millis(10);
+const SESSION_DAEMON_IDLE_LINGER: Duration = Duration::from_secs(120);
 const SESSION_HTTP_HANDSHAKE_DEADLINE: Duration = Duration::from_millis(250);
 const SESSION_HTTP_RESPONSE_WRITE_DEADLINE: Duration = Duration::from_millis(250);
 const TERMINATE_SIGNAL: i32 = 15;
@@ -604,6 +605,7 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
     let mut sessions = HashMap::new();
     let mut packet_clients: Vec<PacketClient> = Vec::new();
     let mut exited_session: Option<(String, bool)> = None;
+    let mut idle_since = Some(Instant::now());
 
     loop {
         let mut did_work = false;
@@ -650,6 +652,9 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
                     if let Err(err) = handle_http_request(root, daemon_name, &mut stream, request, &mut http_state) {
                         let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &err);
                     }
+                    if !sessions.is_empty() {
+                        idle_since = None;
+                    }
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
                 Err(err) => return Err(format!("accept client: {err}")),
@@ -675,9 +680,15 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
         if let Some((session_id, should_keep_session_dir)) = exited_session.take() {
             cleanup_exited_session(&layout, &session_id, should_keep_session_dir);
             sessions.remove(&session_id);
-            if sessions.is_empty() {
+        }
+
+        if sessions.is_empty() {
+            let idle_started = idle_since.get_or_insert_with(Instant::now);
+            if idle_started.elapsed() >= SESSION_DAEMON_IDLE_LINGER {
                 break;
             }
+        } else {
+            idle_since = None;
         }
 
         if !did_work {

--- a/crates/cleat/tests/capture_render.rs
+++ b/crates/cleat/tests/capture_render.rs
@@ -8,7 +8,8 @@ use cleat::{
 };
 
 fn setup_session_with_cast(root: &std::path::Path, id: &str, events: &[Event]) {
-    let session_dir = root.join(id);
+    let layout = RuntimeLayout::new(root.to_path_buf());
+    let session_dir = layout.session_dir(id);
     std::fs::create_dir_all(&session_dir).unwrap();
     let path = session_dir.join(CAST_FILE_NAME);
     let mut f = std::fs::File::create(&path).unwrap();
@@ -63,7 +64,8 @@ fn capture_slice_text_returns_empty_at_eof() {
     let events = vec![Event { time: Duration::from_millis(100), code: EventCode::Output, data: "done".into() }];
     setup_session_with_cast(temp.path(), "sess", &events);
 
-    let file_size = std::fs::metadata(temp.path().join("sess").join(CAST_FILE_NAME)).unwrap().len();
+    let layout = RuntimeLayout::new(temp.path().to_path_buf());
+    let file_size = std::fs::metadata(layout.session_dir("sess").join(CAST_FILE_NAME)).unwrap().len();
     let (result, _outcome) = service.capture_slice_text("sess", StartBound::Offset(file_size), EndBound::EndOfRecording).unwrap();
     assert!(result.is_empty());
 }
@@ -74,7 +76,8 @@ fn capture_slice_errors_when_no_recording() {
     let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
 
     // Create session dir but no .cast file
-    std::fs::create_dir_all(temp.path().join("no-rec")).unwrap();
+    let layout = RuntimeLayout::new(temp.path().to_path_buf());
+    std::fs::create_dir_all(layout.session_dir("no-rec")).unwrap();
 
     let err = service.capture_slice_text("no-rec", StartBound::Offset(0), EndBound::EndOfRecording).unwrap_err();
     assert!(err.contains("no recording"), "error should mention missing recording: {err}");
@@ -95,7 +98,8 @@ fn capture_slice_text_returns_bytes_through_eof_with_start_at_zero() {
     assert_eq!(text, "hello world");
     assert_eq!(outcome.end_status, None);
     assert_eq!(outcome.start_offset, 0);
-    let file_size = std::fs::metadata(temp.path().join("sess").join(CAST_FILE_NAME)).unwrap().len();
+    let layout = RuntimeLayout::new(temp.path().to_path_buf());
+    let file_size = std::fs::metadata(layout.session_dir("sess").join(CAST_FILE_NAME)).unwrap().len();
     assert_eq!(outcome.end_offset, file_size);
 }
 

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -4,7 +4,7 @@ use cleat::{
     runtime::{RuntimeLayout, TerminalSize},
     server::SessionService,
     session::session_socket_path,
-    vt::{self, Rgb, VtEngineKind},
+    vt::{self, VtEngineKind},
 };
 
 #[test]
@@ -361,41 +361,10 @@ fn record_flags_explicit_record_enables() {
 }
 
 #[test]
-fn serve_parses_all_flags() {
-    let cli = Cli::try_parse_from([
-        "cleat",
-        "serve",
-        "--id",
-        "alpha",
-        "--vt",
-        "passthrough",
-        "--cmd",
-        "bash",
-        "--cwd",
-        "/tmp",
-        "--size",
-        "132x43",
-        "--record",
-        "--color-foreground",
-        "123456",
-        "--color-background",
-        "#abcdef",
-        "--color-cursor",
-        "fedcba",
-    ])
-    .expect("parse serve");
-    assert!(matches!(
-        cli.command,
-        Command::Serve {
-            ref id,
-            size: Some(TerminalSize { cols: 132, rows: 43 }),
-            record: true,
-            color_foreground: Some(Rgb { r: 0x12, g: 0x34, b: 0x56 }),
-            color_background: Some(Rgb { r: 0xab, g: 0xcd, b: 0xef }),
-            color_cursor: Some(Rgb { r: 0xfe, g: 0xdc, b: 0xba }),
-            ..
-        } if id == "alpha"
-    ));
+fn serve_parses_as_daemon_scoped_command() {
+    let cli = Cli::try_parse_from(["cleat", "--server", "alternate", "serve"]).expect("parse serve");
+    assert_eq!(cli.server, "alternate");
+    assert!(matches!(cli.command, Command::Serve));
 }
 
 #[test]
@@ -408,6 +377,7 @@ fn mark_command_parses_session_id() {
 fn send_keys_execute_reports_missing_session() {
     let cli = Cli {
         runtime_root: None,
+        server: cleat::runtime::DEFAULT_DAEMON_NAME.to_string(),
         command: Command::SendKeys {
             id: "demo".into(),
             literal: false,
@@ -610,7 +580,7 @@ fn send_command_rejects_submit_with_no_enter() {
 fn send_submit_posts_paste_then_enter_input_requests() {
     let temp = tempfile::tempdir().expect("tempdir");
     let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-    std::fs::create_dir_all(temp.path().join("alpha")).expect("create session dir");
+    std::fs::create_dir_all(service.session_dir("alpha")).expect("create session dir");
 
     let socket_path = session_socket_path(temp.path(), "alpha");
     let listener = std::os::unix::net::UnixListener::bind(&socket_path).expect("bind socket");
@@ -642,7 +612,7 @@ fn send_submit_posts_paste_then_enter_input_requests() {
 fn send_submit_with_mark_marks_before_paste_and_returns_offset() {
     let temp = tempfile::tempdir().expect("tempdir");
     let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
-    std::fs::create_dir_all(temp.path().join("alpha")).expect("create session dir");
+    std::fs::create_dir_all(service.session_dir("alpha")).expect("create session dir");
 
     let socket_path = session_socket_path(temp.path(), "alpha");
     let listener = std::os::unix::net::UnixListener::bind(&socket_path).expect("bind socket");

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -642,6 +642,7 @@ fn packet_connect_emits_hello_and_directory_snapshot() {
     let temp = tempfile::tempdir().expect("tempdir");
     let service = service_for(temp.path());
     service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create alpha");
+    service.create(Some("beta".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create beta");
 
     let mut stream = http_packet_stream(temp.path(), "alpha");
     stream.set_read_timeout(Some(Duration::from_secs(2))).expect("set read timeout");
@@ -654,11 +655,32 @@ fn packet_connect_emits_hello_and_directory_snapshot() {
     assert_eq!(hello_frame.decode::<ControlHello>().expect("decode hello").version, PROTOCOL_VERSION);
     assert_eq!(directory_frame.channel, CHANNEL_CONTROL);
     assert_eq!(directory_frame.msg_type, MSG_CONTROL_DIRECTORY_SNAPSHOT);
-    assert_eq!(directory_frame.decode::<DirectorySnapshot>().expect("decode directory").sessions, vec![cleat::packet::DirectoryEntry {
-        session_id: "alpha".to_string(),
-        cols: 80,
-        rows: 24
-    }]);
+    assert_eq!(directory_frame.decode::<DirectorySnapshot>().expect("decode directory").sessions, vec![
+        cleat::packet::DirectoryEntry { session_id: "alpha".to_string(), cols: 80, rows: 24 },
+        cleat::packet::DirectoryEntry { session_id: "beta".to_string(), cols: 80, rows: 24 },
+    ]);
+}
+
+#[test]
+fn contained_session_panic_does_not_stop_sibling_session() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _panic = EnvVarGuard::set("CLEAT_TEST_PANIC_SESSION_TICK", "alpha");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create alpha");
+    service.create(Some("beta".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create beta");
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while service.inspect("alpha").is_ok() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    assert!(service.inspect("alpha").is_err(), "faulted session should be removed");
+    assert_eq!(service.inspect("beta").expect("sibling session should remain hosted").session.id, "beta");
+    let listed = service.list().expect("list after contained panic");
+    assert_eq!(listed.iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), vec!["beta"]);
+    service.kill("beta").expect("kill sibling session");
 }
 
 #[cfg(feature = "ghostty-vt")]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -261,7 +261,7 @@ fn create_makes_session_directory_and_returns_metadata() {
 
     let output = cli::execute(cli, &service).expect("execute create").expect("create output");
     assert_eq!(output, "alpha");
-    assert!(temp.path().join("alpha").exists());
+    assert!(service.session_dir("alpha").exists());
 }
 
 #[cfg(feature = "ghostty-vt")]
@@ -607,7 +607,9 @@ fn create_respawns_over_a_stale_crashed_daemon() {
     // Hand-build the husk a crashed recording daemon leaves behind: a session dir
     // with a real recording, a leftover socket file with no listener, and a PID
     // file pointing at a process that is not a live cleat.
-    let dir = root.join(id);
+    let layout = RuntimeLayout::new(root.to_path_buf());
+    layout.ensure_daemon_dirs().expect("create daemon dirs");
+    let dir = layout.session_dir(id);
     std::fs::create_dir_all(&dir).expect("create session dir");
     let mut recorder = SessionRecorder::new(&dir, 80, 24, "passthrough").expect("recorder");
     recorder.output(b"prior activation output\r\n", Duration::from_millis(1));
@@ -899,7 +901,7 @@ fn kill_removes_session_directory() {
     let output = cli::execute(cli, &service).expect("execute kill");
 
     assert_eq!(output, None);
-    assert!(!temp.path().join("alpha").exists());
+    assert!(!service.session_dir("alpha").exists());
 }
 
 #[test]
@@ -911,7 +913,7 @@ fn kill_preserves_session_directory_with_recording() {
         .create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sh -c 'printf preserved; sleep 30'".into()), true)
         .expect("create alpha");
 
-    let cast_path = temp.path().join("alpha").join(CAST_FILE_NAME);
+    let cast_path = service.session_dir("alpha").join(CAST_FILE_NAME);
     let deadline = Instant::now() + Duration::from_secs(2);
     while !cast_path.exists() && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(20));
@@ -921,7 +923,7 @@ fn kill_preserves_session_directory_with_recording() {
     let cli = Cli::try_parse_from(["cleat", "kill", "alpha"]).expect("parse kill");
     cli::execute(cli, &service).expect("execute kill");
 
-    assert!(temp.path().join("alpha").exists(), "recording-bearing session directory should be preserved");
+    assert!(service.session_dir("alpha").exists(), "recording-bearing session directory should be preserved");
     assert!(cast_path.exists(), "recording should survive kill");
     assert!(!session_socket_path(temp.path(), "alpha").exists(), "socket should not survive kill");
     assert!(!daemon_pid_path(temp.path(), "alpha").exists(), "pid file should not survive kill");
@@ -936,7 +938,7 @@ fn kill_purge_removes_session_directory_with_recording() {
         .create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sh -c 'printf purged; sleep 30'".into()), true)
         .expect("create alpha");
 
-    let cast_path = temp.path().join("alpha").join(CAST_FILE_NAME);
+    let cast_path = service.session_dir("alpha").join(CAST_FILE_NAME);
     let deadline = Instant::now() + Duration::from_secs(2);
     while !cast_path.exists() && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(20));
@@ -946,7 +948,7 @@ fn kill_purge_removes_session_directory_with_recording() {
     let cli = Cli::try_parse_from(["cleat", "kill", "alpha", "--purge"]).expect("parse kill --purge");
     cli::execute(cli, &service).expect("execute kill --purge");
 
-    assert!(!temp.path().join("alpha").exists(), "purge should delete the recording-bearing session directory");
+    assert!(!service.session_dir("alpha").exists(), "purge should delete the recording-bearing session directory");
 }
 
 #[test]
@@ -1054,7 +1056,7 @@ fn http_detach_records_only_real_foreground_transition() {
     assert!(second_detach.starts_with("HTTP/1.1 204 No Content\r\n"), "{second_detach}");
     drop(attach_stream);
 
-    let cast_path = temp.path().join("alpha").join(cleat::recording::CAST_FILE_NAME);
+    let cast_path = service.session_dir("alpha").join(cleat::recording::CAST_FILE_NAME);
     let events = cleat::cast_reader::read_all_events_since(&cast_path, 0).expect("read cast events");
     let attach_count = events.iter().filter(|event| matches!(event.code, cleat::asciicast::EventCode::Custom('a'))).count();
     let detach_count = events.iter().filter(|event| matches!(event.code, cleat::asciicast::EventCode::Custom('d'))).count();
@@ -1528,7 +1530,7 @@ fn cleat_detach_exits_foreground_client_and_keeps_session_alive() {
     }
 
     assert!(!foreground_path(temp.path(), "alpha").exists(), "detach should clear the foreground marker");
-    assert!(temp.path().join("alpha").exists(), "detach should leave the session directory intact");
+    assert!(service.session_dir("alpha").exists(), "detach should leave the session directory intact");
 }
 
 #[cfg(feature = "ghostty-vt")]
@@ -1581,7 +1583,7 @@ fn cleat_attach_exits_on_sigterm_and_keeps_session_alive() {
     }
 
     assert!(!foreground_path(temp.path(), "alpha").exists(), "signal exit should clear the foreground marker");
-    assert!(temp.path().join("alpha").exists(), "signal exit should leave the session directory intact");
+    assert!(service.session_dir("alpha").exists(), "signal exit should leave the session directory intact");
 }
 
 #[test]
@@ -1692,7 +1694,7 @@ fn short_lived_session_reaps_its_directory_after_child_exit() {
     let service = service_for(temp.path());
     service.create(Some("alpha".into()), None, None, Some("printf done; sleep 0.1".into()), false).expect("create alpha");
 
-    let session_dir = temp.path().join("alpha");
+    let session_dir = service.session_dir("alpha");
     let deadline = Instant::now() + Duration::from_secs(2);
     while session_dir.exists() && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(20));
@@ -1949,7 +1951,7 @@ fn replay_with_session_and_markers_while_daemon_alive() {
     // Resolve range via the live daemon (socket-backed marker lookup), then
     // play into a buffer so we can assert the actual bytes rather than just
     // ExecResult::Ok.
-    let cast_path = service.layout_root().join("alpha").join(cleat::recording::CAST_FILE_NAME);
+    let cast_path = service.session_dir("alpha").join(cleat::recording::CAST_FILE_NAME);
     let (so, eo, _status) = service
         .resolve_slice_range(
             "alpha",

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -925,8 +925,8 @@ fn kill_preserves_session_directory_with_recording() {
 
     assert!(service.session_dir("alpha").exists(), "recording-bearing session directory should be preserved");
     assert!(cast_path.exists(), "recording should survive kill");
-    assert!(!session_socket_path(temp.path(), "alpha").exists(), "socket should not survive kill");
-    assert!(!daemon_pid_path(temp.path(), "alpha").exists(), "pid file should not survive kill");
+    assert!(session_socket_path(temp.path(), "alpha").exists(), "daemon socket should linger after session-scoped kill");
+    assert!(daemon_pid_path(temp.path(), "alpha").exists(), "daemon pid should linger after session-scoped kill");
 }
 
 #[test]
@@ -1679,12 +1679,13 @@ fn signal_term_to_leader_terminates_session() {
 
     let deadline = Instant::now() + Duration::from_secs(2);
     while Instant::now() < deadline {
-        if !socket_path.exists() {
+        if service.inspect(&info.id).is_err() {
             break;
         }
         std::thread::sleep(Duration::from_millis(50));
     }
-    assert!(!socket_path.exists(), "socket should be gone after SIGTERM to leader");
+    assert!(service.inspect(&info.id).is_err(), "session should be gone after SIGTERM to leader");
+    assert!(socket_path.exists(), "daemon socket should linger after session exit");
 }
 
 #[test]
@@ -1701,6 +1702,12 @@ fn short_lived_session_reaps_its_directory_after_child_exit() {
     }
 
     assert!(!session_dir.exists(), "session directory should be reaped after child exit");
+
+    let beta = service
+        .create(Some("beta".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+        .expect("create second session via lingering daemon");
+    assert_eq!(beta.id, "beta");
+    service.kill("beta").expect("kill second session");
 }
 
 #[test]

--- a/crates/cleat/tests/runtime.rs
+++ b/crates/cleat/tests/runtime.rs
@@ -13,7 +13,7 @@ fn named_sessions_use_supplied_name_as_id() {
 
     assert_eq!(session.id, "demo");
     assert_eq!(session.vt_engine, VtEngineKind::Passthrough);
-    assert!(temp.path().join("runtime").join("demo").exists());
+    assert!(layout.session_dir("demo").exists());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #100. Phase 3a of the daemon-mode/M:N arc — ADR 0004 becomes runtime behavior.

Implemented by a cleat-hosted codex from the locked scoping plan on the issue (four commits, each independently green on all four gates).

## Commits

1. `Generalize daemon session state` — `HashMap<SessionId, SessionActor>`, routes resolve by lookup instead of `id == daemon_id` guards, per-session foreground/watcher state. Pure refactor, no UX change.
2. `Add daemon identity and IPC session creation` — layout v2 (`root/<daemon>/{socket,daemon.pid,sessions/<id>/}`), named `serve --server`, `POST /sessions`, `launch` = ensure-daemon + create over IPC, bind-is-the-lock auto-start, global `--server` CLI selector.
3. `Keep empty daemons alive briefly` — 120 s linger (override `CLEAT_DAEMON_LINGER`, humantime), cancelled by creation; empty start supported.
4. `Contain panics to individual sessions` — `catch_unwind` at the actor boundary; a panicking session ends (recorded where possible) without taking the daemon or siblings.

## Live acceptance (run against this branch before this PR)

- `launch a` + `launch b` → **one daemon process**, both in `list`
- Concurrent `packets b` subscription while driving `a` via `send`/`capture`
- Kill both → daemon **lingers** (pid alive); `launch c` during linger **reuses** the same daemon (pid-identical)

## Breaking change (flag day, per scoping)

Runtime layout v2: session dirs live under their daemon dir. Old-layout session dirs are ignored (recordings remain on disk but are not auto-recreated). Pre-1.0, dogfood-approved.

## Deferred to #101

Directory subscription deltas, tags, `(daemon, id)` addressing polish, liveness rerouting off the filesystem, README rewrite.