### PR TITLE
toolchain: pin ghostty SIMD explicitly (-Dsimd=true)

### DIFF
--- a/tools/ghostty-toolchain.toml
+++ b/tools/ghostty-toolchain.toml
@@ -15,4 +15,4 @@ version = "0.15.2"
 [ghostty]
 repo = "https://github.com/rjwittams/ghostty.git"
 ref = "64daa599c531e6938bc4c52d9198a91f1e6ce8cf"
-build_step = "-Demit-lib-vt=true"
+build_step = "-Demit-lib-vt=true -Dsimd=true"


### PR DESCRIPTION
From the ghostty maintenance agent, shepherded in.

**Honest framing: this is currently a no-op.** Ghostty's build default is already `simd: bool = true` (`src/build/Config.zig:34`, all non-wasm targets), and a forced rebuild with the flag produces a byte-identical `libghostty-vt.a`. The value is making the setting **explicit in the pinned-toolchain file**:

- Guards against upstream flipping the default under a future pin bump.
- Records provenance: the maintenance agent validated SIMD on **Windows** against the current pin — enabled by the simdutf MSVC static-init fix now in-tree (#107's pin). Before that fix, simd-on-Windows was the risky configuration; this commit documents that it is now the supported one.

Gates run on this branch (macOS): fresh prepare, feature-on build, all 15 ghostty-vt suites, workspace tests, clippy — green. CI adds the Linux run; Windows remains local-validation-only (no Windows CI job yet).