### PR TITLE
[codex] Directory deltas, opaque tags, daemon-scoped liveness, README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ find .tools/ghostty-install -maxdepth 3 | sort
 
 ## Session Model
 
-**One daemon per session.** Each `cleat launch` (or `cleat attach` to a new ID) spawns a dedicated daemon process that owns the session's PTY. The daemon exits when the child process exits.
+**Named daemons host sets of sessions.** A daemon is the process boundary for one named session set. The default daemon is named `default`; pass `--server NAME` to address a different daemon. A session address is therefore `(daemon, id)`, with an unqualified ID meaning "this ID in the selected daemon."
 
-**Session IDs.** You choose the ID (`cleat launch my-session`) or let cleat generate one (`session-<uuid>`). IDs are directory names under the runtime root, so use filesystem-safe characters. Launching with an ID that already has a running daemon reuses the existing session — no error, no duplicate.
+**Session IDs.** You choose the ID (`cleat launch my-session`) or let cleat generate one (`session-<uuid>`). IDs are directory names under their daemon's `sessions/` directory, so use filesystem-safe characters. Launching with an ID that already has a live session in the selected daemon reuses that session; it does not create a duplicate.
+
+**Tags.** Sessions may carry flat, opaque tags. Add them at launch with repeated `--tag TAG`, mutate them with `cleat tag <id> +TAG -TAG`, and filter directory reads with repeated `--selector TAG`. Selectors are exact whole-tag matches and are ANDed when repeated. `key=value` is only a client convention; cleat does not interpret tag keys, values, hierarchy, or globs.
 
 **Runtime directory.** Discovered in priority order:
 
@@ -72,38 +74,56 @@ find .tools/ghostty-install -maxdepth 3 | sort
 3. `$TMPDIR/cleat-<uid>`
 4. `/tmp/cleat-<uid>`
 
-Each session gets a subdirectory containing:
-- `socket` — Unix domain socket for client-daemon communication
-- `daemon.pid` — daemon process ID
-- `session.cast` — asciicast v3 recording (only if recording is enabled)
+Runtime layout v2 is daemon-scoped:
 
-**Liveness.** The socket file is the liveness indicator. If it exists, the daemon is running and accepting connections.
+```text
+<runtime-root>/
+  <daemon-name>/
+    socket
+    daemon.pid
+    sessions/
+      <session-id>/
+        session.cast
+        foreground
+```
 
-**Cleanup.** When the child process exits, the daemon removes the socket and PID file, then exits. If recording was active, the session directory and `.cast` file are preserved. Otherwise the entire session directory is removed.
+`socket` and `daemon.pid` belong to the daemon, not to an individual session. Session directories live under `sessions/`. `session.cast` is the asciicast v3 recording when recording is active. `foreground` is a transient attachment marker.
 
-**No persistence across restarts.** Sessions do not survive daemon crashes or host reboots — the PTY and process state are gone. Recording files survive if they were flushed to disk.
+**Liveness and discovery.** Session liveness is daemon state, not a per-session socket stat. `cleat list` queries the selected daemon. `cleat list --all` enumerates every daemon directory under the runtime root and queries or sweeps each daemon independently. If a daemon is definitively stale, cleat performs a daemon-scoped sweep: sessions with a non-empty recording are preserved as recreatable, and sessions without a recording are removed.
+
+**Linger and cleanup.** A daemon starts on first use of its name. When it has no live sessions, it lingers for 120 seconds before exiting so a burst of commands does not repeatedly bounce the daemon. When a child process exits, its session is removed unless it has a recording that makes it recreatable.
+
+**Recording and recreation.** CLI-created sessions record by default. Use `--no-record` to opt out, and `cleat record <id>` to enable recording on a running session. Recording is the persistence floor: a daemon crash or host reboot loses the PTY and process state, but a preserved recording can seed scrollback when the session is recreated.
 
 ## Behavioral Model
 
-Three layers cooperate during a session. Knowing which layer is authoritative for which behavior is the main thing to internalize before debugging with cleat — it's the most common source of confusion.
+Four surfaces cooperate during a session. Knowing which surface is authoritative for which behavior is the main thing to internalize before debugging with cleat.
 
-### Layers
+### Surfaces
 
 - **Host terminal** — your real terminal emulator (kitty, ghostty, iTerm, Terminal.app, etc). In play *only while a client is attached*. Renders output to you, supplies keyboard input, and answers the child's capability queries (DA, DSR, kitty/sixel protocol queries) with whatever the host terminal actually supports.
 - **VT engine** — cleat's internal terminal emulator (libghostty with `--features ghostty-vt`; the `passthrough` engine is a placeholder for testing). Always active. Parses child PTY output into a structured screen grid, tracks modes/cursor/styles, and — when *detached* — synthesizes replies to capability queries so the child's detection logic doesn't stall.
-- **Recording** — optional raw PTY output tee, stored as asciicast v3 in `session.cast`. Authoritative source for `transcript` and `expect`. Enabled per-session with `--record` or globally via `CLEAT_RECORD=1`.
+- **Recording** — default-on raw PTY output tee, stored as asciicast v3 in `session.cast`. Authoritative source for `transcript` and `expect`.
+- **Packet surface** — structured multiplexed control/render/directory protocol. `cleat packets` exposes the raw probe surface, and `cleat list --watch` uses the directory subscription to print a snapshot followed by lifecycle deltas.
 
-### Command → layer map
+### Command Map
 
 | Command | Exercises | Notes |
 |---|---|---|
-| `launch` | daemon + VT engine | Creates session, spawns daemon, initializes VT engine |
+| `--server NAME` | daemon selection | Selects the named daemon for the command; default is `default` |
+| `launch [--tag TAG]... [--record|--no-record]` | daemon + VT engine + recording | Creates or reuses a session in the selected daemon |
+| `tag <id> +TAG -TAG` | daemon directory state | Mutates opaque tags; tags are not interpreted by cleat |
 | `attach` / `detach` | host terminal + daemon | While attached, host terminal is authoritative for query replies |
-| `list`, `inspect`, `kill`, `signal` | daemon state | No VT / recording involvement |
+| `watch` | host terminal + daemon | Read-only live view; does not take foreground control |
+| `list [--selector TAG]...` | daemon directory state | One-shot read of the selected daemon's directory |
+| `list --all` | daemon directory state | Enumerates every daemon directory under the runtime root |
+| `list --watch [--selector TAG]...` | packet directory subscription | Prints a snapshot, then one line per directory delta |
+| `packets` | packet protocol | Opens the structured multiplexed probe surface |
+| `inspect`, `kill`, `signal` | daemon state | No VT / recording involvement |
 | `capture` | VT engine | Renders the current screen grid to text; errors on the `passthrough` engine |
 | `transcript`, `expect` | recording | Reads raw bytes from asciicast; no re-rendering |
-| `send`, `send-keys`, `interrupt`, `escape` | daemon → PTY | Writes to child stdin via the PTY master |
-| `record`, `mark` | recording | Mutates recording state |
+| `send`, `send --submit`, `send-keys`, `interrupt`, `escape` | daemon → PTY | Writes to child stdin via the PTY master; `--submit` sends paste/text then Enter |
+| `record`, `mark` | recording | Enables recording or writes a marker |
 | `wait --idle-time` | daemon | PTY-output idle timer |
 | `wait --text` | VT engine | Consults the rendered screen grid |
 | `wait --screen-stable` | VT engine | Waits for the rendered screen grid to stop changing |

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -143,6 +143,8 @@ pub enum Command {
         cwd: Option<PathBuf>,
         #[arg(long, help = "Command to run (default: user's shell)")]
         cmd: Option<String>,
+        #[arg(long = "tag", value_name = "TAG", allow_hyphen_values = true, help = "Attach an opaque tag to the session; repeatable")]
+        tags: Vec<String>,
         #[command(flatten)]
         record: RecordFlags,
     },
@@ -150,6 +152,13 @@ pub enum Command {
     List {
         #[arg(long, help = "Output as JSON")]
         json: bool,
+    },
+    /// Add or remove opaque session tags
+    Tag {
+        #[arg(value_name = "ID")]
+        id: String,
+        #[arg(value_name = "+TAG|-TAG", required = true, num_args = 1.., allow_hyphen_values = true)]
+        mutations: Vec<String>,
     },
     /// Capture terminal screen content
     #[command(after_long_help = "Returns the current rendered screen from the VT engine.\n\
@@ -500,14 +509,23 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Ok(lines) => ExecResult::Ok(Some(lines.join("\n"))),
             Err(err) => ExecResult::Err(err),
         },
-        Command::Launch { id, json, size, vt, cwd, cmd, record } => {
+        Command::Launch { id, json, size, vt, cwd, cmd, tags, record } => {
             // Windows can provide basic sessions through ConPTY plus the
             // passthrough engine while Ghostty VT support is still optional.
             #[cfg(not(windows))]
             if !crate::vt::functional_vt_available() {
                 return ExecResult::Err(crate::vt::nonfunctional_build_error());
             }
-            let created = match service.create_with_size(id, vt, cwd, cmd, record.enabled(), size.unwrap_or_default()) {
+            let tags = match normalize_cli_tags(tags) {
+                Ok(tags) => tags,
+                Err(err) => return ExecResult::Err(err),
+            };
+            let created = match service.create_with_options(id, vt, cwd, cmd, crate::session::SessionStartOptions {
+                record: record.enabled(),
+                initial_size: size.unwrap_or_default(),
+                colors: crate::vt::TerminalColors::default(),
+                tags,
+            }) {
                 Ok(v) => v,
                 Err(e) => return ExecResult::Err(e),
             };
@@ -534,6 +552,17 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 ExecResult::Ok(None)
             } else {
                 ExecResult::Ok(Some(sessions.iter().map(format_session_human).collect::<Vec<_>>().join("\n")))
+            }
+        }
+        Command::Tag { id, mutations } => {
+            let (add, remove) = match parse_tag_mutations(mutations) {
+                Ok(value) => value,
+                Err(err) => return ExecResult::Err(err),
+            };
+            match service.update_tags(&id, add, remove) {
+                Ok(tags) if tags.is_empty() => ExecResult::Ok(None),
+                Ok(tags) => ExecResult::Ok(Some(tags.join(" "))),
+                Err(e) => ExecResult::Err(e),
             }
         }
         Command::Capture { id } => match service.capture(&id) {
@@ -905,6 +934,9 @@ fn format_session_human(session: &crate::protocol::SessionInfo) -> String {
     } else if let Some(cmd) = &session.cmd {
         fields.push(cmd.clone());
     }
+    if !session.tags.is_empty() {
+        fields.push(format!("tags={}", session.tags.join(",")));
+    }
     fields.join("\t")
 }
 
@@ -913,6 +945,35 @@ fn format_session_status(status: &crate::protocol::SessionStatus) -> &'static st
         crate::protocol::SessionStatus::Attached => "attached",
         crate::protocol::SessionStatus::Detached => "detached",
     }
+}
+
+fn normalize_cli_tags(mut tags: Vec<String>) -> Result<Vec<String>, String> {
+    if let Some(tag) = tags.iter().find(|tag| tag.is_empty()) {
+        return Err(format!("tag must not be empty: {tag:?}"));
+    }
+    crate::runtime::normalize_tags(&mut tags);
+    Ok(tags)
+}
+
+fn parse_tag_mutations(mutations: Vec<String>) -> Result<(Vec<String>, Vec<String>), String> {
+    let mut add = Vec::new();
+    let mut remove = Vec::new();
+    for mutation in mutations {
+        let (target, tag) = if let Some(tag) = mutation.strip_prefix('+') {
+            (&mut add, tag)
+        } else if let Some(tag) = mutation.strip_prefix('-') {
+            (&mut remove, tag)
+        } else {
+            return Err(format!("tag mutation must start with + or -: {mutation}"));
+        };
+        if tag.is_empty() {
+            return Err("tag mutation must include a tag after + or -".to_string());
+        }
+        target.push(tag.to_string());
+    }
+    crate::runtime::normalize_tags(&mut add);
+    crate::runtime::normalize_tags(&mut remove);
+    Ok((add, remove))
 }
 
 fn run_packets_command(service: &SessionService, id: &str, count: usize) -> Result<Vec<String>, String> {
@@ -1001,6 +1062,9 @@ fn format_inspect_human(result: &crate::protocol::InspectResult) -> String {
     table.add_row(vec!["state", &result.session.state]);
     table.add_row(vec!["vt_engine", &format!("{} ({})", result.session.vt_engine, result.session.vt_engine_status)]);
     table.add_row(vec!["functional_vt", if result.session.functional_vt_available { "yes" } else { "no" }]);
+    if !result.session.tags.is_empty() {
+        table.add_row(vec!["tags", &result.session.tags.join(", ")]);
+    }
     table.add_row(vec!["terminal", &format!("{}x{}", result.terminal.cols, result.terminal.rows)]);
     table.add_row(vec!["leader_pid", &result.process.leader_pid.to_string()]);
     if let Some(fg) = result.process.foreground_pgid {

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -975,17 +975,27 @@ fn parse_tag_mutations(mutations: Vec<String>) -> Result<(Vec<String>, Vec<Strin
     let mut add = Vec::new();
     let mut remove = Vec::new();
     for mutation in mutations {
-        let (target, tag) = if let Some(tag) = mutation.strip_prefix('+') {
-            (&mut add, tag)
+        let (is_add, tag) = if let Some(tag) = mutation.strip_prefix('+') {
+            (true, tag)
         } else if let Some(tag) = mutation.strip_prefix('-') {
-            (&mut remove, tag)
+            (false, tag)
         } else {
             return Err(format!("tag mutation must start with + or -: {mutation}"));
         };
         if tag.is_empty() {
             return Err("tag mutation must include a tag after + or -".to_string());
         }
-        target.push(tag.to_string());
+        if is_add {
+            remove.retain(|existing| existing != tag);
+            if !add.iter().any(|existing| existing == tag) {
+                add.push(tag.to_string());
+            }
+        } else {
+            add.retain(|existing| existing != tag);
+            if !remove.iter().any(|existing| existing == tag) {
+                remove.push(tag.to_string());
+            }
+        }
     }
     crate::runtime::normalize_tags(&mut add);
     crate::runtime::normalize_tags(&mut remove);
@@ -1006,7 +1016,7 @@ fn run_list_watch_command(service: &SessionService, selectors: &[String], json: 
         )
         .map_err(|err| format!("write directory snapshot: {err}"))?;
     } else {
-        writeln!(stdout, "snapshot\t{}", format_directory_snapshot(&snapshot)).map_err(|err| format!("write directory snapshot: {err}"))?;
+        writeln!(stdout, "{}", format_directory_snapshot(&snapshot)).map_err(|err| format!("write directory snapshot: {err}"))?;
     }
     stdout.flush().map_err(|err| format!("flush directory snapshot: {err}"))?;
 
@@ -1029,9 +1039,9 @@ fn run_list_watch_command(service: &SessionService, selectors: &[String], json: 
 
 fn format_directory_snapshot(snapshot: &crate::packet::DirectorySnapshot) -> String {
     if snapshot.sessions.is_empty() {
-        "empty".to_string()
+        "snapshot\tempty".to_string()
     } else {
-        snapshot.sessions.iter().map(format_directory_entry).collect::<Vec<_>>().join("\n")
+        snapshot.sessions.iter().map(|entry| format!("snapshot\t{}", format_directory_entry(entry))).collect::<Vec<_>>().join("\n")
     }
 }
 

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -152,6 +152,10 @@ pub enum Command {
     List {
         #[arg(long, help = "Output as JSON")]
         json: bool,
+        #[arg(long, help = "Watch directory updates after printing the initial snapshot")]
+        watch: bool,
+        #[arg(long = "selector", value_name = "TAG", allow_hyphen_values = true, help = "Require an exact opaque tag match; repeatable")]
+        selectors: Vec<String>,
     },
     /// Add or remove opaque session tags
     Tag {
@@ -538,8 +542,18 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 ExecResult::Ok(Some(created.id))
             }
         }
-        Command::List { json } => {
-            let sessions = match service.list() {
+        Command::List { json, watch, selectors } => {
+            let selectors = match normalize_cli_tags(selectors) {
+                Ok(selectors) => selectors,
+                Err(err) => return ExecResult::Err(err),
+            };
+            if watch {
+                return match run_list_watch_command(service, &selectors, json) {
+                    Ok(()) => ExecResult::Ok(None),
+                    Err(err) => ExecResult::Err(err),
+                };
+            }
+            let sessions = match service.list_with_selectors(&selectors) {
                 Ok(v) => v,
                 Err(e) => return ExecResult::Err(e),
             };
@@ -974,6 +988,75 @@ fn parse_tag_mutations(mutations: Vec<String>) -> Result<(Vec<String>, Vec<Strin
     crate::runtime::normalize_tags(&mut add);
     crate::runtime::normalize_tags(&mut remove);
     Ok((add, remove))
+}
+
+fn run_list_watch_command(service: &SessionService, selectors: &[String], json: bool) -> Result<(), String> {
+    use std::io::Write;
+
+    let (mut client, snapshot) = service.connect_directory(selectors)?;
+    let mut stdout = std::io::stdout().lock();
+    if json {
+        writeln!(
+            stdout,
+            "{}",
+            serde_json::to_string(&serde_json::json!({"kind": "snapshot", "sessions": snapshot.sessions}))
+                .map_err(|err| format!("serialize directory snapshot: {err}"))?
+        )
+        .map_err(|err| format!("write directory snapshot: {err}"))?;
+    } else {
+        writeln!(stdout, "snapshot\t{}", format_directory_snapshot(&snapshot)).map_err(|err| format!("write directory snapshot: {err}"))?;
+    }
+    stdout.flush().map_err(|err| format!("flush directory snapshot: {err}"))?;
+
+    loop {
+        let delta = client.read_directory_delta().map_err(|err| format!("read directory delta: {err}"))?;
+        if json {
+            writeln!(
+                stdout,
+                "{}",
+                serde_json::to_string(&serde_json::json!({"kind": "delta", "delta": delta}))
+                    .map_err(|err| format!("serialize directory delta: {err}"))?
+            )
+            .map_err(|err| format!("write directory delta: {err}"))?;
+        } else {
+            writeln!(stdout, "{}", format_directory_delta(&delta)).map_err(|err| format!("write directory delta: {err}"))?;
+        }
+        stdout.flush().map_err(|err| format!("flush directory delta: {err}"))?;
+    }
+}
+
+fn format_directory_snapshot(snapshot: &crate::packet::DirectorySnapshot) -> String {
+    if snapshot.sessions.is_empty() {
+        "empty".to_string()
+    } else {
+        snapshot.sessions.iter().map(format_directory_entry).collect::<Vec<_>>().join("\n")
+    }
+}
+
+fn format_directory_delta(delta: &crate::packet::DirectoryDelta) -> String {
+    let mut lines = Vec::new();
+    lines.extend(delta.upserted.iter().map(|entry| format!("upsert\t{}", format_directory_entry(entry))));
+    lines.extend(delta.removed_session_ids.iter().map(|id| format!("remove\t{id}")));
+    if lines.is_empty() {
+        "delta\tempty".to_string()
+    } else {
+        lines.join("\n")
+    }
+}
+
+fn format_directory_entry(entry: &crate::packet::DirectoryEntry) -> String {
+    let mut fields = vec![
+        entry.session_id.clone(),
+        entry.state.clone(),
+        format!("{}x{}", entry.cols, entry.rows),
+        format!("controllers={}", entry.controller_count),
+        format!("watchers={}", entry.watcher_count),
+        format!("recreatable={}", if entry.recreatable { "yes" } else { "no" }),
+    ];
+    if !entry.tags.is_empty() {
+        fields.push(format!("tags={}", entry.tags.join(",")));
+    }
+    fields.join("\t")
 }
 
 fn run_packets_command(service: &SessionService, id: &str, count: usize) -> Result<Vec<String>, String> {

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -154,6 +154,8 @@ pub enum Command {
         json: bool,
         #[arg(long, help = "Watch directory updates after printing the initial snapshot")]
         watch: bool,
+        #[arg(long, conflicts_with = "watch", help = "Enumerate sessions from every daemon directory under the runtime root")]
+        all: bool,
         #[arg(long = "selector", value_name = "TAG", allow_hyphen_values = true, help = "Require an exact opaque tag match; repeatable")]
         selectors: Vec<String>,
     },
@@ -542,7 +544,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 ExecResult::Ok(Some(created.id))
             }
         }
-        Command::List { json, watch, selectors } => {
+        Command::List { json, watch, all, selectors } => {
             let selectors = match normalize_cli_tags(selectors) {
                 Ok(selectors) => selectors,
                 Err(err) => return ExecResult::Err(err),
@@ -553,7 +555,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                     Err(err) => ExecResult::Err(err),
                 };
             }
-            let sessions = match service.list_with_selectors(&selectors) {
+            let sessions = match if all { service.list_all_with_selectors(&selectors) } else { service.list_with_selectors(&selectors) } {
                 Ok(v) => v,
                 Err(e) => return ExecResult::Err(e),
             };

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -278,6 +278,7 @@ pub(crate) enum SessionCommand {
     PasteWithMark { text: Vec<u8>, marker_name: String, reply: mpsc::Sender<Result<u64, String>> },
     SetRecording { enable: bool, reply: mpsc::Sender<Result<(), String>> },
     Mark { name: Option<String>, reply: mpsc::Sender<Result<u64, String>> },
+    UpdateTags { add: Vec<String>, remove: Vec<String>, reply: mpsc::Sender<Result<Vec<String>, String>> },
     ResolveMarker { name: String, reply: mpsc::Sender<Result<Option<u64>, String>> },
     ResolveNextMarker { after: u64, reply: mpsc::Sender<Result<Option<u64>, String>> },
     DispatchSignal { signal: i32, target: SignalTarget, reply: mpsc::Sender<Result<(), String>> },
@@ -712,6 +713,10 @@ impl SessionActor {
         self.request_result(|reply| SessionCommand::Mark { name, reply })
     }
 
+    pub(crate) fn update_tags(&self, add: Vec<String>, remove: Vec<String>) -> Result<Vec<String>, String> {
+        self.request_result(|reply| SessionCommand::UpdateTags { add, remove, reply })
+    }
+
     pub(crate) fn resolve_marker(&self, name: String) -> Result<Option<u64>, String> {
         self.request_result(|reply| SessionCommand::ResolveMarker { name, reply })
     }
@@ -1023,6 +1028,9 @@ fn session_actor_handle_command(
         }
         SessionCommand::Mark { name, reply } => {
             let _ = reply.send(runtime.mark(name));
+        }
+        SessionCommand::UpdateTags { add, remove, reply } => {
+            let _ = reply.send(Ok(runtime.update_tags(add, remove)));
         }
         SessionCommand::ResolveMarker { name, reply } => {
             let _ = reply.send(Ok(runtime.resolve_marker(&name)));

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -216,6 +216,12 @@ pub(crate) struct SessionListResponse {
     pub sessions: Vec<crate::protocol::InspectResult>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub(crate) struct DirectorySubscribeRequest {
+    #[serde(default)]
+    pub selectors: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct CreateSessionResponse {
     pub session: crate::runtime::SessionMetadata,

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -44,6 +44,7 @@ pub(crate) enum Route {
     SessionScreen { id: String },
     SessionSignal { id: String },
     SessionSnapshot { id: String },
+    SessionTags { id: String },
     SessionWait { id: String },
     NotFound,
 }
@@ -136,6 +137,17 @@ pub(crate) struct MarkRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct MarkResponse {
     pub offset: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct TagRequest {
+    pub add: Vec<String>,
+    pub remove: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct TagResponse {
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -501,6 +513,7 @@ pub(crate) fn route(request: &HttpRequest) -> Route {
                 (&Method::GET, Some("screen"), None) => Route::SessionScreen { id: id.to_string() },
                 (&Method::POST, Some("signal"), None) => Route::SessionSignal { id: id.to_string() },
                 (&Method::GET, Some("snapshot"), None) => Route::SessionSnapshot { id: id.to_string() },
+                (&Method::POST, Some("tags"), None) => Route::SessionTags { id: id.to_string() },
                 (&Method::POST, Some("wait"), None) => Route::SessionWait { id: id.to_string() },
                 _ => Route::NotFound,
             }
@@ -756,6 +769,7 @@ mod tests {
             ("GET", "/sessions/alpha/screen", Route::SessionScreen { id: "alpha".to_string() }),
             ("POST", "/sessions/alpha/signal", Route::SessionSignal { id: "alpha".to_string() }),
             ("GET", "/sessions/alpha/snapshot", Route::SessionSnapshot { id: "alpha".to_string() }),
+            ("POST", "/sessions/alpha/tags", Route::SessionTags { id: "alpha".to_string() }),
             ("POST", "/sessions/alpha/wait", Route::SessionWait { id: "alpha".to_string() }),
         ];
 

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -48,6 +48,8 @@ pub struct DirectoryDelta {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirectoryEntry {
     pub session_id: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
     pub cols: u16,
     pub rows: u16,
 }
@@ -239,7 +241,9 @@ mod tests {
     #[test]
     fn buffer_reader_skips_unknown_message_payload_by_length() {
         let unknown = PacketFrame { channel: CHANNEL_CONTROL, msg_type: 250, payload: vec![1, 2, 3, 4] };
-        let directory = DirectorySnapshot { sessions: vec![DirectoryEntry { session_id: "alpha".to_string(), cols: 80, rows: 24 }] };
+        let directory = DirectorySnapshot {
+            sessions: vec![DirectoryEntry { session_id: "alpha".to_string(), tags: vec!["role=impl".to_string()], cols: 80, rows: 24 }],
+        };
         let known = PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT, &directory).expect("encode directory");
         let mut bytes = Vec::new();
         unknown.write(&mut bytes).expect("write unknown");

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -50,6 +50,14 @@ pub struct DirectoryEntry {
     pub session_id: String,
     #[serde(default)]
     pub tags: Vec<String>,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub controller_count: u32,
+    #[serde(default)]
+    pub watcher_count: u32,
+    #[serde(default)]
+    pub recreatable: bool,
     pub cols: u16,
     pub rows: u16,
 }
@@ -215,6 +223,15 @@ impl<S: Read + Write> PacketClient<S> {
         }
     }
 
+    pub fn read_directory_delta(&mut self) -> std::io::Result<DirectoryDelta> {
+        loop {
+            let frame = self.read_frame()?;
+            if frame.channel == CHANNEL_CONTROL && frame.msg_type == MSG_CONTROL_DIRECTORY_DELTA {
+                return frame.decode();
+            }
+        }
+    }
+
     fn write<T: Serialize>(&mut self, channel: u32, msg_type: u8, value: &T) -> std::io::Result<()> {
         PacketFrame::new(channel, msg_type, value)?.write(&mut self.stream)
     }
@@ -242,7 +259,16 @@ mod tests {
     fn buffer_reader_skips_unknown_message_payload_by_length() {
         let unknown = PacketFrame { channel: CHANNEL_CONTROL, msg_type: 250, payload: vec![1, 2, 3, 4] };
         let directory = DirectorySnapshot {
-            sessions: vec![DirectoryEntry { session_id: "alpha".to_string(), tags: vec!["role=impl".to_string()], cols: 80, rows: 24 }],
+            sessions: vec![DirectoryEntry {
+                session_id: "alpha".to_string(),
+                tags: vec!["role=impl".to_string()],
+                state: "running".to_string(),
+                controller_count: 0,
+                watcher_count: 0,
+                recreatable: false,
+                cols: 80,
+                rows: 24,
+            }],
         };
         let known = PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT, &directory).expect("encode directory");
         let mut bytes = Vec::new();

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -426,6 +426,7 @@ mod tests {
             vt_engine: VtEngineKind::Passthrough,
             cwd: None,
             cmd: Some("echo ready".into()),
+            tags: Vec::new(),
             record: false,
             initial_size: TerminalSize::default(),
             colors: crate::vt::TerminalColors::default(),

--- a/crates/cleat/src/platform/unix.rs
+++ b/crates/cleat/src/platform/unix.rs
@@ -580,6 +580,7 @@ mod tests {
             vt_engine: VtEngineKind::Passthrough,
             cwd: None,
             cmd: Some("sleep 0.2; printf READY; sleep 0.2".to_string()),
+            tags: Vec::new(),
             record: false,
             initial_size: TerminalSize::default(),
             colors: TerminalColors::default(),

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -15,6 +15,8 @@ pub struct SessionInfo {
     pub functional_vt_available: bool,
     pub cwd: Option<PathBuf>,
     pub cmd: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
     pub status: SessionStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -46,6 +48,8 @@ pub struct SessionInspect {
     pub functional_vt_available: bool,
     pub cwd: Option<PathBuf>,
     pub cmd: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -1729,6 +1729,7 @@ fn create_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Re
         record: desc.record,
         initial_size: TerminalSize { cols, rows },
         colors,
+        tags: Vec::new(),
     })?;
     let mut session =
         DaemonSession { id: metadata.id, runtime_root: provider.runtime_root.clone(), rows, observation: ObservationState::new(rows) };

--- a/crates/cleat/src/runtime.rs
+++ b/crates/cleat/src/runtime.rs
@@ -37,6 +37,8 @@ pub struct SessionMetadata {
     pub vt_engine: VtEngineKind,
     pub cwd: Option<PathBuf>,
     pub cmd: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
     pub record: bool,
     pub initial_size: TerminalSize,
     pub colors: TerminalColors,
@@ -128,7 +130,16 @@ impl RuntimeLayout {
     }
 
     pub fn session_metadata(&self, id: String, vt_engine: VtEngineKind, cwd: Option<PathBuf>, cmd: Option<String>) -> SessionMetadata {
-        SessionMetadata { id, vt_engine, cwd, cmd, record: false, initial_size: TerminalSize::default(), colors: TerminalColors::default() }
+        SessionMetadata {
+            id,
+            vt_engine,
+            cwd,
+            cmd,
+            tags: Vec::new(),
+            record: false,
+            initial_size: TerminalSize::default(),
+            colors: TerminalColors::default(),
+        }
     }
 
     pub fn remove_session(&self, id: &str) -> Result<(), String> {
@@ -152,6 +163,11 @@ pub fn validate_runtime_name(name: &str) -> Result<(), String> {
     } else {
         Err(format!("invalid filesystem-safe name: {name}"))
     }
+}
+
+pub fn normalize_tags(tags: &mut Vec<String>) {
+    tags.sort();
+    tags.dedup();
 }
 
 fn discover_runtime_root(

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -229,8 +229,14 @@ impl SessionService {
                 }
                 Ok(sessions)
             }
-            Err(err) => sweep_dead_daemon_sessions(&self.layout, err)
-                .map(|sessions| sessions.into_iter().filter(|session| session_matches_selectors(session, selectors)).collect()),
+            Err(err) => {
+                if daemon_control_is_unavailable(&self.layout) {
+                    sweep_dead_daemon_sessions(&self.layout, err)
+                        .map(|sessions| sessions.into_iter().filter(|session| session_matches_selectors(session, selectors)).collect())
+                } else {
+                    Err(err)
+                }
+            }
         }
     }
 
@@ -1077,6 +1083,41 @@ mod tests {
         assert!(!layout.foreground_path("kept").exists(), "volatile foreground marker should be removed");
         assert!(!discarded_dir.exists(), "non-recreatable session should be removed");
         assert!(!layout.daemon_pid_path().exists(), "stale daemon pid should be removed");
+    }
+
+    #[test]
+    fn list_http_error_from_reachable_daemon_does_not_sweep_sessions() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let layout = RuntimeLayout::new(temp.path().to_path_buf());
+        let kept_dir = create_test_session_dir(temp.path(), "kept");
+        let discarded_dir = create_test_session_dir(temp.path(), "discarded");
+        fs::write(kept_dir.join(crate::recording::CAST_FILE_NAME), b"{\"version\":3}\n").expect("write cast");
+        fs::write(layout.daemon_pid_path(), std::process::id().to_string()).expect("write pid");
+
+        let listener = UnixListener::bind(layout.socket_path()).expect("bind socket");
+        let reader = thread::spawn(move || {
+            for index in 0..3 {
+                use std::io::Write;
+
+                let (mut stream, _) = listener.accept().expect("accept connection");
+                if index == 1 {
+                    let _request = read_http_request_for_test(&mut stream);
+                    stream
+                        .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 4\r\nConnection: close\r\n\r\noops")
+                        .expect("write error response");
+                }
+            }
+        });
+
+        let service = SessionService::new(layout.clone());
+        let err = service.list_all_with_selectors(&[]).expect_err("live daemon HTTP error should propagate");
+
+        reader.join().expect("join reader");
+        assert!(err.contains("500 Internal Server Error"), "{err}");
+        assert!(kept_dir.exists(), "recreatable session should remain");
+        assert!(discarded_dir.exists(), "non-recreatable live session should not be swept");
+        assert!(layout.socket_path().exists(), "daemon socket should remain reachable");
+        assert!(layout.daemon_pid_path().exists(), "daemon pid should remain");
     }
 
     #[test]

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -10,7 +10,10 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     http_uds,
-    platform::ipc::{set_stream_read_timeout, try_connect_session_stream, SessionStream},
+    platform::{
+        daemon::is_session_daemon_alive,
+        ipc::{set_stream_read_timeout, try_connect_session_stream, SessionStream},
+    },
     protocol::{SessionInfo, SessionStatus},
     runtime::{RuntimeLayout, TerminalSize},
     session::{attach_foreground, ensure_session_started, run_session_daemon, watch_foreground, ForegroundAttach, SessionStartOptions},
@@ -56,6 +59,12 @@ pub struct SliceOutcome {
 #[derive(Debug, Clone)]
 pub struct SessionService {
     layout: RuntimeLayout,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ListScope {
+    Current,
+    All,
 }
 
 impl SessionService {
@@ -138,63 +147,91 @@ impl SessionService {
     }
 
     pub fn list_with_selectors(&self, selectors: &[String]) -> Result<Vec<SessionInfo>, String> {
+        self.list_daemons(selectors, ListScope::Current)
+    }
+
+    pub fn list_all_with_selectors(&self, selectors: &[String]) -> Result<Vec<SessionInfo>, String> {
+        self.list_daemons(selectors, ListScope::All)
+    }
+
+    fn list_daemons(&self, selectors: &[String], scope: ListScope) -> Result<Vec<SessionInfo>, String> {
         if !self.layout.root().exists() {
             return Ok(vec![]);
         }
 
         let mut sessions = Vec::new();
-        let entries =
-            std::fs::read_dir(self.layout.root()).map_err(|err| format!("read runtime root {}: {err}", self.layout.root().display()))?;
-
-        for entry in entries {
-            let entry = entry.map_err(|err| format!("read runtime entry: {err}"))?;
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let daemon_name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(name) => name.to_string(),
-                None => continue,
-            };
-            if !path.join("sessions").is_dir() {
-                continue;
-            }
+        for daemon_name in self.daemon_names(scope)? {
             let daemon_service = self.with_daemon(daemon_name)?;
-            if !daemon_service.layout.socket_path().exists() || session_socket_is_stale(&daemon_service.layout.socket_path()) {
-                continue;
-            }
-            match daemon_service.http_json_daemon::<_, http_uds::SessionListResponse>(Method::GET, "/sessions", &()) {
-                Ok(result) => {
-                    for result in result.sessions {
-                        let status =
-                            if has_controller_attachment(&result.attachments) { SessionStatus::Attached } else { SessionStatus::Detached };
-                        let info = SessionInfo {
-                            id: result.session.id,
-                            vt_engine: parse_vt_engine_kind(&result.session.vt_engine),
-                            vt_engine_status: result.session.vt_engine_status,
-                            functional_vt_available: result.session.functional_vt_available,
-                            cwd: result.session.cwd,
-                            cmd: result.session.cmd,
-                            tags: result.session.tags,
-                            status,
-                            error: None,
-                        };
-                        if session_matches_selectors(&info, selectors) {
-                            sessions.push(info);
-                        }
-                    }
-                }
-                Err(err) => {
-                    sessions.extend(
-                        list_preserved_sessions_with_error(&daemon_service.layout, err)?
-                            .into_iter()
-                            .filter(|session| session_matches_selectors(session, selectors)),
-                    );
-                }
-            }
+            sessions.extend(daemon_service.list_one_daemon_with_selectors(selectors)?);
         }
         sessions.sort_by(|a, b| a.id.cmp(&b.id));
         Ok(sessions)
+    }
+
+    fn daemon_names(&self, scope: ListScope) -> Result<Vec<String>, String> {
+        match scope {
+            ListScope::Current => {
+                if self.layout.sessions_dir().is_dir() {
+                    Ok(vec![self.layout.daemon_name().to_string()])
+                } else {
+                    Ok(vec![])
+                }
+            }
+            ListScope::All => {
+                let entries = std::fs::read_dir(self.layout.root())
+                    .map_err(|err| format!("read runtime root {}: {err}", self.layout.root().display()))?;
+                let mut names = Vec::new();
+                for entry in entries {
+                    let entry = entry.map_err(|err| format!("read runtime entry: {err}"))?;
+                    let path = entry.path();
+                    if !path.is_dir() || !path.join("sessions").is_dir() {
+                        continue;
+                    }
+                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                        names.push(name.to_string());
+                    }
+                }
+                names.sort();
+                Ok(names)
+            }
+        }
+    }
+
+    fn list_one_daemon_with_selectors(&self, selectors: &[String]) -> Result<Vec<SessionInfo>, String> {
+        if !self.layout.sessions_dir().is_dir() {
+            return Ok(vec![]);
+        }
+        if daemon_control_is_unavailable(&self.layout) {
+            return sweep_dead_daemon_sessions(&self.layout, "daemon control socket is unavailable".to_string())
+                .map(|sessions| sessions.into_iter().filter(|session| session_matches_selectors(session, selectors)).collect());
+        }
+
+        match self.http_json_daemon::<_, http_uds::SessionListResponse>(Method::GET, "/sessions", &()) {
+            Ok(result) => {
+                let mut sessions = Vec::new();
+                for result in result.sessions {
+                    let status =
+                        if has_controller_attachment(&result.attachments) { SessionStatus::Attached } else { SessionStatus::Detached };
+                    let info = SessionInfo {
+                        id: result.session.id,
+                        vt_engine: parse_vt_engine_kind(&result.session.vt_engine),
+                        vt_engine_status: result.session.vt_engine_status,
+                        functional_vt_available: result.session.functional_vt_available,
+                        cwd: result.session.cwd,
+                        cmd: result.session.cmd,
+                        tags: result.session.tags,
+                        status,
+                        error: None,
+                    };
+                    if session_matches_selectors(&info, selectors) {
+                        sessions.push(info);
+                    }
+                }
+                Ok(sessions)
+            }
+            Err(err) => sweep_dead_daemon_sessions(&self.layout, err)
+                .map(|sessions| sessions.into_iter().filter(|session| session_matches_selectors(session, selectors)).collect()),
+        }
     }
 
     pub fn kill(&self, id: &str) -> Result<(), String> {
@@ -210,6 +247,13 @@ impl SessionService {
             if !self.layout.session_dir(id).exists() {
                 return Ok(());
             }
+        }
+        if daemon_control_is_unavailable(&self.layout) {
+            let _ = sweep_dead_daemon_sessions(&self.layout, "daemon control socket is unavailable".to_string())?;
+            if purge && self.layout.session_dir(id).exists() {
+                return self.layout.remove_session(id);
+            }
+            return Ok(());
         }
         if purge || !crate::recreate::session_is_recreatable(&self.layout.session_dir(id)) {
             self.layout.remove_session(id)
@@ -667,7 +711,17 @@ fn session_socket_is_stale(socket_path: &Path) -> bool {
     try_connect_session_stream(socket_path).is_err()
 }
 
-fn list_preserved_sessions_with_error(layout: &RuntimeLayout, err: String) -> Result<Vec<SessionInfo>, String> {
+fn daemon_control_is_unavailable(layout: &RuntimeLayout) -> bool {
+    if !is_session_daemon_alive(layout.root(), layout.daemon_name()) {
+        return true;
+    }
+    if !layout.socket_path().exists() {
+        return !layout.daemon_pid_path().exists();
+    }
+    session_socket_is_stale(&layout.socket_path())
+}
+
+fn sweep_dead_daemon_sessions(layout: &RuntimeLayout, err: String) -> Result<Vec<SessionInfo>, String> {
     let mut sessions = Vec::new();
     let entries = std::fs::read_dir(layout.sessions_dir()).map_err(|read_err| {
         format!("read daemon sessions directory {} after inspect failure ({err}): {read_err}", layout.sessions_dir().display())
@@ -675,12 +729,17 @@ fn list_preserved_sessions_with_error(layout: &RuntimeLayout, err: String) -> Re
     for entry in entries {
         let entry = entry.map_err(|read_err| format!("read daemon session entry: {read_err}"))?;
         let path = entry.path();
-        if !path.is_dir() || !crate::recreate::session_is_recreatable(&path) {
+        if !path.is_dir() {
             continue;
         }
         let Some(id) = path.file_name().and_then(|name| name.to_str()).map(str::to_string) else {
             continue;
         };
+        if !crate::recreate::session_is_recreatable(&path) {
+            layout.remove_session(&id)?;
+            continue;
+        }
+        let _ = std::fs::remove_file(layout.foreground_path(&id));
         sessions.push(SessionInfo {
             id,
             vt_engine: crate::vt::default_vt_engine_kind(),
@@ -693,7 +752,17 @@ fn list_preserved_sessions_with_error(layout: &RuntimeLayout, err: String) -> Re
             error: Some(err.clone()),
         });
     }
+    remove_stale_daemon_file(layout.socket_path(), "socket")?;
+    remove_stale_daemon_file(layout.daemon_pid_path(), "pid")?;
     Ok(sessions)
+}
+
+fn remove_stale_daemon_file(path: std::path::PathBuf, label: &str) -> Result<(), String> {
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(format!("remove stale daemon {label} {}: {err}", path.display())),
+    }
 }
 
 /// Resolve start and end bounds into byte offsets against a cast file without
@@ -985,6 +1054,29 @@ mod tests {
 
         assert!(started.elapsed() < Duration::from_secs(1), "purge should not wait for a missing socket");
         assert!(!session_dir.exists(), "purge should remove the preserved recording directory");
+    }
+
+    #[test]
+    fn list_sweeps_dead_daemon_and_preserves_only_recreatable_sessions() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let layout = RuntimeLayout::new(temp.path().to_path_buf());
+        let kept_dir = create_test_session_dir(temp.path(), "kept");
+        let discarded_dir = create_test_session_dir(temp.path(), "discarded");
+        fs::write(kept_dir.join(crate::recording::CAST_FILE_NAME), b"{\"version\":3}\n").expect("write cast");
+        fs::write(layout.foreground_path("kept"), b"12345").expect("write foreground marker");
+        fs::write(layout.daemon_pid_path(), "999999999").expect("write stale pid");
+
+        let service = SessionService::new(layout.clone());
+        let sessions = service.list_all_with_selectors(&[]).expect("list all");
+
+        assert_eq!(sessions.iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), vec!["kept"]);
+        assert_eq!(sessions[0].status, crate::protocol::SessionStatus::Detached);
+        assert!(sessions[0].error.as_deref().unwrap_or_default().contains("daemon control socket"));
+        assert!(kept_dir.exists(), "recreatable session should be preserved");
+        assert!(kept_dir.join(crate::recording::CAST_FILE_NAME).exists(), "recording should remain");
+        assert!(!layout.foreground_path("kept").exists(), "volatile foreground marker should be removed");
+        assert!(!discarded_dir.exists(), "non-recreatable session should be removed");
+        assert!(!layout.daemon_pid_path().exists(), "stale daemon pid should be removed");
     }
 
     #[test]

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -99,11 +99,23 @@ impl SessionService {
         record: bool,
         initial_size: TerminalSize,
     ) -> Result<SessionInfo, String> {
-        let session = ensure_session_started(&self.layout, name, vt_engine, cwd, cmd, SessionStartOptions {
+        self.create_with_options(name, vt_engine, cwd, cmd, SessionStartOptions {
             record,
             initial_size,
             colors: crate::vt::TerminalColors::default(),
-        })?;
+            tags: Vec::new(),
+        })
+    }
+
+    pub fn create_with_options(
+        &self,
+        name: Option<String>,
+        vt_engine: Option<VtEngineKind>,
+        cwd: Option<std::path::PathBuf>,
+        cmd: Option<String>,
+        options: SessionStartOptions,
+    ) -> Result<SessionInfo, String> {
+        let session = ensure_session_started(&self.layout, name, vt_engine, cwd, cmd, options)?;
         // If the daemon was already running, get real config via inspect.
         if let Ok(result) = self.inspect(&session.id) {
             return Ok(session_info_from_inspect(result, SessionStatus::Detached));
@@ -115,6 +127,7 @@ impl SessionService {
             functional_vt_available: crate::vt::functional_vt_available(),
             cwd: session.cwd,
             cmd: session.cmd,
+            tags: session.tags,
             status: SessionStatus::Detached,
             error: None,
         })
@@ -158,6 +171,7 @@ impl SessionService {
                             functional_vt_available: result.session.functional_vt_available,
                             cwd: result.session.cwd,
                             cmd: result.session.cmd,
+                            tags: result.session.tags,
                             status,
                             error: None,
                         });
@@ -369,6 +383,7 @@ impl SessionService {
                 record: false,
                 initial_size: TerminalSize::default(),
                 colors: crate::vt::TerminalColors::default(),
+                tags: Vec::new(),
             }
         } else {
             ensure_session_started(&self.layout, name, vt_engine, cwd, cmd, SessionStartOptions::default())?
@@ -384,6 +399,7 @@ impl SessionService {
                 functional_vt_available: crate::vt::functional_vt_available(),
                 cwd: session.cwd,
                 cmd: session.cmd,
+                tags: session.tags,
                 status: SessionStatus::Attached,
                 error: None,
             }
@@ -442,6 +458,15 @@ impl SessionService {
             return Err(format!("missing session {id}"));
         }
         self.http_json(id, Method::GET, &format!("/sessions/{id}"), &())
+    }
+
+    pub fn update_tags(&self, id: &str, add: Vec<String>, remove: Vec<String>) -> Result<Vec<String>, String> {
+        if !self.layout.session_dir(id).exists() {
+            return Err(format!("missing session {id}"));
+        }
+        let response: http_uds::TagResponse =
+            self.http_json(id, Method::POST, &format!("/sessions/{id}/tags"), &http_uds::TagRequest { add, remove })?;
+        Ok(response.tags)
     }
 
     pub fn signal(&self, id: &str, signal: i32, target: crate::protocol::SignalTarget) -> Result<(), String> {
@@ -630,6 +655,7 @@ fn list_preserved_sessions_with_error(layout: &RuntimeLayout, err: String) -> Re
             functional_vt_available: false,
             cwd: None,
             cmd: None,
+            tags: Vec::new(),
             status: SessionStatus::Detached,
             error: Some(err.clone()),
         });
@@ -692,6 +718,7 @@ fn session_info_from_inspect(result: crate::protocol::InspectResult, status: Ses
         functional_vt_available: result.session.functional_vt_available,
         cwd: result.session.cwd,
         cmd: result.session.cmd,
+        tags: result.session.tags,
         status,
         error: None,
     }

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -134,6 +134,10 @@ impl SessionService {
     }
 
     pub fn list(&self) -> Result<Vec<SessionInfo>, String> {
+        self.list_with_selectors(&[])
+    }
+
+    pub fn list_with_selectors(&self, selectors: &[String]) -> Result<Vec<SessionInfo>, String> {
         if !self.layout.root().exists() {
             return Ok(vec![]);
         }
@@ -164,7 +168,7 @@ impl SessionService {
                     for result in result.sessions {
                         let status =
                             if has_controller_attachment(&result.attachments) { SessionStatus::Attached } else { SessionStatus::Detached };
-                        sessions.push(SessionInfo {
+                        let info = SessionInfo {
                             id: result.session.id,
                             vt_engine: parse_vt_engine_kind(&result.session.vt_engine),
                             vt_engine_status: result.session.vt_engine_status,
@@ -174,11 +178,18 @@ impl SessionService {
                             tags: result.session.tags,
                             status,
                             error: None,
-                        });
+                        };
+                        if session_matches_selectors(&info, selectors) {
+                            sessions.push(info);
+                        }
                     }
                 }
                 Err(err) => {
-                    sessions.extend(list_preserved_sessions_with_error(&daemon_service.layout, err)?);
+                    sessions.extend(
+                        list_preserved_sessions_with_error(&daemon_service.layout, err)?
+                            .into_iter()
+                            .filter(|session| session_matches_selectors(session, selectors)),
+                    );
                 }
             }
         }
@@ -422,14 +433,32 @@ impl SessionService {
         if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
+        self.connect_directory(&[]).and_then(|(client, directory)| {
+            if directory.sessions.iter().any(|entry| entry.session_id == id) {
+                Ok((client, directory))
+            } else {
+                Err(format!("session {id} was not present in packet directory"))
+            }
+        })
+    }
+
+    pub fn connect_directory(
+        &self,
+        selectors: &[String],
+    ) -> Result<(crate::packet::PacketClient<SessionStream>, crate::packet::DirectorySnapshot), String> {
+        crate::session::ensure_daemon_started(&self.layout)?;
 
         let socket_path = self.layout.socket_path();
         let mut stream = connect_session_socket(&socket_path)?;
+        let body = serde_json::to_vec(&http_uds::DirectorySubscribeRequest { selectors: selectors.to_vec() })
+            .map_err(|err| format!("serialize directory subscribe request: {err}"))?;
         write!(
             stream,
-            "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Length: 0\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n"
+            "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n",
+            body.len()
         )
         .map_err(|err| format!("write packet upgrade request: {err}"))?;
+        stream.write_all(&body).map_err(|err| format!("write directory subscribe request: {err}"))?;
         let response = http_uds::read_response_head(&mut stream).map_err(|err| format!("read packet upgrade response: {err}"))?;
         if response.status != StatusCode::SWITCHING_PROTOCOLS {
             return Err(format!("unexpected packet response: {}", response.status));
@@ -628,6 +657,10 @@ impl SessionService {
         http_uds::write_request(&mut stream, method, path, &body).map_err(|err| format!("write HTTP request: {err}"))?;
         http_uds::read_response(&mut stream).map_err(|err| format!("read HTTP response: {err}"))
     }
+}
+
+fn session_matches_selectors(session: &SessionInfo, selectors: &[String]) -> bool {
+    selectors.iter().all(|selector| session.tags.contains(selector))
 }
 
 fn session_socket_is_stale(socket_path: &Path) -> bool {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -56,11 +56,12 @@ pub struct ForegroundAttach {
     stream: Arc<Mutex<SessionStream>>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SessionStartOptions {
     pub record: bool,
     pub initial_size: TerminalSize,
     pub colors: vt::TerminalColors,
+    pub tags: Vec<String>,
 }
 
 impl ForegroundAttach {
@@ -250,6 +251,8 @@ pub fn ensure_session_started(
     session.record = options.record;
     session.initial_size = options.initial_size;
     session.colors = options.colors;
+    session.tags = options.tags;
+    crate::runtime::normalize_tags(&mut session.tags);
 
     ensure_daemon_started(layout)?;
     let mut stream = connect_session_stream(&layout.socket_path())?;
@@ -1053,6 +1056,7 @@ fn handle_http_request(
                 let inspect = hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?;
                 directory_entries.push(DirectoryEntry {
                     session_id: inspect.session.id,
+                    tags: inspect.session.tags,
                     cols: inspect.terminal.cols,
                     rows: inspect.terminal.rows,
                 });
@@ -1257,6 +1261,16 @@ fn handle_http_request(
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP record request: {err}"))?;
             hosted.actor.set_recording(body.enable)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP record response: {err}"))
+        }
+        http_uds::Route::SessionTags { id } => {
+            let Some(hosted) = state.sessions.get(&id) else {
+                return write_http_not_found(stream);
+            };
+            let body: http_uds::TagRequest =
+                serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP tag request: {err}"))?;
+            let tags = hosted.actor.update_tags(body.add, body.remove)?;
+            http_uds::write_json(stream, StatusCode::OK, &http_uds::TagResponse { tags })
+                .map_err(|err| format!("write HTTP tag response: {err}"))
         }
         http_uds::Route::SessionMark { id } => {
             let Some(hosted) = state.sessions.get(&id) else {
@@ -2083,6 +2097,7 @@ mod tests {
             vt_engine: vt::default_vt_engine_kind(),
             cwd: None,
             cmd: None,
+            tags: Vec::new(),
             record: false,
             initial_size: TerminalSize::default(),
             colors: vt::TerminalColors::default(),
@@ -2106,6 +2121,7 @@ mod tests {
             vt_engine: vt::default_vt_engine_kind(),
             cwd: None,
             cmd: None,
+            tags: Vec::new(),
             record: false,
             initial_size: TerminalSize { cols: 120, rows: 40 },
             colors: vt::TerminalColors::default(),

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(unix), allow(dead_code, unused_imports))]
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     fs,
     io::{self, Read, Write},
     panic::{self, AssertUnwindSafe},
@@ -20,9 +20,10 @@ use crate::{
     host::actor::{RawOutputTap, SessionActor, SessionMouseEvent, SessionWheelEvent},
     http_uds,
     packet::{
-        Ack, CloseChannel, ControlError, ControlHello, DirectoryEntry, DirectorySnapshot, Input, OpenChannel, PacketFrame, RenderPacket,
-        Resize, CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL, MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_ERROR, MSG_CONTROL_HELLO,
-        MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT, MSG_SESSION_RENDER, MSG_SESSION_RESIZE,
+        Ack, CloseChannel, ControlError, ControlHello, DirectoryDelta, DirectoryEntry, DirectorySnapshot, Input, OpenChannel, PacketFrame,
+        RenderPacket, Resize, CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL, MSG_CONTROL_DIRECTORY_DELTA, MSG_CONTROL_DIRECTORY_SNAPSHOT,
+        MSG_CONTROL_ERROR, MSG_CONTROL_HELLO, MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT, MSG_SESSION_RENDER,
+        MSG_SESSION_RESIZE,
     },
     platform::{
         daemon::{is_session_daemon_alive, spawn_daemon_process},
@@ -666,7 +667,7 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
             }
         }
 
-        did_work |= service_packet_clients(&mut sessions, &mut packet_clients)?;
+        did_work |= service_packet_clients(&layout, &mut sessions, &mut packet_clients)?;
         let session_ids: Vec<String> = sessions.keys().cloned().collect();
         for session_id in session_ids {
             let Some(hosted) = sessions.get_mut(&session_id) else {
@@ -703,12 +704,14 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
 
         if let Some(session_id) = faulted_session.take() {
             cleanup_exited_session(&layout, &session_id, true);
+            broadcast_directory_remove(&session_id, &mut packet_clients)?;
             sessions.remove(&session_id);
             remove_packet_channels_for_session(&session_id, &mut packet_clients);
         }
 
         if let Some((session_id, should_keep_session_dir)) = exited_session.take() {
             cleanup_exited_session(&layout, &session_id, should_keep_session_dir);
+            broadcast_directory_remove(&session_id, &mut packet_clients)?;
             sessions.remove(&session_id);
             remove_packet_channels_for_session(&session_id, &mut packet_clients);
         }
@@ -761,6 +764,70 @@ fn remove_packet_channels_for_session(session_id: &str, packet_clients: &mut [Pa
     }
 }
 
+fn directory_entry_for_session(layout: &RuntimeLayout, hosted: &HostedSession) -> Result<DirectoryEntry, String> {
+    let inspect = hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?;
+    Ok(DirectoryEntry {
+        session_id: inspect.session.id.clone(),
+        tags: inspect.session.tags,
+        state: inspect.session.state,
+        controller_count: if hosted.active_client.is_some() { 1 } else { 0 },
+        watcher_count: u32::try_from(hosted.watchers.len()).unwrap_or(u32::MAX),
+        recreatable: crate::recreate::session_is_recreatable(&layout.session_dir(&inspect.session.id)),
+        cols: inspect.terminal.cols,
+        rows: inspect.terminal.rows,
+    })
+}
+
+fn directory_snapshot_for_sessions(
+    layout: &RuntimeLayout,
+    sessions: &HashMap<String, HostedSession>,
+    selectors: &[String],
+) -> Result<DirectorySnapshot, String> {
+    let mut entries = Vec::new();
+    for hosted in sessions.values() {
+        let entry = directory_entry_for_session(layout, hosted)?;
+        if directory_entry_matches_selectors(&entry, selectors) {
+            entries.push(entry);
+        }
+    }
+    entries.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+    Ok(DirectorySnapshot { sessions: entries })
+}
+
+fn directory_entry_matches_selectors(entry: &DirectoryEntry, selectors: &[String]) -> bool {
+    selectors.iter().all(|selector| entry.tags.contains(selector))
+}
+
+fn broadcast_directory_upsert(entry: DirectoryEntry, packet_clients: &mut Vec<PacketClient>) -> Result<(), String> {
+    for client in packet_clients {
+        if directory_entry_matches_selectors(&entry, &client.selectors) {
+            client.known_directory_sessions.insert(entry.session_id.clone());
+            client.enqueue_control(MSG_CONTROL_DIRECTORY_DELTA, &DirectoryDelta {
+                upserted: vec![entry.clone()],
+                removed_session_ids: Vec::new(),
+            })?;
+        } else if client.known_directory_sessions.remove(&entry.session_id) {
+            client.enqueue_control(MSG_CONTROL_DIRECTORY_DELTA, &DirectoryDelta {
+                upserted: Vec::new(),
+                removed_session_ids: vec![entry.session_id.clone()],
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn broadcast_directory_remove(session_id: &str, packet_clients: &mut Vec<PacketClient>) -> Result<(), String> {
+    for client in packet_clients {
+        if client.known_directory_sessions.remove(session_id) {
+            client.enqueue_control(MSG_CONTROL_DIRECTORY_DELTA, &DirectoryDelta {
+                upserted: Vec::new(),
+                removed_session_ids: vec![session_id.to_string()],
+            })?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(not(debug_assertions))]
 fn maybe_panic_for_containment_test(_session_id: &str) {}
 
@@ -786,6 +853,9 @@ fn service_hosted_session(
     packet_clients: &mut Vec<PacketClient>,
 ) -> Result<bool, String> {
     let mut did_work = false;
+    let previous_controller_count = hosted.active_client.is_some();
+    let previous_watcher_count = hosted.watchers.len();
+    let mut resized = false;
 
     did_work |=
         drain_raw_output_tap(layout, id, &hosted.actor, &mut hosted.raw_output_tap, &mut hosted.active_client, &mut hosted.watchers)?;
@@ -810,6 +880,7 @@ fn service_hosted_session(
                 }
                 Frame::Resize { cols, rows } => {
                     hosted.actor.resize(cols, rows)?;
+                    resized = true;
                 }
                 _ => {}
             }
@@ -837,6 +908,10 @@ fn service_hosted_session(
     }
     flush_watchers(&mut hosted.watchers);
     push_due_packet_renders(id, &hosted.actor, packet_clients, &mut hosted.packet_render_cache)?;
+
+    if resized || previous_controller_count != hosted.active_client.is_some() || previous_watcher_count != hosted.watchers.len() {
+        broadcast_directory_upsert(directory_entry_for_session(layout, hosted)?, packet_clients)?;
+    }
 
     service_pending_waits(&hosted.actor, &mut hosted.pending_waits);
     service_pending_expects(layout, id, &hosted.actor, &mut hosted.pending_expects)?;
@@ -1035,11 +1110,18 @@ fn handle_http_request(
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP session create request: {err}"))?;
             crate::runtime::validate_runtime_name(&session.id)?;
             session.vt_engine.ensure_available()?;
+            let mut created = false;
             if !state.sessions.contains_key(&session.id) {
                 let session_dir = state.layout.session_dir(&session.id);
                 fs::create_dir_all(&session_dir).map_err(|err| format!("create session dir {}: {err}", session_dir.display()))?;
                 let hosted = HostedSession::spawn(session_dir, session.clone())?;
                 state.sessions.insert(session.id.clone(), hosted);
+                created = true;
+            }
+            if created {
+                if let Some(hosted) = state.sessions.get(&session.id) {
+                    broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
+                }
             }
             http_uds::write_json(stream, StatusCode::OK, &http_uds::CreateSessionResponse { session })
                 .map_err(|err| format!("write HTTP session create response: {err}"))
@@ -1051,24 +1133,21 @@ fn handle_http_request(
                 return Ok(());
             }
 
-            let mut directory_entries = Vec::new();
-            for hosted in state.sessions.values() {
-                let inspect = hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?;
-                directory_entries.push(DirectoryEntry {
-                    session_id: inspect.session.id,
-                    tags: inspect.session.tags,
-                    cols: inspect.terminal.cols,
-                    rows: inspect.terminal.rows,
-                });
-            }
-            directory_entries.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+            let subscribe = if request.body().is_empty() {
+                http_uds::DirectorySubscribeRequest::default()
+            } else {
+                serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP directory subscribe request: {err}"))?
+            };
+            let mut selectors = subscribe.selectors;
+            crate::runtime::normalize_tags(&mut selectors);
+            let directory = directory_snapshot_for_sessions(state.layout, state.sessions, &selectors)?;
             http_uds::write_packet_switching_protocols(stream).map_err(|err| format!("write HTTP packet upgrade response: {err}"))?;
             let packet_stream = stream.try_clone().map_err(|err| format!("clone HTTP packet stream: {err}"))?;
             #[cfg(unix)]
             set_stream_nonblocking(&packet_stream, true).map_err(|err| format!("set HTTP packet stream nonblocking: {err}"))?;
-            let mut client = PacketClient::new(packet_stream)?;
+            let mut client = PacketClient::new(packet_stream, selectors, &directory)?;
             client.enqueue_control(MSG_CONTROL_HELLO, &ControlHello::current())?;
-            client.enqueue_control(MSG_CONTROL_DIRECTORY_SNAPSHOT, &DirectorySnapshot { sessions: directory_entries })?;
+            client.enqueue_control(MSG_CONTROL_DIRECTORY_SNAPSHOT, &directory)?;
             state.packet_clients.push(client);
             Ok(())
         }
@@ -1118,6 +1197,7 @@ fn handle_http_request(
             hosted.had_foreground_client = true;
             hosted.actor.set_client_presence(true)?;
             hosted.actor.record_attach()?;
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
             Ok(())
         }
         http_uds::Route::SessionWatch { id } => {
@@ -1139,6 +1219,7 @@ fn handle_http_request(
                 }
             }
             hosted.watchers.push(watcher);
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
             Ok(())
         }
         http_uds::Route::SessionDetach { id } => {
@@ -1151,6 +1232,7 @@ fn handle_http_request(
             }
             hosted.actor.set_client_presence(false)?;
             hosted.active_client = None;
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP detach response: {err}"))
         }
         http_uds::Route::SessionExpect { id } => 'expect: {
@@ -1220,6 +1302,7 @@ fn handle_http_request(
                 }
                 http_uds::InputRequest::Resize { cols, rows } => {
                     hosted.actor.resize(cols, rows)?;
+                    broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
                 }
             }
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP input response: {err}"))
@@ -1269,6 +1352,7 @@ fn handle_http_request(
             let body: http_uds::TagRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP tag request: {err}"))?;
             let tags = hosted.actor.update_tags(body.add, body.remove)?;
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::TagResponse { tags })
                 .map_err(|err| format!("write HTTP tag response: {err}"))
         }
@@ -1313,6 +1397,7 @@ fn handle_http_request(
             let body: http_uds::ResizeRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP resize request: {err}"))?;
             hosted.actor.resize(body.cols, body.rows)?;
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP resize response: {err}"))
         }
         http_uds::Route::SessionScreen { id } => {
@@ -1479,6 +1564,8 @@ struct PacketClient {
     input_reader: ActiveClientReader,
     input_buffer: Vec<u8>,
     channels: HashMap<u32, PacketSessionChannel>,
+    selectors: Vec<String>,
+    known_directory_sessions: HashSet<String>,
 }
 
 struct PacketSessionChannel {
@@ -1507,9 +1594,17 @@ impl PacketRenderCache {
 }
 
 impl PacketClient {
-    fn new(stream: SessionStream) -> Result<Self, String> {
+    fn new(stream: SessionStream, selectors: Vec<String>, initial_directory: &DirectorySnapshot) -> Result<Self, String> {
         let input_reader = ActiveClientReader::new(&stream)?;
-        Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new(), channels: HashMap::new() })
+        Ok(Self {
+            stream,
+            pending_output: Vec::new(),
+            input_reader,
+            input_buffer: Vec::new(),
+            channels: HashMap::new(),
+            selectors,
+            known_directory_sessions: initial_directory.sessions.iter().map(|entry| entry.session_id.clone()).collect(),
+        })
     }
 
     fn enqueue_control<T: serde::Serialize>(&mut self, msg_type: u8, value: &T) -> Result<(), String> {
@@ -1565,7 +1660,11 @@ impl PacketClient {
     }
 }
 
-fn service_packet_clients(sessions: &mut HashMap<String, HostedSession>, packet_clients: &mut Vec<PacketClient>) -> Result<bool, String> {
+fn service_packet_clients(
+    layout: &RuntimeLayout,
+    sessions: &mut HashMap<String, HostedSession>,
+    packet_clients: &mut Vec<PacketClient>,
+) -> Result<bool, String> {
     let mut did_work = false;
     let mut index = 0;
     while index < packet_clients.len() {
@@ -1581,14 +1680,22 @@ fn service_packet_clients(sessions: &mut HashMap<String, HostedSession>, packet_
 
         while let Some(frame) = pending.pop_front() {
             did_work = true;
-            handle_packet_frame(sessions, &mut packet_clients[index], frame)?;
+            if let Some(entry) = handle_packet_frame(layout, sessions, &mut packet_clients[index], frame)? {
+                broadcast_directory_upsert(entry, packet_clients)?;
+            }
         }
         index += 1;
     }
     Ok(did_work)
 }
 
-fn handle_packet_frame(sessions: &mut HashMap<String, HostedSession>, client: &mut PacketClient, frame: PacketFrame) -> Result<(), String> {
+fn handle_packet_frame(
+    layout: &RuntimeLayout,
+    sessions: &mut HashMap<String, HostedSession>,
+    client: &mut PacketClient,
+    frame: PacketFrame,
+) -> Result<Option<DirectoryEntry>, String> {
+    let mut directory_update = None;
     match (frame.channel, frame.msg_type) {
         (CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL) => {
             let open = frame.decode::<OpenChannel>().map_err(|err| format!("decode open-channel packet: {err}"))?;
@@ -1623,12 +1730,13 @@ fn handle_packet_frame(sessions: &mut HashMap<String, HostedSession>, client: &m
             if let Some(session_id) = client.channels.get(&channel).map(|session| session.session_id.clone()) {
                 if let Some(hosted) = sessions.get(&session_id) {
                     hosted.actor.resize(resize.cols, resize.rows)?;
+                    directory_update = Some(directory_entry_for_session(layout, hosted)?);
                 }
             }
         }
         _ => {}
     }
-    Ok(())
+    Ok(directory_update)
 }
 
 fn open_packet_channel(sessions: &mut HashMap<String, HostedSession>, client: &mut PacketClient, open: OpenChannel) -> Result<(), String> {
@@ -1946,7 +2054,7 @@ impl ActiveClientReader {
 }
 
 fn wait_for_socket(path: &Path) -> Result<(), String> {
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + Duration::from_secs(15);
     while Instant::now() < deadline {
         if try_connect_session_stream(path).is_ok() {
             return Ok(());
@@ -1956,7 +2064,7 @@ fn wait_for_socket(path: &Path) -> Result<(), String> {
     Err(format!("timed out waiting for socket {}", path.display()))
 }
 
-fn ensure_daemon_started(layout: &RuntimeLayout) -> Result<(), String> {
+pub(crate) fn ensure_daemon_started(layout: &RuntimeLayout) -> Result<(), String> {
     if try_connect_session_stream(&layout.socket_path()).is_ok() && is_session_daemon_alive(layout.root(), layout.daemon_name()) {
         return Ok(());
     }

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -2054,6 +2054,8 @@ impl ActiveClientReader {
 }
 
 fn wait_for_socket(path: &Path) -> Result<(), String> {
+    // Feature builds can spend several seconds loading the Ghostty VT library
+    // and starting the daemon process under CI load before the socket is bound.
     let deadline = Instant::now() + Duration::from_secs(15);
     while Instant::now() < deadline {
         if try_connect_session_stream(path).is_ok() {

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -15,7 +15,7 @@ use crate::{
         ViewportCommandOutcome,
     },
     recording::SessionRecorder,
-    runtime::SessionMetadata,
+    runtime::{normalize_tags, SessionMetadata},
     vt::{self, TerminalModeState, VtEngine},
 };
 
@@ -282,6 +282,7 @@ impl SessionRuntime {
                 functional_vt_available: crate::vt::functional_vt_available(),
                 cwd: self.session.cwd.clone(),
                 cmd: self.session.cmd.clone(),
+                tags: self.session.tags.clone(),
             },
             terminal: crate::protocol::TerminalInspect { rows, cols },
             process: crate::protocol::ProcessInspect {
@@ -308,6 +309,17 @@ impl SessionRuntime {
         };
         self.record_custom_event('s', &serde_json::json!({"signal": signal, "target": target_str}).to_string());
         Ok(())
+    }
+
+    pub(crate) fn update_tags(&mut self, add: Vec<String>, remove: Vec<String>) -> Vec<String> {
+        for tag in add {
+            if !self.session.tags.contains(&tag) {
+                self.session.tags.push(tag);
+            }
+        }
+        self.session.tags.retain(|tag| !remove.contains(tag));
+        normalize_tags(&mut self.session.tags);
+        self.session.tags.clone()
     }
 
     pub(crate) fn mark(&mut self, name: Option<String>) -> Result<u64, String> {
@@ -540,6 +552,7 @@ mod tests {
             vt_engine: VtEngineKind::Passthrough,
             cwd: None,
             cmd: Some("true".to_string()),
+            tags: Vec::new(),
             record: true,
             initial_size: crate::runtime::TerminalSize::default(),
             colors: crate::vt::TerminalColors::default(),
@@ -583,6 +596,7 @@ mod tests {
             vt_engine: VtEngineKind::Ghostty,
             cwd: None,
             cmd: Some("sh -c 'printf RECREATE_MARKER; sleep 30'".to_string()),
+            tags: Vec::new(),
             record: true,
             initial_size: crate::runtime::TerminalSize::default(),
             colors,

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -17,6 +17,7 @@ fn help_lists_expected_subcommands() {
         "packets",
         "launch",
         "list",
+        "tag",
         "capture",
         "transcript",
         "replay",
@@ -115,6 +116,7 @@ fn launch_command_parses() {
         vt: None,
         cwd: None,
         cmd: Some("bash".into()),
+        tags: Vec::new(),
         record: RecordFlags::default()
     });
 }
@@ -148,8 +150,22 @@ fn launch_command_parses_positional_name() {
         vt: None,
         cwd: None,
         cmd: Some("bash".into()),
+        tags: Vec::new(),
         record: RecordFlags::default()
     });
+}
+
+#[test]
+fn launch_command_parses_repeatable_tags() {
+    let cli = Cli::try_parse_from(["cleat", "launch", "demo", "--tag", "role=impl", "--tag", "task=99"]).expect("launch --tag parses");
+    assert!(matches!(
+        cli.command,
+        Command::Launch {
+            id: Some(ref id),
+            tags: ref parsed_tags,
+            ..
+        } if id == "demo" && parsed_tags == &vec!["role=impl".to_string(), "task=99".to_string()]
+    ));
 }
 
 #[test]
@@ -162,6 +178,7 @@ fn launch_command_parses_json() {
         vt: None,
         cwd: None,
         cmd: None,
+        tags: Vec::new(),
         record: RecordFlags::default()
     });
 }
@@ -176,6 +193,7 @@ fn launch_command_parses_vt() {
         vt: Some(VtEngineKind::Ghostty),
         cwd: None,
         cmd: None,
+        tags: Vec::new(),
         record: RecordFlags::default()
     });
 }
@@ -190,6 +208,7 @@ fn create_alias_still_parses_as_launch() {
         vt: None,
         cwd: None,
         cmd: Some("bash".into()),
+        tags: Vec::new(),
         record: RecordFlags::default()
     });
 }

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -216,20 +216,36 @@ fn create_alias_still_parses_as_launch() {
 #[test]
 fn list_command_parses() {
     let cli = Cli::try_parse_from(["cleat", "list"]).expect("list parses");
-    assert_eq!(cli.command, Command::List { json: false, watch: false, selectors: Vec::new() });
+    assert_eq!(cli.command, Command::List { json: false, watch: false, all: false, selectors: Vec::new() });
 }
 
 #[test]
 fn list_command_parses_json() {
     let cli = Cli::try_parse_from(["cleat", "list", "--json"]).expect("list --json parses");
-    assert_eq!(cli.command, Command::List { json: true, watch: false, selectors: Vec::new() });
+    assert_eq!(cli.command, Command::List { json: true, watch: false, all: false, selectors: Vec::new() });
 }
 
 #[test]
 fn list_command_parses_watch_and_selectors() {
     let cli =
         Cli::try_parse_from(["cleat", "list", "--watch", "--selector", "role=impl", "--selector", "task=99"]).expect("list watch parses");
-    assert_eq!(cli.command, Command::List { json: false, watch: true, selectors: vec!["role=impl".to_string(), "task=99".to_string()] });
+    assert_eq!(cli.command, Command::List {
+        json: false,
+        watch: true,
+        all: false,
+        selectors: vec!["role=impl".to_string(), "task=99".to_string()]
+    });
+}
+
+#[test]
+fn list_command_parses_all() {
+    let cli = Cli::try_parse_from(["cleat", "list", "--all"]).expect("list --all parses");
+    assert_eq!(cli.command, Command::List { json: false, watch: false, all: true, selectors: Vec::new() });
+}
+
+#[test]
+fn list_command_rejects_all_with_watch() {
+    assert!(Cli::try_parse_from(["cleat", "list", "--all", "--watch"]).is_err());
 }
 
 #[test]

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -216,13 +216,20 @@ fn create_alias_still_parses_as_launch() {
 #[test]
 fn list_command_parses() {
     let cli = Cli::try_parse_from(["cleat", "list"]).expect("list parses");
-    assert_eq!(cli.command, Command::List { json: false });
+    assert_eq!(cli.command, Command::List { json: false, watch: false, selectors: Vec::new() });
 }
 
 #[test]
 fn list_command_parses_json() {
     let cli = Cli::try_parse_from(["cleat", "list", "--json"]).expect("list --json parses");
-    assert_eq!(cli.command, Command::List { json: true });
+    assert_eq!(cli.command, Command::List { json: true, watch: false, selectors: Vec::new() });
+}
+
+#[test]
+fn list_command_parses_watch_and_selectors() {
+    let cli =
+        Cli::try_parse_from(["cleat", "list", "--watch", "--selector", "role=impl", "--selector", "task=99"]).expect("list watch parses");
+    assert_eq!(cli.command, Command::List { json: false, watch: true, selectors: vec!["role=impl".to_string(), "task=99".to_string()] });
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -16,7 +16,8 @@ use cleat::session::foreground_path;
 use cleat::{
     cli::{self, Cli, ExecResult},
     packet::{
-        ControlHello, DirectorySnapshot, PacketFrame, CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_HELLO, PROTOCOL_VERSION,
+        ControlHello, DirectoryDelta, DirectorySnapshot, PacketFrame, CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_DELTA,
+        MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_HELLO, PROTOCOL_VERSION,
     },
     protocol::{Frame, SessionInfo},
     provider::ProviderFeatures,
@@ -78,10 +79,28 @@ fn http_watch_stream(root: &std::path::Path, id: &str, cols: u16, rows: u16, cap
 }
 
 fn http_packet_stream(root: &std::path::Path, id: &str) -> UnixStream {
+    http_packet_stream_with_selectors(root, id, &[])
+}
+
+fn http_packet_stream_with_selectors(root: &std::path::Path, id: &str, selectors: &[String]) -> UnixStream {
     let socket_path = session_socket_path(root, id);
     let mut stream = UnixStream::connect(&socket_path).expect("connect session socket");
-    write!(stream, "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Length: 0\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n",)
+    let body = if selectors.is_empty() { String::new() } else { serde_json::json!({ "selectors": selectors }).to_string() };
+    if body.is_empty() {
+        write!(
+            stream,
+            "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Length: 0\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n",
+        )
         .expect("write packet upgrade request");
+    } else {
+        write!(
+            stream,
+            "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .expect("write packet upgrade request");
+    }
 
     let response = read_http_response_head(&mut stream);
     assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{response}");
@@ -131,6 +150,39 @@ fn read_packet_render(stream: &mut UnixStream, channel: u32, timeout: Duration) 
     panic!("timed out waiting for render packet on channel {channel}");
 }
 
+fn read_directory_delta_named(stream: &mut UnixStream, timeout: Duration, label: &str) -> DirectoryDelta {
+    stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
+    let deadline = Instant::now() + timeout;
+    let mut buffer = Vec::new();
+    while Instant::now() < deadline {
+        while let Some(frame) = PacketFrame::read_from_buffer(&mut buffer).expect("parse packet buffer") {
+            if frame.channel == CHANNEL_CONTROL && frame.msg_type == MSG_CONTROL_DIRECTORY_DELTA {
+                return frame.decode::<DirectoryDelta>().expect("decode directory delta");
+            }
+        }
+        let mut chunk = [0; 4096];
+        match stream.read(&mut chunk) {
+            Ok(0) => panic!("packet stream closed while waiting for directory delta"),
+            Ok(n) => buffer.extend_from_slice(&chunk[..n]),
+            Err(err) if packet_read_would_wait(&err) => {}
+            Err(err) => panic!("read packet frame: {err}"),
+        }
+    }
+    panic!("timed out waiting for {label}");
+}
+
+fn read_until_directory_remove(stream: &mut UnixStream, session_id: &str, timeout: Duration) -> DirectoryDelta {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let delta = read_directory_delta_named(stream, remaining, &format!("remove delta for {session_id}"));
+        if delta.removed_session_ids.iter().any(|id| id == session_id) {
+            return delta;
+        }
+        assert!(Instant::now() < deadline, "timed out waiting for remove delta for {session_id}");
+    }
+}
+
 #[cfg(feature = "ghostty-vt")]
 fn expect_no_packet(stream: &mut UnixStream, timeout: Duration) {
     stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
@@ -150,7 +202,6 @@ fn expect_no_packet(stream: &mut UnixStream, timeout: Duration) {
     }
 }
 
-#[cfg(feature = "ghostty-vt")]
 fn packet_read_would_wait(err: &std::io::Error) -> bool {
     matches!(err.kind(), std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut) || err.raw_os_error() == Some(libc::EINVAL)
 }
@@ -396,6 +447,47 @@ fn list_and_inspect_report_opaque_tags() {
 }
 
 #[test]
+fn list_selector_requires_exact_opaque_tag_matches() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create_with_options(
+            Some("alpha".into()),
+            Some(VtEngineKind::Passthrough),
+            None,
+            Some("zsh".into()),
+            cleat::session::SessionStartOptions {
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: cleat::vt::TerminalColors::default(),
+                tags: vec!["role=impl".into(), "task=99".into()],
+            },
+        )
+        .expect("create alpha");
+    service
+        .create_with_options(
+            Some("beta".into()),
+            Some(VtEngineKind::Passthrough),
+            None,
+            Some("zsh".into()),
+            cleat::session::SessionStartOptions {
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: cleat::vt::TerminalColors::default(),
+                tags: vec!["role=shepherd".into()],
+            },
+        )
+        .expect("create beta");
+    let cli = Cli::try_parse_from(["cleat", "list", "--selector", "role=impl", "--selector", "task=99"]).expect("parse list");
+
+    let output = cli::execute(cli, &service).expect("execute list").expect("list output");
+
+    assert!(output.contains("alpha"), "{output}");
+    assert!(!output.contains("beta"), "{output}");
+}
+
+#[test]
 fn tag_command_adds_and_removes_opaque_tags() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");
@@ -408,6 +500,89 @@ fn tag_command_adds_and_removes_opaque_tags() {
 
     assert_eq!(output, "task=99");
     assert_eq!(inspect.session.tags, vec!["task=99"]);
+}
+
+#[test]
+fn directory_subscription_filters_and_emits_lifecycle_deltas() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let selector = "role=impl".to_string();
+    service
+        .create_with_options(
+            Some("alpha".into()),
+            Some(VtEngineKind::Passthrough),
+            None,
+            Some("sleep 30".into()),
+            cleat::session::SessionStartOptions {
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: cleat::vt::TerminalColors::default(),
+                tags: vec![selector.clone()],
+            },
+        )
+        .expect("create alpha");
+    let mut stream = http_packet_stream_with_selectors(temp.path(), "alpha", std::slice::from_ref(&selector));
+    stream.set_read_timeout(Some(Duration::from_secs(2))).expect("set read timeout");
+    let hello_frame = PacketFrame::read(&mut stream).expect("read hello");
+    let directory_frame = PacketFrame::read(&mut stream).expect("read directory");
+
+    assert_eq!(hello_frame.channel, CHANNEL_CONTROL);
+    assert_eq!(hello_frame.msg_type, MSG_CONTROL_HELLO);
+    assert_eq!(directory_frame.channel, CHANNEL_CONTROL);
+    assert_eq!(directory_frame.msg_type, MSG_CONTROL_DIRECTORY_SNAPSHOT);
+    let snapshot = directory_frame.decode::<DirectorySnapshot>().expect("decode directory");
+    assert_eq!(snapshot.sessions.iter().map(|entry| entry.session_id.as_str()).collect::<Vec<_>>(), vec!["alpha"]);
+
+    service
+        .create_with_options(
+            Some("gamma".into()),
+            Some(VtEngineKind::Passthrough),
+            None,
+            Some("sleep 30".into()),
+            cleat::session::SessionStartOptions {
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: cleat::vt::TerminalColors::default(),
+                tags: vec![selector.clone()],
+            },
+        )
+        .expect("create gamma");
+    let delta = read_directory_delta_named(&mut stream, Duration::from_secs(30), "gamma create delta");
+    assert_eq!(delta.removed_session_ids, Vec::<String>::new());
+    assert_eq!(delta.upserted.iter().map(|entry| entry.session_id.as_str()).collect::<Vec<_>>(), vec!["gamma"]);
+
+    service.create(Some("beta".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create beta");
+    service.update_tags("beta", vec![selector.clone()], Vec::new()).expect("tag beta");
+    let delta = read_directory_delta_named(&mut stream, Duration::from_secs(30), "beta retag delta");
+    assert_eq!(delta.upserted.iter().map(|entry| entry.session_id.as_str()).collect::<Vec<_>>(), vec!["beta"]);
+
+    let (_info, attach) = service.attach(Some("beta".into()), None, None, None, true).expect("attach beta");
+    let delta = read_directory_delta_named(&mut stream, Duration::from_secs(30), "beta attach delta");
+    assert_eq!(delta.upserted[0].session_id, "beta");
+    assert_eq!(delta.upserted[0].controller_count, 1);
+    drop(attach);
+
+    service
+        .create_with_options(
+            Some("short".into()),
+            Some(VtEngineKind::Passthrough),
+            None,
+            Some("true".into()),
+            cleat::session::SessionStartOptions {
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: cleat::vt::TerminalColors::default(),
+                tags: vec![selector.clone()],
+            },
+        )
+        .expect("create short");
+    let delta = read_until_directory_remove(&mut stream, "short", Duration::from_secs(30));
+    assert_eq!(delta.removed_session_ids, vec!["short"]);
+
+    service.update_tags("alpha", Vec::new(), vec![selector]).expect("untag alpha");
+    let delta = read_until_directory_remove(&mut stream, "alpha", Duration::from_secs(30));
+    assert_eq!(delta.removed_session_ids, vec!["alpha"]);
 }
 
 #[test]
@@ -699,8 +874,26 @@ fn packet_connect_emits_hello_and_directory_snapshot() {
     assert_eq!(directory_frame.channel, CHANNEL_CONTROL);
     assert_eq!(directory_frame.msg_type, MSG_CONTROL_DIRECTORY_SNAPSHOT);
     assert_eq!(directory_frame.decode::<DirectorySnapshot>().expect("decode directory").sessions, vec![
-        cleat::packet::DirectoryEntry { session_id: "alpha".to_string(), tags: Vec::new(), cols: 80, rows: 24 },
-        cleat::packet::DirectoryEntry { session_id: "beta".to_string(), tags: Vec::new(), cols: 80, rows: 24 },
+        cleat::packet::DirectoryEntry {
+            session_id: "alpha".to_string(),
+            tags: Vec::new(),
+            state: "running".to_string(),
+            controller_count: 0,
+            watcher_count: 0,
+            recreatable: false,
+            cols: 80,
+            rows: 24,
+        },
+        cleat::packet::DirectoryEntry {
+            session_id: "beta".to_string(),
+            tags: Vec::new(),
+            state: "running".to_string(),
+            controller_count: 0,
+            watcher_count: 0,
+            recreatable: false,
+            cols: 80,
+            rows: 24,
+        },
     ]);
 }
 

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -368,6 +368,49 @@ fn list_json_reports_existing_sessions() {
 }
 
 #[test]
+fn list_and_inspect_report_opaque_tags() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create_with_options(
+            Some("alpha".into()),
+            Some(VtEngineKind::Passthrough),
+            None,
+            Some("zsh".into()),
+            cleat::session::SessionStartOptions {
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: cleat::vt::TerminalColors::default(),
+                tags: vec!["task=99".into(), "role=impl".into(), "role=impl".into()],
+            },
+        )
+        .expect("create alpha");
+    let cli = Cli::try_parse_from(["cleat", "list"]).expect("parse list");
+
+    let output = cli::execute(cli, &service).expect("execute list").expect("list output");
+    let listed = service.inspect("alpha").expect("inspect alpha");
+
+    assert!(output.contains("tags=role=impl,task=99"), "{output}");
+    assert_eq!(listed.session.tags, vec!["role=impl", "task=99"]);
+}
+
+#[test]
+fn tag_command_adds_and_removes_opaque_tags() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create alpha");
+    let cli = Cli::try_parse_from(["cleat", "tag", "alpha", "+role=impl", "+task=99", "-role=impl"]).expect("parse tag");
+
+    let output = cli::execute(cli, &service).expect("execute tag").expect("tag output");
+    let inspect = service.inspect("alpha").expect("inspect alpha");
+
+    assert_eq!(output, "task=99");
+    assert_eq!(inspect.session.tags, vec!["task=99"]);
+}
+
+#[test]
 fn list_reports_watch_only_session_as_detached() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");
@@ -656,8 +699,8 @@ fn packet_connect_emits_hello_and_directory_snapshot() {
     assert_eq!(directory_frame.channel, CHANNEL_CONTROL);
     assert_eq!(directory_frame.msg_type, MSG_CONTROL_DIRECTORY_SNAPSHOT);
     assert_eq!(directory_frame.decode::<DirectorySnapshot>().expect("decode directory").sessions, vec![
-        cleat::packet::DirectoryEntry { session_id: "alpha".to_string(), cols: 80, rows: 24 },
-        cleat::packet::DirectoryEntry { session_id: "beta".to_string(), cols: 80, rows: 24 },
+        cleat::packet::DirectoryEntry { session_id: "alpha".to_string(), tags: Vec::new(), cols: 80, rows: 24 },
+        cleat::packet::DirectoryEntry { session_id: "beta".to_string(), tags: Vec::new(), cols: 80, rows: 24 },
     ]);
 }
 

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -488,6 +488,31 @@ fn list_selector_requires_exact_opaque_tag_matches() {
 }
 
 #[test]
+fn list_defaults_to_selected_daemon_and_all_enumerates_every_daemon() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let other = service.with_daemon("other".to_string()).expect("other daemon");
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create alpha");
+    other.create(Some("beta".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create beta");
+
+    let default_sessions = service.list().expect("list default daemon");
+    let other_sessions = other.list().expect("list other daemon");
+    let all_sessions = service.list_all_with_selectors(&[]).expect("list all daemons");
+    let all_cli = Cli::try_parse_from(["cleat", "list", "--all"]).expect("parse list --all");
+    let all_output = cli::execute(all_cli, &service).expect("execute list --all").expect("list all output");
+
+    assert_eq!(default_sessions.iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), vec!["alpha"]);
+    assert_eq!(other_sessions.iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), vec!["beta"]);
+    assert_eq!(all_sessions.iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), vec!["alpha", "beta"]);
+    assert!(all_output.contains("alpha"), "{all_output}");
+    assert!(all_output.contains("beta"), "{all_output}");
+
+    service.kill("alpha").expect("kill alpha");
+    other.kill("beta").expect("kill beta");
+}
+
+#[test]
 fn tag_command_adds_and_removes_opaque_tags() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -528,6 +528,24 @@ fn tag_command_adds_and_removes_opaque_tags() {
 }
 
 #[test]
+fn tag_command_applies_mutations_in_cli_order() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create alpha");
+
+    let cli = Cli::try_parse_from(["cleat", "tag", "alpha", "-role=impl", "+role=impl"]).expect("parse remove then add");
+    let output = cli::execute(cli, &service).expect("execute remove then add").expect("tag output");
+    assert_eq!(output, "role=impl");
+    assert_eq!(service.inspect("alpha").expect("inspect alpha").session.tags, vec!["role=impl"]);
+
+    let cli = Cli::try_parse_from(["cleat", "tag", "alpha", "+role=impl", "-role=impl"]).expect("parse add then remove");
+    let output = cli::execute(cli, &service).expect("execute add then remove");
+    assert_eq!(output, None);
+    assert!(service.inspect("alpha").expect("inspect alpha").session.tags.is_empty());
+}
+
+#[test]
 fn directory_subscription_filters_and_emits_lifecycle_deltas() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Fixes #101. Phase 3b — closes the M:N core (ADR 0004 fully realized).

Implemented by a cleat-hosted codex from the locked scoping plan (four commits, each independently green on all four gates).

## Commits

1. `Add opaque session tags` — flat uninterpreted strings (constraint from flotilla-org/flotilla#634); `launch --tag` (repeatable), `cleat tag <id> [+t|-t]`, tags in inspect/list/`DirectoryEntry`.
2. `Stream directory deltas` — lifecycle events (create/end/retag/attach/watch/resize) push `DirectoryDelta` on channel 0; `cleat list --watch` probe; `--selector` (exact-match, ANDed) on one-shot and subscription.
3. `Complete daemon-scoped listing liveness` — daemon-level stale sweep, per-session-socket relics removed, `list --all` across daemon dirs.
4. `Update README for directory sessions` — Session Model rewritten (named multi-session daemons, layout v2, linger, recording-on-by-default per ADR 0002), command table gains the new surface.

## Live acceptance (run against this branch)

```
list --selector role=impl  → only the matching session, tags shown
list --watch               → snapshot (2 entries, control state + recreatable + tags)
                             upsert c            (created)
                             upsert c tags=ephemeral   (retagged)
                             remove c            (killed)
```

README contains zero occurrences of 'one daemon per session'.