### PR TITLE
Daemon packet backend: multiplexed FFI connection, viewport commands, channel roles, daemon self-fencing

### DIFF
--- a/crates/cleat/include/cleat_provider.h
+++ b/crates/cleat/include/cleat_provider.h
@@ -589,6 +589,10 @@ bool cleat_session_scroll_viewport(cleat_session *session,
  * same session.
  * dirty_rows is populated only when dirty is CLEAT_DIRTY_PARTIAL and the
  * provider knows exact dirty rows; otherwise dirty_row_count is zero.
+ * Always returns false for daemon-backed sessions: they are fed by render
+ * updates rather than snapshots, and no full-grid state is held client-side.
+ * Use cleat_session_render_update instead; the first update after a channel
+ * opens is full-dirty and carries the complete grid.
  */
 bool cleat_session_snapshot(cleat_session *session, cleat_snapshot *out);
 /*

--- a/crates/cleat/include/cleat_provider.h
+++ b/crates/cleat/include/cleat_provider.h
@@ -21,6 +21,10 @@ extern "C" {
 #define CLEAT_SESSION_STREAMING 1u
 #define CLEAT_SESSION_DISCONNECTED 2u
 #define CLEAT_SESSION_CLOSED 3u
+/* Attachment role (cleat_session_role / cleat_session_desc.role). */
+#define CLEAT_ROLE_UNKNOWN 0u
+#define CLEAT_ROLE_WATCHER 1u
+#define CLEAT_ROLE_CONTROLLER 2u
 #define CLEAT_INPUT_KEY 1u
 #define CLEAT_INPUT_TEXT 2u
 #define CLEAT_INPUT_MOUSE 3u
@@ -191,6 +195,13 @@ typedef struct cleat_session_desc {
      */
     const cleat_str *tags;
     size_t tag_count;
+    /*
+     * Daemon-backend only: requested attachment role. CLEAT_ROLE_UNKNOWN and
+     * CLEAT_ROLE_CONTROLLER request control (the daemon may grant watcher if
+     * another controller holds the session); CLEAT_ROLE_WATCHER attaches
+     * read-only. The granted role is reported by cleat_session_role.
+     */
+    uint32_t role;
 } cleat_session_desc;
 
 /*
@@ -518,6 +529,20 @@ bool cleat_session_id(const cleat_session *session, cleat_str *out);
  * recovers on its own), and CLOSED once the daemon reported the session gone.
  */
 uint32_t cleat_session_connection_state(const cleat_session *session);
+/*
+ * Granted attachment role (CLEAT_ROLE_*). In-process sessions are their own
+ * controllers. Daemon sessions report UNKNOWN until the daemon's grant
+ * arrives; the role can change later (another client may take control — the
+ * wake callback fires on the change). Watcher input, resize, and viewport
+ * commands are dropped daemon-side.
+ */
+uint32_t cleat_session_role(const cleat_session *session);
+/*
+ * Request the controller role, preempting another packet client's control if
+ * needed (a legacy `cleat attach` stream controller is never preempted). The
+ * grant lands asynchronously; poll cleat_session_role after wake.
+ */
+bool cleat_session_take_control(cleat_session *session);
 
 /* Updates row/column terminal size. Pixel geometry is updated separately. */
 bool cleat_session_resize(cleat_session *session, uint16_t cols, uint16_t rows);

--- a/crates/cleat/include/cleat_provider.h
+++ b/crates/cleat/include/cleat_provider.h
@@ -9,13 +9,18 @@
 extern "C" {
 #endif
 
-#define CLEAT_PROVIDER_ABI_VERSION 6u
+#define CLEAT_PROVIDER_ABI_VERSION 7u
 #define CLEAT_PROVIDER_BACKEND_MOCK 0u
 #define CLEAT_PROVIDER_BACKEND_IN_PROCESS 1u
 #define CLEAT_PROVIDER_BACKEND_DAEMON 2u
 #define CLEAT_PROVIDER_VT_DEFAULT 0u
 #define CLEAT_PROVIDER_VT_PASSTHROUGH 1u
 #define CLEAT_PROVIDER_VT_GHOSTTY 2u
+/* Transport state of a session (cleat_session_connection_state). */
+#define CLEAT_SESSION_CONNECTING 0u
+#define CLEAT_SESSION_STREAMING 1u
+#define CLEAT_SESSION_DISCONNECTED 2u
+#define CLEAT_SESSION_CLOSED 3u
 #define CLEAT_INPUT_KEY 1u
 #define CLEAT_INPUT_TEXT 2u
 #define CLEAT_INPUT_MOUSE 3u
@@ -133,12 +138,32 @@ typedef enum cleat_dirty_state {
     CLEAT_DIRTY_FULL = 2,
 } cleat_dirty_state;
 
+/* Borrowed, non-NUL-terminated UTF-8 slice. */
+typedef struct cleat_str {
+    const uint8_t *ptr;
+    size_t len;
+} cleat_str;
+
 typedef struct cleat_provider_desc {
     uint32_t abi_version;
     uint32_t requested_features;
     uint32_t backend;
     const uint8_t *runtime_root;
     size_t runtime_root_len;
+    /*
+     * Daemon-backend only: name of the daemon under the runtime root (NULL for
+     * the default daemon). One provider talks to one daemon over one
+     * multiplexed packet connection; open one provider per daemon.
+     */
+    const uint8_t *daemon_name;
+    size_t daemon_name_len;
+    /*
+     * Daemon-backend only: optional directory subscription tag selectors.
+     * AND-only exact match against opaque session tags; empty subscribes to
+     * every session on the daemon.
+     */
+    const cleat_str *directory_selectors;
+    size_t directory_selector_count;
 } cleat_provider_desc;
 
 typedef struct cleat_session_desc {
@@ -160,7 +185,36 @@ typedef struct cleat_session_desc {
     size_t id_len;
     bool record;
     const struct cleat_session_colors *colors;
+    /*
+     * Daemon-backend only: opaque tags attached at creation (client convention
+     * is key=value, e.g. "project=uishell"). Ignored by other backends.
+     */
+    const cleat_str *tags;
+    size_t tag_count;
 } cleat_session_desc;
+
+/*
+ * One entry of the daemon directory subscription. All cleat_str pointers
+ * borrow from the live directory and stay valid until
+ * cleat_provider_directory_release.
+ */
+typedef struct cleat_directory_entry {
+    cleat_str session_id;
+    cleat_str state;
+    const cleat_str *tags;
+    size_t tag_count;
+    uint32_t controller_count;
+    uint32_t watcher_count;
+    bool recreatable;
+    uint16_t cols;
+    uint16_t rows;
+} cleat_directory_entry;
+
+typedef struct cleat_directory {
+    uint64_t generation;
+    const cleat_directory_entry *entries;
+    size_t entry_count;
+} cleat_directory;
 
 typedef struct cleat_rgb {
     uint8_t r;
@@ -431,8 +485,39 @@ cleat_provider *cleat_provider_open(const cleat_provider_desc *desc);
 void cleat_provider_set_wake_callback(cleat_provider *provider, cleat_wake_fn *wake, void *user_data);
 void cleat_provider_close(cleat_provider *provider);
 
+/*
+ * Daemon directory subscription (Workspace Inventory feed). The generation
+ * counter starts at 0 before the first snapshot and bumps on every snapshot or
+ * delta (including retags); poll it and re-read the directory on change. Only
+ * one directory may be live per provider; release before requesting again.
+ * Entries are sorted by session id. Always 0/false for non-daemon providers.
+ */
+uint64_t cleat_provider_directory_generation(const cleat_provider *provider);
+bool cleat_provider_directory_snapshot(cleat_provider *provider, cleat_directory *out);
+void cleat_provider_directory_release(cleat_provider *provider, cleat_directory *directory);
+
 cleat_session *cleat_session_create(cleat_provider *provider, const cleat_session_desc *desc);
+/*
+ * Attach to an existing daemon session by id instead of creating one. Honors
+ * only id, cols, rows, and cell pixel sizes of the desc. If the session does
+ * not exist the daemon closes the channel and the session reports
+ * CLEAT_SESSION_CLOSED.
+ */
+cleat_session *cleat_session_attach(cleat_provider *provider, const cleat_session_desc *desc);
 void cleat_session_destroy(cleat_session *session);
+
+/*
+ * Daemon session id for attach-by-id and directory correlation (borrows from
+ * the session; valid until destroy). False for non-daemon sessions.
+ */
+bool cleat_session_id(const cleat_session *session, cleat_str *out);
+/*
+ * Transport state (CLEAT_SESSION_*). In-process sessions are always
+ * STREAMING. Daemon sessions report CONNECTING until the first render packet,
+ * DISCONNECTED while the connection is down (it reconnects with backoff and
+ * recovers on its own), and CLOSED once the daemon reported the session gone.
+ */
+uint32_t cleat_session_connection_state(const cleat_session *session);
 
 /* Updates row/column terminal size. Pixel geometry is updated separately. */
 bool cleat_session_resize(cleat_session *session, uint16_t cols, uint16_t rows);

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -1077,7 +1077,8 @@ fn run_packets_command(service: &SessionService, id: &str, count: usize) -> Resu
         return Err(format!("session {id} was not present in packet directory"));
     }
     const DEBUG_CHANNEL: u32 = 1;
-    client.open_channel(DEBUG_CHANNEL, id).map_err(|err| format!("open packet channel: {err}"))?;
+    // read-only probe: never steals input/resize authority from a real client
+    client.open_channel(DEBUG_CHANNEL, id, crate::packet::ChannelRole::Watcher).map_err(|err| format!("open packet channel: {err}"))?;
 
     let mut lines = Vec::with_capacity(count);
     let mut previous_modes = None;

--- a/crates/cleat/src/lib.rs
+++ b/crates/cleat/src/lib.rs
@@ -10,6 +10,7 @@ pub mod packet;
 pub mod platform;
 pub mod protocol;
 pub mod provider;
+mod provider_daemon;
 pub mod provider_ffi;
 pub mod recording;
 pub mod recreate;

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::provider::{TerminalInputEvent, TerminalRenderUpdate};
 
-pub const PROTOCOL_VERSION: u16 = 1;
+pub const PROTOCOL_VERSION: u16 = 2;
 pub const CHANNEL_CONTROL: u32 = 0;
 
 pub const MSG_CONTROL_HELLO: u8 = 1;
@@ -18,6 +18,8 @@ pub const MSG_SESSION_RENDER: u8 = 16;
 pub const MSG_SESSION_ACK: u8 = 17;
 pub const MSG_SESSION_INPUT: u8 = 18;
 pub const MSG_SESSION_RESIZE: u8 = 19;
+pub const MSG_SESSION_VIEWPORT: u8 = 20;
+pub const MSG_SESSION_ROLE: u8 = 21;
 
 const HEADER_LEN: usize = 9;
 pub const MAX_PACKET_PAYLOAD_LEN: usize = 4 * 1024 * 1024;
@@ -62,10 +64,39 @@ pub struct DirectoryEntry {
     pub rows: u16,
 }
 
+/// Attachment role of a session channel. One controller per session across
+/// packet and legacy stream clients: the controller's input, resize, and
+/// viewport commands are routed; watchers are read-only and never resize.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChannelRole {
+    Watcher,
+    Controller,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenChannel {
     pub channel: u32,
     pub session_id: String,
+    /// Requested role; the granted role arrives as a `RoleState` before the
+    /// initial render packet (a controller request may be granted Watcher).
+    pub role: ChannelRole,
+    /// Preempt an existing packet controller. Never preempts a legacy stream
+    /// controller (there is no way to demote a raw attach to read-only).
+    pub take: bool,
+}
+
+/// Client→server on an open session channel: request a role change.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleRequest {
+    pub role: ChannelRole,
+    pub take: bool,
+}
+
+/// Server→client on a session channel: the granted role, sent on open and on
+/// any later change (e.g. demotion because another client took control).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleState {
+    pub role: ChannelRole,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -99,6 +130,14 @@ pub struct Input {
 pub struct Resize {
     pub cols: u16,
     pub rows: u16,
+}
+
+/// Client→server viewport movement (scrollbar drag, keyboard paging). The
+/// resulting viewport/scrollbar state flows back through the next render
+/// packet rather than a reply message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Viewport {
+    pub command: crate::provider::ViewportCommand,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -174,8 +213,13 @@ impl<S: Read + Write> PacketClient<S> {
         Self { stream, buffer: Vec::new() }
     }
 
-    pub fn open_channel(&mut self, channel: u32, session_id: &str) -> std::io::Result<()> {
-        self.write(CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL, &OpenChannel { channel, session_id: session_id.to_string() })
+    pub fn open_channel(&mut self, channel: u32, session_id: &str, role: ChannelRole) -> std::io::Result<()> {
+        self.write(CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL, &OpenChannel {
+            channel,
+            session_id: session_id.to_string(),
+            role,
+            take: false,
+        })
     }
 
     pub fn close_channel(&mut self, channel: u32, reason: Option<String>) -> std::io::Result<()> {

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -34,6 +34,13 @@ impl ControlHello {
     pub fn current() -> Self {
         Self { version: PROTOCOL_VERSION, min_supported_version: PROTOCOL_VERSION }
     }
+
+    /// The hello advertises the version range this daemon speaks,
+    /// `min_supported_version..=version`. A client is compatible when its own
+    /// protocol version falls inside that range.
+    pub fn accepts(&self, client_version: u16) -> bool {
+        (self.min_supported_version..=self.version).contains(&client_version)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -284,6 +291,22 @@ impl<S: Read + Write> PacketClient<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hello_accepts_client_versions_inside_advertised_range() {
+        let hello = ControlHello { version: 4, min_supported_version: 2 };
+
+        assert!(hello.accepts(2));
+        assert!(hello.accepts(3));
+        assert!(hello.accepts(4));
+        assert!(!hello.accepts(1));
+        assert!(!hello.accepts(5));
+    }
+
+    #[test]
+    fn current_hello_accepts_current_protocol_version() {
+        assert!(ControlHello::current().accepts(PROTOCOL_VERSION));
+    }
 
     #[test]
     fn codec_round_trips_postcard_control_payloads() {

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -27,9 +27,10 @@ use http::StatusCode;
 use crate::{
     http_uds,
     packet::{
-        ControlError, ControlHello, DirectoryDelta, DirectoryEntry, DirectorySnapshot, OpenChannel, PacketFrame, RenderPacket,
+        ChannelRole, ControlError, ControlHello, DirectoryDelta, DirectoryEntry, DirectorySnapshot, OpenChannel, PacketFrame, RenderPacket,
         CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_DELTA, MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_ERROR, MSG_CONTROL_HELLO,
-        MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT, MSG_SESSION_RENDER, MSG_SESSION_RESIZE, PROTOCOL_VERSION,
+        MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT, MSG_SESSION_RENDER, MSG_SESSION_RESIZE, MSG_SESSION_ROLE,
+        PROTOCOL_VERSION,
     },
     platform::ipc::{try_connect_session_stream, SessionStream},
     provider::{
@@ -119,6 +120,11 @@ pub(crate) struct ChannelSlot {
     /// Size the caller wants; re-asserted after every reconnect.
     pub desired_cols: u16,
     pub desired_rows: u16,
+    /// Role the caller wants; requested on every (re)open with take=false —
+    /// control lost across a disconnect is re-taken explicitly, not silently.
+    pub desired_role: ChannelRole,
+    /// Role the daemon granted (None until the first RoleState arrives).
+    pub granted_role: Option<ChannelRole>,
     /// Set when the daemon reported an error for this channel (e.g. the
     /// session went away).
     pub closed: Option<String>,
@@ -237,14 +243,22 @@ impl DaemonConnection {
 
     /// Register a session channel. The open frame is sent immediately when
     /// connected; otherwise (and after every reconnect) the reader thread
-    /// replays it, and the daemon answers with a full render packet.
-    pub(crate) fn open_session_channel(&self, session_id: String, cols: u16, rows: u16) -> (u32, Arc<Mutex<ChannelSlot>>) {
+    /// replays it, and the daemon answers with a role grant + full render.
+    pub(crate) fn open_session_channel(
+        &self,
+        session_id: String,
+        cols: u16,
+        rows: u16,
+        role: ChannelRole,
+    ) -> (u32, Arc<Mutex<ChannelSlot>>) {
         let slot = Arc::new(Mutex::new(ChannelSlot {
             session_id: session_id.clone(),
             pending: None,
             last: LastKnown::new(cols, rows),
             desired_cols: cols,
             desired_rows: rows,
+            desired_role: role,
+            granted_role: None,
             closed: None,
         }));
         let (channel, connected) = {
@@ -255,13 +269,25 @@ impl DaemonConnection {
             (channel, state.connected)
         };
         if connected {
-            let _ = self.send_open_frame(channel, &session_id, cols, rows);
+            let _ = self.send_open_frame(channel, &session_id, cols, rows, role);
         } else {
             // The caller may have just spawned the daemon (session create);
             // cut the reconnect backoff short.
             self.retry_now.store(true, Ordering::SeqCst);
         }
         (channel, slot)
+    }
+
+    /// Request a role change on an open channel (take=true preempts another
+    /// packet controller). The grant arrives asynchronously as a RoleState.
+    pub(crate) fn request_role(&self, channel: u32, role: ChannelRole, take: bool) -> Result<(), String> {
+        {
+            let state = self.state.lock().expect("connection state lock");
+            if let Some(slot) = state.channels.get(&channel) {
+                slot.lock().expect("channel slot lock").desired_role = role;
+            }
+        }
+        self.send_frame_result(PacketFrame::new(channel, MSG_SESSION_ROLE, &crate::packet::RoleRequest { role, take }))
     }
 
     pub(crate) fn close_session_channel(&self, channel: u32) {
@@ -301,17 +327,24 @@ impl DaemonConnection {
         self.send_frame_result(PacketFrame::new(channel, MSG_SESSION_RESIZE, &crate::packet::Resize { cols, rows }))
     }
 
+    pub(crate) fn send_viewport(&self, channel: u32, command: crate::provider::ViewportCommand) -> Result<(), String> {
+        self.send_frame_result(PacketFrame::new(channel, crate::packet::MSG_SESSION_VIEWPORT, &crate::packet::Viewport { command }))
+    }
+
     pub(crate) fn send_ack(&self, channel: u32, generation: u64) -> Result<(), String> {
         self.send_frame_result(PacketFrame::new(channel, MSG_SESSION_ACK, &crate::packet::Ack { generation }))
     }
 
-    fn send_open_frame(&self, channel: u32, session_id: &str, cols: u16, rows: u16) -> Result<(), String> {
+    fn send_open_frame(&self, channel: u32, session_id: &str, cols: u16, rows: u16, role: ChannelRole) -> Result<(), String> {
         self.send_frame_result(PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL, &OpenChannel {
             channel,
             session_id: session_id.to_string(),
+            role,
+            take: false,
         }))?;
         // The daemon does not resize on channel open; assert the size this
         // client wants so a session created detached comes up at view size.
+        // (A watcher's resize is dropped daemon-side, which is the intent.)
         self.send_resize(channel, cols, rows)
     }
 
@@ -380,18 +413,20 @@ impl DaemonConnection {
             let mut state = self.state.lock().expect("connection state lock");
             state.connected = true;
             state.directory.replace(snapshot);
-            let reopen: Vec<(u32, String, u16, u16)> = state
+            let reopen: Vec<(u32, String, u16, u16, ChannelRole)> = state
                 .channels
                 .iter()
                 .map(|(channel, slot)| {
-                    let slot = slot.lock().expect("channel slot lock");
-                    (*channel, slot.session_id.clone(), slot.desired_cols, slot.desired_rows)
+                    let mut slot = slot.lock().expect("channel slot lock");
+                    // the old grant died with the connection
+                    slot.granted_role = None;
+                    (*channel, slot.session_id.clone(), slot.desired_cols, slot.desired_rows, slot.desired_role)
                 })
                 .collect();
             (reopen, std::mem::take(&mut state.queued_input))
         };
-        for (channel, session_id, cols, rows) in reopen {
-            let _ = self.send_open_frame(channel, &session_id, cols, rows);
+        for (channel, session_id, cols, rows, role) in reopen {
+            let _ = self.send_open_frame(channel, &session_id, cols, rows, role);
         }
         for frame in queued_input {
             let _ = self.send_frame_result(Ok(frame));
@@ -452,6 +487,18 @@ impl DaemonConnection {
                         let mut slot = slot.lock().expect("channel slot lock");
                         slot.pending = Some(packet.update);
                         drop(slot);
+                        (self.wake)();
+                    }
+                }
+            }
+            (channel, MSG_SESSION_ROLE) if channel != CHANNEL_CONTROL => {
+                if let Ok(role_state) = frame.decode::<crate::packet::RoleState>() {
+                    let slot = {
+                        let state = self.state.lock().expect("connection state lock");
+                        state.channels.get(&channel).cloned()
+                    };
+                    if let Some(slot) = slot {
+                        slot.lock().expect("channel slot lock").granted_role = Some(role_state.role);
                         (self.wake)();
                     }
                 }
@@ -636,10 +683,15 @@ mod tests {
         wait_until(|| connection.is_connected());
         assert_eq!(connection.with_directory(|directory| directory.entries.len()), 1);
 
-        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 100, 40);
+        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 100, 40, ChannelRole::Controller);
         let open = PacketFrame::read(&mut server).expect("open frame");
         assert_eq!((open.channel, open.msg_type), (CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL));
-        assert_eq!(open.decode::<OpenChannel>().expect("open payload"), OpenChannel { channel, session_id: "alpha".to_string() });
+        assert_eq!(open.decode::<OpenChannel>().expect("open payload"), OpenChannel {
+            channel,
+            session_id: "alpha".to_string(),
+            role: ChannelRole::Controller,
+            take: false
+        });
         let resize = PacketFrame::read(&mut server).expect("resize frame");
         assert_eq!((resize.channel, resize.msg_type), (channel, MSG_SESSION_RESIZE));
         assert_eq!(resize.decode::<Resize>().expect("resize payload"), Resize { cols: 100, rows: 40 });
@@ -659,6 +711,13 @@ mod tests {
         assert_eq!((ack.channel, ack.msg_type), (channel, MSG_SESSION_ACK));
         assert_eq!(ack.decode::<Ack>().expect("ack payload"), Ack { generation: 7 });
 
+        connection.send_viewport(channel, crate::provider::ViewportCommand::DeltaRows(-12)).expect("viewport");
+        let viewport = PacketFrame::read(&mut server).expect("viewport frame");
+        assert_eq!((viewport.channel, viewport.msg_type), (channel, crate::packet::MSG_SESSION_VIEWPORT));
+        assert_eq!(viewport.decode::<crate::packet::Viewport>().expect("viewport payload"), crate::packet::Viewport {
+            command: crate::provider::ViewportCommand::DeltaRows(-12)
+        });
+
         connection.shutdown();
     }
 
@@ -670,7 +729,7 @@ mod tests {
 
         let mut server = daemon.accept(vec![directory_entry("alpha")]);
         wait_until(|| connection.is_connected());
-        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 80, 24);
+        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 80, 24, ChannelRole::Controller);
         let _open = PacketFrame::read(&mut server).expect("open frame");
         let _resize = PacketFrame::read(&mut server).expect("resize frame");
 
@@ -687,7 +746,12 @@ mod tests {
         let mut server = daemon.accept(vec![directory_entry("alpha")]);
         wait_until(|| connection.is_connected());
         let open = PacketFrame::read(&mut server).expect("reopen frame");
-        assert_eq!(open.decode::<OpenChannel>().expect("reopen payload"), OpenChannel { channel, session_id: "alpha".to_string() });
+        assert_eq!(open.decode::<OpenChannel>().expect("reopen payload"), OpenChannel {
+            channel,
+            session_id: "alpha".to_string(),
+            role: ChannelRole::Controller,
+            take: false
+        });
         let resize = PacketFrame::read(&mut server).expect("resize frame");
         assert_eq!(resize.decode::<Resize>().expect("resize payload"), Resize { cols: 120, rows: 50 });
         let input = PacketFrame::read(&mut server).expect("queued input frame");

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -775,6 +775,52 @@ mod tests {
     }
 
     #[test]
+    fn reconnect_skips_closed_channels() {
+        let (_temp, layout) = test_layout();
+        let daemon = FakeDaemon::bind(&layout);
+        let connection = DaemonConnection::open(layout, Vec::new(), Arc::new(|| {}));
+
+        let mut server = daemon.accept(vec![directory_entry("alpha"), directory_entry("beta")]);
+        wait_until(|| connection.is_connected());
+        let (closed_channel, closed_slot) = connection.open_session_channel("alpha".to_string(), 80, 24, ChannelRole::Controller);
+        let (live_channel, _live_slot) = connection.open_session_channel("beta".to_string(), 80, 24, ChannelRole::Controller);
+        for _ in 0..4 {
+            PacketFrame::read(&mut server).expect("initial open/resize frames");
+        }
+
+        // The daemon reports alpha's channel dead (e.g. the session exited).
+        PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_ERROR, &crate::packet::ControlError {
+            channel: closed_channel,
+            message: "session alpha exited".to_string(),
+        })
+        .expect("control error frame")
+        .write(&mut server)
+        .expect("write control error");
+        wait_until(|| closed_slot.lock().expect("slot").closed.is_some());
+
+        drop(server);
+        wait_until(|| !connection.is_connected());
+
+        // Only the live channel is reopened; a closed channel would just
+        // re-error on every reconnect until the FFI caller destroys it.
+        let mut server = daemon.accept(vec![directory_entry("beta")]);
+        wait_until(|| connection.is_connected());
+        let open = PacketFrame::read(&mut server).expect("reopen frame");
+        assert_eq!(open.decode::<OpenChannel>().expect("reopen payload"), OpenChannel {
+            channel: live_channel,
+            session_id: "beta".to_string(),
+            role: ChannelRole::Controller,
+            take: false
+        });
+        let resize = PacketFrame::read(&mut server).expect("resize frame");
+        assert_eq!((resize.channel, resize.msg_type), (live_channel, MSG_SESSION_RESIZE));
+        server.set_read_timeout(Some(std::time::Duration::from_millis(100))).expect("set read timeout");
+        assert!(PacketFrame::read(&mut server).is_err(), "closed channel must not be reopened");
+
+        connection.shutdown();
+    }
+
+    #[test]
     fn directory_deltas_apply_and_bump_generation() {
         let (_temp, layout) = test_layout();
         let daemon = FakeDaemon::bind(&layout);

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -560,8 +560,11 @@ pub(crate) fn connect_packet_stream(layout: &RuntimeLayout, selectors: &[String]
         return Err("packet stream did not start with control hello".to_string());
     }
     let hello = hello.decode::<ControlHello>().map_err(|err| format!("decode packet hello: {err}"))?;
-    if hello.version != PROTOCOL_VERSION {
-        return Err(format!("unsupported packet protocol version {}", hello.version));
+    if !hello.accepts(PROTOCOL_VERSION) {
+        return Err(format!(
+            "incompatible packet protocol: daemon supports {}..={}, client speaks {}",
+            hello.min_supported_version, hello.version, PROTOCOL_VERSION
+        ));
     }
 
     let directory = PacketFrame::read(&mut stream).map_err(|err| format!("read packet directory: {err}"))?;

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -524,3 +524,216 @@ pub(crate) fn connect_packet_stream(layout: &RuntimeLayout, selectors: &[String]
     let directory = directory.decode::<DirectorySnapshot>().map_err(|err| format!("decode packet directory: {err}"))?;
     Ok((stream, directory))
 }
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::{
+        io::Read,
+        os::unix::net::{UnixListener, UnixStream},
+        sync::atomic::AtomicUsize,
+        time::Instant,
+    };
+
+    use super::*;
+    use crate::packet::{Ack, Input, Resize};
+
+    fn test_layout() -> (tempfile::TempDir, RuntimeLayout) {
+        let temp = tempfile::Builder::new().prefix("cleat-pd-").tempdir_in("/tmp").expect("tempdir");
+        let layout = RuntimeLayout::new(temp.path().to_path_buf());
+        layout.ensure_daemon_dirs().expect("daemon dirs");
+        (temp, layout)
+    }
+
+    struct FakeDaemon {
+        listener: UnixListener,
+    }
+
+    impl FakeDaemon {
+        fn bind(layout: &RuntimeLayout) -> Self {
+            let _ = std::fs::remove_file(layout.socket_path());
+            Self { listener: UnixListener::bind(layout.socket_path()).expect("bind fake daemon socket") }
+        }
+
+        /// Accept a connection and drive the server half of the upgrade.
+        fn accept(&self, sessions: Vec<DirectoryEntry>) -> UnixStream {
+            let (mut stream, _) = self.listener.accept().expect("accept");
+            // Consume the upgrade request: head, then Content-Length body.
+            let mut buffer = Vec::new();
+            let header_end = loop {
+                let mut chunk = [0u8; 1024];
+                let n = stream.read(&mut chunk).expect("read upgrade request");
+                assert!(n > 0, "client hung up during upgrade");
+                buffer.extend_from_slice(&chunk[..n]);
+                if let Some(pos) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            };
+            let head = String::from_utf8_lossy(&buffer[..header_end]).to_string();
+            assert!(head.contains("Upgrade: cleat-packet/1"), "missing upgrade token in: {head}");
+            let content_length: usize = head
+                .lines()
+                .find_map(|line| line.to_ascii_lowercase().strip_prefix("content-length:").map(|value| value.trim().parse().unwrap()))
+                .expect("content-length header");
+            while buffer.len() < header_end + content_length {
+                let mut chunk = [0u8; 1024];
+                let n = stream.read(&mut chunk).expect("read upgrade body");
+                assert!(n > 0);
+                buffer.extend_from_slice(&chunk[..n]);
+            }
+            stream.write_all(b"HTTP/1.1 101 Switching Protocols\r\n\r\n").expect("write 101");
+            PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_HELLO, &ControlHello::current())
+                .expect("hello frame")
+                .write(&mut stream)
+                .expect("write hello");
+            PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT, &DirectorySnapshot { sessions })
+                .expect("snapshot frame")
+                .write(&mut stream)
+                .expect("write snapshot");
+            stream
+        }
+    }
+
+    fn directory_entry(session_id: &str) -> DirectoryEntry {
+        DirectoryEntry {
+            session_id: session_id.to_string(),
+            tags: vec!["project=uishell".to_string()],
+            state: "running".to_string(),
+            controller_count: 0,
+            watcher_count: 0,
+            recreatable: false,
+            cols: 80,
+            rows: 24,
+        }
+    }
+
+    fn render_update(generation: u64) -> TerminalRenderUpdate {
+        TerminalRenderUpdate { render_generation: generation, cols: 80, rows: 24, dirty: DirtyState::Full, ..Default::default() }
+    }
+
+    fn wait_until(mut condition: impl FnMut() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !condition() {
+            assert!(Instant::now() < deadline, "condition not met within deadline");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[test]
+    fn connection_opens_channels_streams_renders_and_acks_on_consumption() {
+        let (_temp, layout) = test_layout();
+        let daemon = FakeDaemon::bind(&layout);
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let wake_count = Arc::clone(&wakes);
+        let connection = DaemonConnection::open(
+            layout,
+            Vec::new(),
+            Arc::new(move || {
+                wake_count.fetch_add(1, Ordering::SeqCst);
+            }),
+        );
+
+        let mut server = daemon.accept(vec![directory_entry("alpha")]);
+        wait_until(|| connection.is_connected());
+        assert_eq!(connection.with_directory(|directory| directory.entries.len()), 1);
+
+        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 100, 40);
+        let open = PacketFrame::read(&mut server).expect("open frame");
+        assert_eq!((open.channel, open.msg_type), (CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL));
+        assert_eq!(open.decode::<OpenChannel>().expect("open payload"), OpenChannel { channel, session_id: "alpha".to_string() });
+        let resize = PacketFrame::read(&mut server).expect("resize frame");
+        assert_eq!((resize.channel, resize.msg_type), (channel, MSG_SESSION_RESIZE));
+        assert_eq!(resize.decode::<Resize>().expect("resize payload"), Resize { cols: 100, rows: 40 });
+
+        PacketFrame::new(channel, MSG_SESSION_RENDER, &RenderPacket { update: render_update(7) })
+            .expect("render frame")
+            .write(&mut server)
+            .expect("write render");
+        wait_until(|| slot.lock().expect("slot").pending.is_some());
+        assert_eq!(slot.lock().expect("slot").dirty(), DirtyState::Full);
+
+        // Consume like the FFI does: take pending, absorb, ack.
+        let update = slot.lock().expect("slot").pending.take().expect("pending update");
+        slot.lock().expect("slot").last.absorb(&update);
+        connection.send_ack(channel, update.render_generation).expect("ack");
+        let ack = PacketFrame::read(&mut server).expect("ack frame");
+        assert_eq!((ack.channel, ack.msg_type), (channel, MSG_SESSION_ACK));
+        assert_eq!(ack.decode::<Ack>().expect("ack payload"), Ack { generation: 7 });
+
+        connection.shutdown();
+    }
+
+    #[test]
+    fn reconnect_reopens_channels_reasserts_size_and_flushes_queued_input() {
+        let (_temp, layout) = test_layout();
+        let daemon = FakeDaemon::bind(&layout);
+        let connection = DaemonConnection::open(layout, Vec::new(), Arc::new(|| {}));
+
+        let mut server = daemon.accept(vec![directory_entry("alpha")]);
+        wait_until(|| connection.is_connected());
+        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 80, 24);
+        let _open = PacketFrame::read(&mut server).expect("open frame");
+        let _resize = PacketFrame::read(&mut server).expect("resize frame");
+
+        // Daemon connection drops (e.g. lid close); input typed while down is
+        // queued, and a resize records the new desired size.
+        drop(server);
+        wait_until(|| !connection.is_connected());
+        if let Ok(mut slot) = slot.lock() {
+            slot.desired_cols = 120;
+            slot.desired_rows = 50;
+        }
+        connection.send_input(channel, TerminalInputEvent::RawBytes(b"queued".to_vec())).expect("queue input while down");
+
+        let mut server = daemon.accept(vec![directory_entry("alpha")]);
+        wait_until(|| connection.is_connected());
+        let open = PacketFrame::read(&mut server).expect("reopen frame");
+        assert_eq!(open.decode::<OpenChannel>().expect("reopen payload"), OpenChannel { channel, session_id: "alpha".to_string() });
+        let resize = PacketFrame::read(&mut server).expect("resize frame");
+        assert_eq!(resize.decode::<Resize>().expect("resize payload"), Resize { cols: 120, rows: 50 });
+        let input = PacketFrame::read(&mut server).expect("queued input frame");
+        assert_eq!((input.channel, input.msg_type), (channel, MSG_SESSION_INPUT));
+        assert_eq!(input.decode::<Input>().expect("input payload"), Input { event: TerminalInputEvent::RawBytes(b"queued".to_vec()) });
+
+        connection.shutdown();
+    }
+
+    #[test]
+    fn directory_deltas_apply_and_bump_generation() {
+        let (_temp, layout) = test_layout();
+        let daemon = FakeDaemon::bind(&layout);
+        let connection = DaemonConnection::open(layout, Vec::new(), Arc::new(|| {}));
+
+        let mut server = daemon.accept(vec![directory_entry("alpha")]);
+        wait_until(|| connection.is_connected());
+        let first_generation = connection.with_directory(|directory| directory.generation);
+
+        let mut retagged = directory_entry("alpha");
+        retagged.tags = vec!["project=uishell".to_string(), "purpose=test".to_string()];
+        PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_DELTA, &DirectoryDelta {
+            upserted: vec![retagged, directory_entry("beta")],
+            removed_session_ids: Vec::new(),
+        })
+        .expect("delta frame")
+        .write(&mut server)
+        .expect("write delta");
+
+        wait_until(|| connection.with_directory(|directory| directory.generation > first_generation));
+        connection.with_directory(|directory| {
+            assert_eq!(directory.entries.len(), 2);
+            assert_eq!(directory.entries["alpha"].tags.len(), 2);
+        });
+
+        PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_DELTA, &DirectoryDelta {
+            upserted: Vec::new(),
+            removed_session_ids: vec!["alpha".to_string()],
+        })
+        .expect("remove delta")
+        .write(&mut server)
+        .expect("write remove delta");
+
+        wait_until(|| connection.with_directory(|directory| !directory.entries.contains_key("alpha")));
+        assert_eq!(connection.with_directory(|directory| directory.entries.len()), 1);
+
+        connection.shutdown();
+    }
+}

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -1,0 +1,526 @@
+//! Packet-connection daemon backend for the provider FFI.
+//!
+//! One multiplexed connection per daemon: channel 0 carries the directory
+//! subscription (snapshot + live deltas), non-zero channels carry per-session
+//! render packets down and input/resize/ack packets up. Render delivery is
+//! ack-gated server-side (one un-acked packet in flight), so a slow consumer
+//! receives coalesced state and can never stall the terminal.
+//!
+//! A dedicated reader thread owns the connection: it (re)connects with
+//! backoff, re-opens session channels after a reconnect (the daemon responds
+//! with a full render), applies directory deltas, and parks incoming render
+//! updates in per-channel slots for the FFI caller to consume.
+
+use std::{
+    collections::HashMap,
+    io::Write,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread::JoinHandle,
+    time::Duration,
+};
+
+use http::StatusCode;
+
+use crate::{
+    http_uds,
+    packet::{
+        ControlError, ControlHello, DirectoryDelta, DirectoryEntry, DirectorySnapshot, OpenChannel, PacketFrame, RenderPacket,
+        CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_DELTA, MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_ERROR, MSG_CONTROL_HELLO,
+        MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT, MSG_SESSION_RENDER, MSG_SESSION_RESIZE, PROTOCOL_VERSION,
+    },
+    platform::ipc::{try_connect_session_stream, SessionStream},
+    provider::{
+        DirtyState, TerminalCursor, TerminalInputEvent, TerminalRenderUpdate, TerminalRenderUpdateOpKind, TerminalScrollbarState,
+        TerminalViewportKind,
+    },
+    runtime::RuntimeLayout,
+    vt,
+};
+
+pub(crate) type WakeFn = Arc<dyn Fn() + Send + Sync + 'static>;
+
+const RECONNECT_BACKOFF_START: Duration = Duration::from_millis(100);
+const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(2);
+const BACKOFF_POLL_STEP: Duration = Duration::from_millis(10);
+/// Input events queued while the connection is down (they flush after the
+/// session channels are re-opened). Beyond this the send reports failure.
+const MAX_QUEUED_INPUT_FRAMES: usize = 1024;
+
+/// State the last consumed render packet left behind. Used to answer
+/// scrollbar/extent queries between packets and to synthesize a clean update
+/// when the caller asks for one while nothing is pending.
+#[derive(Clone, Debug)]
+pub(crate) struct LastKnown {
+    pub cols: u16,
+    pub rows: u16,
+    pub viewport_kind: TerminalViewportKind,
+    pub scrollback_offset_rows: u64,
+    pub scrollbar: TerminalScrollbarState,
+    pub terminal_modes: vt::TerminalModeState,
+    pub cursor: TerminalCursor,
+    pub render_generation: u64,
+}
+
+impl LastKnown {
+    fn new(cols: u16, rows: u16) -> Self {
+        Self {
+            cols,
+            rows,
+            viewport_kind: TerminalViewportKind::LiveNormal,
+            scrollback_offset_rows: 0,
+            scrollbar: TerminalScrollbarState::for_live_viewport(TerminalViewportKind::LiveNormal, rows),
+            terminal_modes: vt::TerminalModeState::default(),
+            cursor: TerminalCursor::default(),
+            render_generation: 0,
+        }
+    }
+
+    pub(crate) fn absorb(&mut self, update: &TerminalRenderUpdate) {
+        self.cols = update.cols;
+        self.rows = update.rows;
+        self.viewport_kind = update.viewport_kind;
+        self.scrollback_offset_rows = update.scrollback_offset_rows;
+        self.scrollbar = update.scrollbar;
+        self.terminal_modes = update.terminal_modes;
+        self.cursor = update.cursor;
+        self.render_generation = update.render_generation;
+    }
+
+    pub(crate) fn clean_update(&self) -> TerminalRenderUpdate {
+        TerminalRenderUpdate {
+            cols: self.cols,
+            rows: self.rows,
+            geometry: Default::default(),
+            viewport_kind: self.viewport_kind,
+            scrollback_offset_rows: self.scrollback_offset_rows,
+            scrollbar: self.scrollbar,
+            terminal_modes: self.terminal_modes,
+            render_generation: self.render_generation,
+            cursor: self.cursor,
+            dirty: DirtyState::Clean,
+            ops: Vec::new(),
+            image_resources: Vec::new(),
+            image_placements: Vec::new(),
+        }
+    }
+}
+
+/// Per-session-channel state shared between the reader thread and the FFI
+/// caller.
+pub(crate) struct ChannelSlot {
+    pub session_id: String,
+    /// Latest un-consumed render packet. The ack-gated protocol guarantees at
+    /// most one arrives before we ack, and we ack on consumption.
+    pub pending: Option<TerminalRenderUpdate>,
+    pub last: LastKnown,
+    /// Size the caller wants; re-asserted after every reconnect.
+    pub desired_cols: u16,
+    pub desired_rows: u16,
+    /// Set when the daemon reported an error for this channel (e.g. the
+    /// session went away).
+    pub closed: Option<String>,
+}
+
+impl ChannelSlot {
+    pub(crate) fn dirty(&self) -> DirtyState {
+        match &self.pending {
+            None => DirtyState::Clean,
+            Some(update) => update_dirty_state(update),
+        }
+    }
+}
+
+fn update_dirty_state(update: &TerminalRenderUpdate) -> DirtyState {
+    let full = update.dirty == DirtyState::Full
+        || update.ops.iter().any(|op| op.kind == TerminalRenderUpdateOpKind::FullVisibleReplace)
+        || update.ops.iter().any(|op| op.kind == TerminalRenderUpdateOpKind::ScrollCopy);
+    if full {
+        DirtyState::Full
+    } else {
+        DirtyState::Partial
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct DirectoryState {
+    pub entries: HashMap<String, DirectoryEntry>,
+    /// Bumped on every snapshot or delta application; FFI callers poll this to
+    /// notice changes and re-read the whole (small) list.
+    pub generation: u64,
+    /// True once the first snapshot has been received.
+    pub populated: bool,
+}
+
+impl DirectoryState {
+    fn replace(&mut self, snapshot: DirectorySnapshot) {
+        self.entries = snapshot.sessions.into_iter().map(|entry| (entry.session_id.clone(), entry)).collect();
+        self.generation = self.generation.wrapping_add(1);
+        self.populated = true;
+    }
+
+    fn apply_delta(&mut self, delta: DirectoryDelta) {
+        for entry in delta.upserted {
+            self.entries.insert(entry.session_id.clone(), entry);
+        }
+        for session_id in delta.removed_session_ids {
+            self.entries.remove(&session_id);
+        }
+        self.generation = self.generation.wrapping_add(1);
+    }
+}
+
+struct ConnectionState {
+    connected: bool,
+    next_channel: u32,
+    channels: HashMap<u32, Arc<Mutex<ChannelSlot>>>,
+    directory: DirectoryState,
+    queued_input: Vec<PacketFrame>,
+}
+
+/// One multiplexed packet connection to a named daemon, shared by every
+/// session the provider opens against it.
+pub(crate) struct DaemonConnection {
+    layout: RuntimeLayout,
+    selectors: Vec<String>,
+    wake: WakeFn,
+    stop: AtomicBool,
+    /// Interrupts the reconnect backoff sleep; set when a caller has reason to
+    /// believe the daemon just became reachable (e.g. it spawned it).
+    retry_now: AtomicBool,
+    writer: Mutex<Option<SessionStream>>,
+    state: Mutex<ConnectionState>,
+    reader: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl DaemonConnection {
+    pub(crate) fn open(layout: RuntimeLayout, selectors: Vec<String>, wake: WakeFn) -> Arc<Self> {
+        let connection = Arc::new(Self {
+            layout,
+            selectors,
+            wake,
+            stop: AtomicBool::new(false),
+            retry_now: AtomicBool::new(false),
+            writer: Mutex::new(None),
+            state: Mutex::new(ConnectionState {
+                connected: false,
+                next_channel: 1,
+                channels: HashMap::new(),
+                directory: DirectoryState::default(),
+                queued_input: Vec::new(),
+            }),
+            reader: Mutex::new(None),
+        });
+        let thread_connection = Arc::clone(&connection);
+        let handle = std::thread::Builder::new()
+            .name(format!("cleat-daemon-io:{}", thread_connection.layout.daemon_name()))
+            .spawn(move || thread_connection.reader_loop())
+            .expect("spawn daemon connection reader thread");
+        *connection.reader.lock().expect("reader handle lock") = Some(handle);
+        connection
+    }
+
+    pub(crate) fn layout(&self) -> &RuntimeLayout {
+        &self.layout
+    }
+
+    pub(crate) fn is_connected(&self) -> bool {
+        self.state.lock().map(|state| state.connected).unwrap_or(false)
+    }
+
+    pub(crate) fn with_directory<R>(&self, read: impl FnOnce(&DirectoryState) -> R) -> R {
+        let state = self.state.lock().expect("connection state lock");
+        read(&state.directory)
+    }
+
+    /// Register a session channel. The open frame is sent immediately when
+    /// connected; otherwise (and after every reconnect) the reader thread
+    /// replays it, and the daemon answers with a full render packet.
+    pub(crate) fn open_session_channel(&self, session_id: String, cols: u16, rows: u16) -> (u32, Arc<Mutex<ChannelSlot>>) {
+        let slot = Arc::new(Mutex::new(ChannelSlot {
+            session_id: session_id.clone(),
+            pending: None,
+            last: LastKnown::new(cols, rows),
+            desired_cols: cols,
+            desired_rows: rows,
+            closed: None,
+        }));
+        let (channel, connected) = {
+            let mut state = self.state.lock().expect("connection state lock");
+            let channel = state.next_channel;
+            state.next_channel = state.next_channel.wrapping_add(1).max(1);
+            state.channels.insert(channel, Arc::clone(&slot));
+            (channel, state.connected)
+        };
+        if connected {
+            let _ = self.send_open_frame(channel, &session_id, cols, rows);
+        } else {
+            // The caller may have just spawned the daemon (session create);
+            // cut the reconnect backoff short.
+            self.retry_now.store(true, Ordering::SeqCst);
+        }
+        (channel, slot)
+    }
+
+    pub(crate) fn close_session_channel(&self, channel: u32) {
+        let removed = {
+            let mut state = self.state.lock().expect("connection state lock");
+            state.channels.remove(&channel).is_some()
+        };
+        if removed {
+            let _ = self.send_frame_result(PacketFrame::new(
+                CHANNEL_CONTROL,
+                crate::packet::MSG_CONTROL_CLOSE_CHANNEL,
+                &crate::packet::CloseChannel { channel, reason: None },
+            ));
+        }
+    }
+
+    pub(crate) fn send_input(&self, channel: u32, event: TerminalInputEvent) -> Result<(), String> {
+        let frame = PacketFrame::new(channel, MSG_SESSION_INPUT, &crate::packet::Input { event })
+            .map_err(|err| format!("encode packet frame: {err}"))?;
+        {
+            // Queue while disconnected: the reader flushes the queue right
+            // after it re-opens the session channels, so input typed across a
+            // brief reconnect is not lost.
+            let mut state = self.state.lock().expect("connection state lock");
+            if !state.connected {
+                if state.queued_input.len() >= MAX_QUEUED_INPUT_FRAMES {
+                    return Err("daemon connection is down and the input queue is full".to_string());
+                }
+                state.queued_input.push(frame);
+                return Ok(());
+            }
+        }
+        self.send_frame_result(Ok(frame))
+    }
+
+    pub(crate) fn send_resize(&self, channel: u32, cols: u16, rows: u16) -> Result<(), String> {
+        self.send_frame_result(PacketFrame::new(channel, MSG_SESSION_RESIZE, &crate::packet::Resize { cols, rows }))
+    }
+
+    pub(crate) fn send_ack(&self, channel: u32, generation: u64) -> Result<(), String> {
+        self.send_frame_result(PacketFrame::new(channel, MSG_SESSION_ACK, &crate::packet::Ack { generation }))
+    }
+
+    fn send_open_frame(&self, channel: u32, session_id: &str, cols: u16, rows: u16) -> Result<(), String> {
+        self.send_frame_result(PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL, &OpenChannel {
+            channel,
+            session_id: session_id.to_string(),
+        }))?;
+        // The daemon does not resize on channel open; assert the size this
+        // client wants so a session created detached comes up at view size.
+        self.send_resize(channel, cols, rows)
+    }
+
+    fn send_frame_result(&self, frame: std::io::Result<PacketFrame>) -> Result<(), String> {
+        let frame = frame.map_err(|err| format!("encode packet frame: {err}"))?;
+        let mut writer = self.writer.lock().expect("connection writer lock");
+        let Some(stream) = writer.as_mut() else {
+            return Err("daemon connection is down".to_string());
+        };
+        let mut encoded = Vec::new();
+        frame.write(&mut encoded).map_err(|err| format!("encode packet frame: {err}"))?;
+        match stream.write_all(&encoded) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                // The reader thread notices the broken stream and reconnects;
+                // drop our writer clone so later sends fail fast.
+                *writer = None;
+                Err(format!("write packet frame: {err}"))
+            }
+        }
+    }
+
+    pub(crate) fn shutdown(&self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Ok(mut writer) = self.writer.lock() {
+            if let Some(stream) = writer.take() {
+                let _ = stream.shutdown(std::net::Shutdown::Both);
+            }
+        }
+        let handle = self.reader.lock().ok().and_then(|mut reader| reader.take());
+        if let Some(handle) = handle {
+            let _ = handle.join();
+        }
+    }
+
+    fn reader_loop(self: Arc<Self>) {
+        let mut backoff = RECONNECT_BACKOFF_START;
+        while !self.stop.load(Ordering::SeqCst) {
+            match connect_packet_stream(&self.layout, &self.selectors) {
+                Ok((mut stream, snapshot)) => {
+                    backoff = RECONNECT_BACKOFF_START;
+                    if !self.install_connection(&stream, snapshot) {
+                        continue;
+                    }
+                    self.read_until_disconnect(&mut stream);
+                    self.teardown_connection();
+                }
+                Err(_) => {
+                    self.sleep_backoff(backoff);
+                    backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+                }
+            }
+        }
+    }
+
+    fn install_connection(&self, stream: &SessionStream, snapshot: DirectorySnapshot) -> bool {
+        let writer_stream = match stream.try_clone() {
+            Ok(writer_stream) => writer_stream,
+            Err(_) => return false,
+        };
+        {
+            let mut writer = self.writer.lock().expect("connection writer lock");
+            *writer = Some(writer_stream);
+        }
+        let (reopen, queued_input) = {
+            let mut state = self.state.lock().expect("connection state lock");
+            state.connected = true;
+            state.directory.replace(snapshot);
+            let reopen: Vec<(u32, String, u16, u16)> = state
+                .channels
+                .iter()
+                .map(|(channel, slot)| {
+                    let slot = slot.lock().expect("channel slot lock");
+                    (*channel, slot.session_id.clone(), slot.desired_cols, slot.desired_rows)
+                })
+                .collect();
+            (reopen, std::mem::take(&mut state.queued_input))
+        };
+        for (channel, session_id, cols, rows) in reopen {
+            let _ = self.send_open_frame(channel, &session_id, cols, rows);
+        }
+        for frame in queued_input {
+            let _ = self.send_frame_result(Ok(frame));
+        }
+        (self.wake)();
+        true
+    }
+
+    fn read_until_disconnect(&self, stream: &mut SessionStream) {
+        loop {
+            if self.stop.load(Ordering::SeqCst) {
+                return;
+            }
+            match PacketFrame::read(stream) {
+                Ok(frame) => self.dispatch_frame(frame),
+                Err(_) => return,
+            }
+        }
+    }
+
+    fn dispatch_frame(&self, frame: PacketFrame) {
+        match (frame.channel, frame.msg_type) {
+            (CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT) => {
+                if let Ok(snapshot) = frame.decode::<DirectorySnapshot>() {
+                    let mut state = self.state.lock().expect("connection state lock");
+                    state.directory.replace(snapshot);
+                    drop(state);
+                    (self.wake)();
+                }
+            }
+            (CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_DELTA) => {
+                if let Ok(delta) = frame.decode::<DirectoryDelta>() {
+                    let mut state = self.state.lock().expect("connection state lock");
+                    state.directory.apply_delta(delta);
+                    drop(state);
+                    (self.wake)();
+                }
+            }
+            (CHANNEL_CONTROL, MSG_CONTROL_ERROR) => {
+                if let Ok(error) = frame.decode::<ControlError>() {
+                    let slot = {
+                        let state = self.state.lock().expect("connection state lock");
+                        state.channels.get(&error.channel).cloned()
+                    };
+                    if let Some(slot) = slot {
+                        slot.lock().expect("channel slot lock").closed = Some(error.message);
+                        (self.wake)();
+                    }
+                }
+            }
+            (channel, MSG_SESSION_RENDER) if channel != CHANNEL_CONTROL => {
+                if let Ok(packet) = frame.decode::<RenderPacket>() {
+                    let slot = {
+                        let state = self.state.lock().expect("connection state lock");
+                        state.channels.get(&channel).cloned()
+                    };
+                    if let Some(slot) = slot {
+                        let mut slot = slot.lock().expect("channel slot lock");
+                        slot.pending = Some(packet.update);
+                        drop(slot);
+                        (self.wake)();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn teardown_connection(&self) {
+        {
+            let mut writer = self.writer.lock().expect("connection writer lock");
+            *writer = None;
+        }
+        {
+            let mut state = self.state.lock().expect("connection state lock");
+            state.connected = false;
+        }
+        (self.wake)();
+    }
+
+    fn sleep_backoff(&self, backoff: Duration) {
+        let mut remaining = backoff;
+        while !self.stop.load(Ordering::SeqCst) && remaining > Duration::ZERO {
+            if self.retry_now.swap(false, Ordering::SeqCst) {
+                return;
+            }
+            let step = remaining.min(BACKOFF_POLL_STEP);
+            std::thread::sleep(step);
+            remaining = remaining.saturating_sub(step);
+        }
+    }
+}
+
+impl Drop for DaemonConnection {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+    }
+}
+
+/// Client half of the daemon-scoped `/connect` upgrade: HTTP upgrade dance,
+/// protocol hello, initial directory snapshot.
+pub(crate) fn connect_packet_stream(layout: &RuntimeLayout, selectors: &[String]) -> Result<(SessionStream, DirectorySnapshot), String> {
+    let socket_path = layout.socket_path();
+    let mut stream = try_connect_session_stream(&socket_path).map_err(|err| format!("connect {}: {err}", socket_path.display()))?;
+    let body = serde_json::to_vec(&http_uds::DirectorySubscribeRequest { selectors: selectors.to_vec() })
+        .map_err(|err| format!("serialize packet subscribe request: {err}"))?;
+    let head = format!(
+        "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(&[head.as_bytes(), &body].concat()).map_err(|err| format!("write packet upgrade request: {err}"))?;
+    let response = http_uds::read_response_head(&mut stream).map_err(|err| format!("read packet upgrade response: {err}"))?;
+    if response.status != StatusCode::SWITCHING_PROTOCOLS {
+        return Err(format!("unexpected packet response: {}", response.status));
+    }
+
+    let hello = PacketFrame::read(&mut stream).map_err(|err| format!("read packet hello: {err}"))?;
+    if hello.channel != CHANNEL_CONTROL || hello.msg_type != MSG_CONTROL_HELLO {
+        return Err("packet stream did not start with control hello".to_string());
+    }
+    let hello = hello.decode::<ControlHello>().map_err(|err| format!("decode packet hello: {err}"))?;
+    if hello.version != PROTOCOL_VERSION {
+        return Err(format!("unsupported packet protocol version {}", hello.version));
+    }
+
+    let directory = PacketFrame::read(&mut stream).map_err(|err| format!("read packet directory: {err}"))?;
+    if directory.channel != CHANNEL_CONTROL || directory.msg_type != MSG_CONTROL_DIRECTORY_SNAPSHOT {
+        return Err("packet stream did not send a directory snapshot after hello".to_string());
+    }
+    let directory = directory.decode::<DirectorySnapshot>().map_err(|err| format!("decode packet directory: {err}"))?;
+    Ok((stream, directory))
+}

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -111,6 +111,10 @@ impl LastKnown {
 
 /// Per-session-channel state shared between the reader thread and the FFI
 /// caller.
+///
+/// Lock order: the connection-state mutex is always taken BEFORE a channel
+/// slot (`install_connection`, `request_role`). Never call a connection
+/// method that takes the state lock while holding a slot guard.
 pub(crate) struct ChannelSlot {
     pub session_id: String,
     /// Latest un-consumed render packet. The ack-gated protocol guarantees at
@@ -416,11 +420,17 @@ impl DaemonConnection {
             let reopen: Vec<(u32, String, u16, u16, ChannelRole)> = state
                 .channels
                 .iter()
-                .map(|(channel, slot)| {
+                .filter_map(|(channel, slot)| {
                     let mut slot = slot.lock().expect("channel slot lock");
+                    // A closed channel (session gone) stays closed; reopening
+                    // it would just re-error on every reconnect until the FFI
+                    // caller destroys the session.
+                    if slot.closed.is_some() {
+                        return None;
+                    }
                     // the old grant died with the connection
                     slot.granted_role = None;
-                    (*channel, slot.session_id.clone(), slot.desired_cols, slot.desired_rows, slot.desired_role)
+                    Some((*channel, slot.session_id.clone(), slot.desired_cols, slot.desired_rows, slot.desired_role))
                 })
                 .collect();
             (reopen, std::mem::take(&mut state.queued_input))

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -6,25 +6,25 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use http::{Method, StatusCode};
-
 use crate::{
     host::actor::{ObservationState, SessionActor, SessionCommand, SessionMouseEvent, SessionWheelEvent},
-    http_uds, keys,
-    platform::ipc::connect_session_stream,
+    keys,
     provider::{
         DirtyState, ProviderFeatures, TerminalCell, TerminalCellFlags, TerminalCellWidth, TerminalCursor, TerminalCursorStyle,
-        TerminalGeometry, TerminalImagePlacement, TerminalImageResource, TerminalRenderUpdate, TerminalRenderUpdateOpKind, TerminalRgb,
-        TerminalScrollbackExtent, TerminalScrollbarState, TerminalSnapshot, TerminalStyleColor, TerminalStyleColorTag,
-        TerminalViewportKind, ViewportCommand, ViewportCommandOutcome, TERMINAL_IMAGE_PLACEMENT_VIRTUAL,
+        TerminalFocusEvent, TerminalGeometry, TerminalImagePlacement, TerminalImageResource, TerminalInputEvent, TerminalModifiers,
+        TerminalMouseButtons, TerminalMouseEvent, TerminalMouseEventKind, TerminalPasteEvent, TerminalRenderUpdate,
+        TerminalRenderUpdateOpKind, TerminalRgb, TerminalScrollbackExtent, TerminalScrollbarState, TerminalSnapshot, TerminalStyleColor,
+        TerminalStyleColorTag, TerminalTextEvent, TerminalViewportKind, ViewportCommand, ViewportCommandOutcome,
+        TERMINAL_IMAGE_PLACEMENT_VIRTUAL,
     },
+    provider_daemon::{ChannelSlot, DaemonConnection},
     runtime::{RuntimeLayout, TerminalSize},
     session::{ensure_session_started, SessionStartOptions},
     session_runtime::SessionRuntime,
     vt::{self, Rgb, TerminalColors, VtEngineKind},
 };
 
-pub const CLEAT_PROVIDER_ABI_VERSION: u32 = 6;
+pub const CLEAT_PROVIDER_ABI_VERSION: u32 = 7;
 pub const CLEAT_PROVIDER_BACKEND_MOCK: u32 = 0;
 pub const CLEAT_PROVIDER_BACKEND_IN_PROCESS: u32 = 1;
 pub const CLEAT_PROVIDER_BACKEND_DAEMON: u32 = 2;
@@ -152,12 +152,23 @@ impl From<DirtyState> for CleatDirtyState {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CleatStr {
+    pub ptr: *const u8,
+    pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CleatProviderDesc {
     pub abi_version: u32,
     pub requested_features: u32,
     pub backend: u32,
     pub runtime_root: *const u8,
     pub runtime_root_len: usize,
+    pub daemon_name: *const u8,
+    pub daemon_name_len: usize,
+    pub directory_selectors: *const CleatStr,
+    pub directory_selector_count: usize,
 }
 
 #[repr(C)]
@@ -499,6 +510,7 @@ pub struct CleatProvider {
     backend: ProviderBackend,
     runtime_root: PathBuf,
     wake: Arc<Mutex<WakeCallback>>,
+    daemon: Option<Arc<DaemonConnection>>,
 }
 
 pub struct CleatSession {
@@ -536,9 +548,15 @@ struct InProcessSession {
 
 struct DaemonSession {
     id: String,
-    runtime_root: PathBuf,
-    rows: u16,
-    observation: ObservationState,
+    connection: Arc<DaemonConnection>,
+    channel: u32,
+    slot: Arc<Mutex<ChannelSlot>>,
+}
+
+impl Drop for DaemonSession {
+    fn drop(&mut self) {
+        self.connection.close_session_channel(self.channel);
+    }
 }
 
 pub type CleatWakeFn = Option<unsafe extern "C" fn(*mut c_void)>;
@@ -882,6 +900,10 @@ pub unsafe extern "C" fn cleat_provider_open(desc: *const CleatProviderDesc) -> 
         backend: CLEAT_PROVIDER_BACKEND_MOCK,
         runtime_root: ptr::null(),
         runtime_root_len: 0,
+        daemon_name: ptr::null(),
+        daemon_name_len: 0,
+        directory_selectors: ptr::null(),
+        directory_selector_count: 0,
     });
     if requested.abi_version != CLEAT_PROVIDER_ABI_VERSION {
         return ptr::null_mut();
@@ -897,11 +919,41 @@ pub unsafe extern "C" fn cleat_provider_open(desc: *const CleatProviderDesc) -> 
         Ok(None) => RuntimeLayout::discover().root().to_path_buf(),
         Err(_) => return ptr::null_mut(),
     };
+    let daemon_name = match read_optional_utf8(requested.daemon_name, requested.daemon_name_len) {
+        Ok(name) => name,
+        Err(_) => return ptr::null_mut(),
+    };
+    let selectors = match read_selector_strings(requested.directory_selectors, requested.directory_selector_count) {
+        Ok(selectors) => selectors,
+        Err(_) => return ptr::null_mut(),
+    };
     let features = ProviderFeatures::from_bits_truncate(requested.requested_features)
         | ProviderFeatures::CELL_SNAPSHOTS
         | ProviderFeatures::STRUCTURED_MOUSE_INPUT
         | ProviderFeatures::RENDER_UPDATES;
-    Box::into_raw(Box::new(CleatProvider { features, backend, runtime_root, wake: Arc::new(Mutex::new(WakeCallback::default())) }))
+    let wake = Arc::new(Mutex::new(WakeCallback::default()));
+    let daemon = if backend == ProviderBackend::Daemon {
+        let mut layout = RuntimeLayout::new(runtime_root.clone());
+        if let Some(name) = daemon_name {
+            layout = match layout.with_daemon(name) {
+                Ok(layout) => layout,
+                Err(_) => return ptr::null_mut(),
+            };
+        }
+        let wake_for_connection = Arc::clone(&wake);
+        Some(DaemonConnection::open(layout, selectors, Arc::new(move || notify_wake(&wake_for_connection))))
+    } else {
+        None
+    };
+    Box::into_raw(Box::new(CleatProvider { features, backend, runtime_root, wake, daemon }))
+}
+
+fn read_selector_strings(selectors: *const CleatStr, count: usize) -> Result<Vec<String>, Utf8Error> {
+    if count == 0 || selectors.is_null() {
+        return Ok(Vec::new());
+    }
+    let slices = unsafe { slice::from_raw_parts(selectors, count) };
+    slices.iter().map(|selector| read_optional_utf8(selector.ptr, selector.len).map(|value| value.unwrap_or_default())).collect()
 }
 
 /// # Safety
@@ -929,7 +981,11 @@ pub unsafe extern "C" fn cleat_provider_set_wake_callback(provider: *mut CleatPr
 #[no_mangle]
 pub unsafe extern "C" fn cleat_provider_close(provider: *mut CleatProvider) {
     if !provider.is_null() {
-        drop(unsafe { Box::from_raw(provider) });
+        let provider = unsafe { Box::from_raw(provider) };
+        if let Some(daemon) = &provider.daemon {
+            daemon.shutdown();
+        }
+        drop(provider);
     }
 }
 
@@ -1017,11 +1073,14 @@ pub unsafe extern "C" fn cleat_session_resize(session: *mut CleatSession, cols: 
             in_process.actor.request_result(|reply| SessionCommand::Resize { cols: cols.max(1), rows: rows.max(1), reply }).is_ok()
         }
         SessionBackend::Daemon(daemon) => {
-            if daemon_resize(daemon, cols.max(1), rows.max(1)).is_err() {
-                return false;
+            let (cols, rows) = (cols.max(1), rows.max(1));
+            if let Ok(mut slot) = daemon.slot.lock() {
+                slot.desired_cols = cols;
+                slot.desired_rows = rows;
             }
-            daemon.rows = rows.max(1);
-            mark_full_and_wake(&mut daemon.observation, rows.max(1), &session.wake);
+            // Best-effort while connected; the desired size is re-asserted on
+            // every reconnect, so a send failure is not a caller error.
+            let _ = daemon.connection.send_resize(daemon.channel, cols, rows);
             true
         }
     }
@@ -1056,9 +1115,9 @@ pub unsafe extern "C" fn cleat_session_update_geometry(session: *mut CleatSessio
             }
             session.geometry = geometry;
         }
-        SessionBackend::Daemon(daemon) => {
+        SessionBackend::Daemon(_) => {
             session.geometry = geometry;
-            mark_full_and_wake(&mut daemon.observation, 1, &session.wake);
+            notify_wake(&session.wake);
         }
     }
     true
@@ -1172,9 +1231,9 @@ fn send_input_event(session: &mut CleatSession, event: &CleatInputEvent) -> Opti
             Ok(None) => Some(0),
             Err(_) => None,
         },
-        SessionBackend::Daemon(daemon) => match daemon_input_request(event) {
+        SessionBackend::Daemon(daemon) => match packet_input_event(event) {
             Ok(Some(input)) => {
-                if daemon_send_input(daemon, input).is_err() {
+                if daemon.connection.send_input(daemon.channel, input).is_err() {
                     return None;
                 }
                 Some(1)
@@ -1311,10 +1370,7 @@ pub unsafe extern "C" fn cleat_session_write_bytes(session: *mut CleatSession, b
             in_process.actor.request_result(|reply| SessionCommand::WriteInput { bytes: bytes.to_vec(), reply }).is_ok()
         }
         SessionBackend::Daemon(daemon) => {
-            if daemon_write_bytes(daemon, bytes).is_err() {
-                return false;
-            }
-            true
+            daemon.connection.send_input(daemon.channel, TerminalInputEvent::RawBytes(bytes.to_vec())).is_ok()
         }
     }
 }
@@ -1334,7 +1390,7 @@ pub unsafe extern "C" fn cleat_session_poll(session: *mut CleatSession) -> Cleat
     match &mut session.backend {
         SessionBackend::Mock(mock) => mock.observation.dirty().into(),
         SessionBackend::InProcess(in_process) => in_process.actor.observation().dirty().into(),
-        SessionBackend::Daemon(daemon) => daemon.observation.dirty().into(),
+        SessionBackend::Daemon(daemon) => daemon_slot_dirty(daemon).into(),
     }
 }
 
@@ -1349,9 +1405,13 @@ pub unsafe extern "C" fn cleat_session_dirty(session: *const CleatSession) -> Cl
         .map(|session| match &session.backend {
             SessionBackend::Mock(mock) => mock.observation.dirty().into(),
             SessionBackend::InProcess(in_process) => in_process.actor.observation().dirty().into(),
-            SessionBackend::Daemon(daemon) => daemon.observation.dirty().into(),
+            SessionBackend::Daemon(daemon) => daemon_slot_dirty(daemon).into(),
         })
         .unwrap_or(CleatDirtyState::Full)
+}
+
+fn daemon_slot_dirty(daemon: &DaemonSession) -> DirtyState {
+    daemon.slot.lock().map(|slot| slot.dirty()).unwrap_or(DirtyState::Clean)
 }
 
 /// # Safety
@@ -1369,7 +1429,9 @@ pub unsafe extern "C" fn cleat_session_mark_observed(session: *mut CleatSession,
         SessionBackend::InProcess(in_process) => {
             in_process.actor.request(|reply| SessionCommand::MarkObserved { generation, reply }, false)
         }
-        SessionBackend::Daemon(daemon) => daemon.observation.mark_observed(generation),
+        // Daemon renders are acked (and thereby marked observed daemon-side)
+        // when the pending packet is consumed by cleat_session_render_update.
+        SessionBackend::Daemon(_) => true,
     }
 }
 
@@ -1468,13 +1530,9 @@ pub unsafe extern "C" fn cleat_session_snapshot(session: *mut CleatSession, out:
             Ok(snapshot) => snapshot,
             Err(_) => return false,
         },
-        SessionBackend::Daemon(daemon) => match daemon_snapshot(daemon) {
-            Ok(mut snapshot) => {
-                daemon.observation.annotate_snapshot(&mut snapshot);
-                snapshot
-            }
-            Err(_) => return false,
-        },
+        // Daemon sessions are render-update-fed; there is no full-grid state
+        // FFI-side to serve a snapshot from.
+        SessionBackend::Daemon(_) => return false,
     };
     snapshot.geometry = session.geometry;
     snapshot.scrollbar = session_scrollbar_state(session);
@@ -1512,13 +1570,33 @@ pub unsafe extern "C" fn cleat_session_render_update(session: *mut CleatSession,
             Ok(update) => update,
             Err(_) => return false,
         },
-        SessionBackend::Daemon(daemon) => match daemon_snapshot(daemon) {
-            Ok(mut snapshot) => {
-                daemon.observation.annotate_snapshot(&mut snapshot);
-                TerminalRenderUpdate::from_snapshot(snapshot)
+        SessionBackend::Daemon(daemon) => {
+            let taken = {
+                let mut slot = match daemon.slot.lock() {
+                    Ok(slot) => slot,
+                    Err(_) => return false,
+                };
+                match slot.pending.take() {
+                    Some(update) => {
+                        slot.last.absorb(&update);
+                        Some(update)
+                    }
+                    None => None,
+                }
+            };
+            match taken {
+                Some(update) => {
+                    // Consuming the packet is the observation; ack it so the
+                    // daemon may send the next one (one-un-acked backpressure).
+                    let _ = daemon.connection.send_ack(daemon.channel, update.render_generation);
+                    update
+                }
+                None => match daemon.slot.lock() {
+                    Ok(slot) => slot.last.clean_update(),
+                    Err(_) => return false,
+                },
             }
-            Err(_) => return false,
-        },
+        }
     };
     update.geometry = session.geometry;
     update.scrollbar = session_scrollbar_state(session);
@@ -1600,9 +1678,15 @@ fn session_scrollback_extent(session: &mut CleatSession) -> TerminalScrollbackEx
                 alternate_screen: false,
             })
         }
-        SessionBackend::Daemon(daemon) => {
-            TerminalScrollbackExtent { normal_scrollback_rows: 0, live_rows: daemon.rows, alternate_screen: false }
-        }
+        SessionBackend::Daemon(daemon) => daemon
+            .slot
+            .lock()
+            .map(|slot| TerminalScrollbackExtent {
+                normal_scrollback_rows: slot.last.scrollbar.total_rows.saturating_sub(u64::from(slot.last.rows)),
+                live_rows: slot.last.rows,
+                alternate_screen: slot.last.terminal_modes.active_alternate_screen,
+            })
+            .unwrap_or(TerminalScrollbackExtent { normal_scrollback_rows: 0, live_rows: 0, alternate_screen: false }),
     }
 }
 
@@ -1612,7 +1696,11 @@ fn session_scrollbar_state(session: &mut CleatSession) -> TerminalScrollbarState
         SessionBackend::InProcess(in_process) => {
             in_process.actor.request(|reply| SessionCommand::ScrollbarState { reply }, TerminalScrollbarState::default())
         }
-        SessionBackend::Daemon(daemon) => TerminalScrollbarState::for_live_viewport(TerminalViewportKind::LiveNormal, daemon.rows),
+        SessionBackend::Daemon(daemon) => daemon
+            .slot
+            .lock()
+            .map(|slot| slot.last.scrollbar)
+            .unwrap_or_else(|_| TerminalScrollbarState::for_live_viewport(TerminalViewportKind::LiveNormal, 0)),
     }
 }
 
@@ -1717,7 +1805,7 @@ fn create_in_process_session(provider: &CleatProvider, desc: CleatSessionDesc) -
 }
 
 fn create_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Result<DaemonSession, String> {
-    let layout = RuntimeLayout::new(provider.runtime_root.clone());
+    let connection = provider.daemon.as_ref().ok_or_else(|| "provider has no daemon connection".to_string())?;
     let vt_engine = vt_engine_from_tag(desc.vt_engine)?;
     let colors = session_colors_from_desc(desc);
     let cmd = read_optional_utf8(desc.command, desc.command_len).map_err(|err| format!("command is not valid UTF-8: {err}"))?;
@@ -1725,16 +1813,14 @@ fn create_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Re
     let id = read_optional_utf8(desc.id, desc.id_len).map_err(|err| format!("id is not valid UTF-8: {err}"))?;
     let cols = desc.cols.max(1);
     let rows = desc.rows.max(1);
-    let metadata = ensure_session_started(&layout, id, Some(vt_engine), cwd, cmd, SessionStartOptions {
+    let metadata = ensure_session_started(connection.layout(), id, Some(vt_engine), cwd, cmd, SessionStartOptions {
         record: desc.record,
         initial_size: TerminalSize { cols, rows },
         colors,
         tags: Vec::new(),
     })?;
-    let mut session =
-        DaemonSession { id: metadata.id, runtime_root: provider.runtime_root.clone(), rows, observation: ObservationState::new(rows) };
-    daemon_resize(&mut session, cols, rows)?;
-    Ok(session)
+    let (channel, slot) = connection.open_session_channel(metadata.id.clone(), cols, rows);
+    Ok(DaemonSession { id: metadata.id, connection: Arc::clone(connection), channel, slot })
 }
 
 fn vt_engine_from_tag(tag: u32) -> Result<VtEngineKind, String> {
@@ -1764,200 +1850,64 @@ fn rgb_from_ffi(rgb: CleatRgb) -> Rgb {
     Rgb { r: rgb.r, g: rgb.g, b: rgb.b }
 }
 
-fn daemon_resize(session: &mut DaemonSession, cols: u16, rows: u16) -> Result<(), String> {
-    let body =
-        serde_json::to_vec(&serde_json::json!({ "cols": cols, "rows": rows })).map_err(|err| format!("serialize resize request: {err}"))?;
-    let response = daemon_request(session, Method::POST, &format!("/sessions/{}/resize", session.id), &body)?;
-    expect_status(response, StatusCode::NO_CONTENT, "resize")?;
-    session.rows = rows;
-    Ok(())
-}
-
-fn daemon_write_bytes(session: &mut DaemonSession, bytes: &[u8]) -> Result<(), String> {
-    let body = serde_json::to_vec(&serde_json::json!({ "bytes": bytes })).map_err(|err| format!("serialize keys request: {err}"))?;
-    let response = daemon_request(session, Method::POST, &format!("/sessions/{}/keys", session.id), &body)?;
-    expect_status(response, StatusCode::NO_CONTENT, "keys")
-}
-
-fn daemon_send_input(session: &mut DaemonSession, input: http_uds::InputRequest) -> Result<(), String> {
-    let body = serde_json::to_vec(&input).map_err(|err| format!("serialize input request: {err}"))?;
-    let response = daemon_request(session, Method::POST, &format!("/sessions/{}/input", session.id), &body)?;
-    expect_status(response, StatusCode::NO_CONTENT, "input")
-}
-
-fn daemon_snapshot(session: &mut DaemonSession) -> Result<TerminalSnapshot, String> {
-    let response = daemon_request(session, Method::GET, &format!("/sessions/{}/snapshot", session.id), &[])?;
-    if response.status != StatusCode::OK {
-        return Err(format!("snapshot returned {}", response.status));
-    }
-    let snapshot: http_uds::SnapshotResponse =
-        serde_json::from_slice(&response.body).map_err(|err| format!("parse snapshot response: {err}"))?;
-    terminal_snapshot_from_http(snapshot)
-}
-
-fn daemon_request(session: &DaemonSession, method: Method, path: &str, body: &[u8]) -> Result<http_uds::HttpResponse, String> {
-    let socket_path = RuntimeLayout::new(session.runtime_root.clone()).socket_path();
-    let mut stream = connect_session_stream(&socket_path)?;
-    http_uds::write_request(&mut stream, method, path, body).map_err(|err| format!("write HTTP request: {err}"))?;
-    http_uds::read_response(&mut stream).map_err(|err| format!("read HTTP response: {err}"))
-}
-
-fn expect_status(response: http_uds::HttpResponse, expected: StatusCode, operation: &str) -> Result<(), String> {
-    if response.status == expected {
-        Ok(())
-    } else {
-        Err(format!("{operation} returned {}", response.status))
-    }
-}
-
-fn terminal_snapshot_from_http(snapshot: http_uds::SnapshotResponse) -> Result<TerminalSnapshot, String> {
-    Ok(TerminalSnapshot {
-        cols: snapshot.cols,
-        rows: snapshot.rows,
-        geometry: geometry_from_http(snapshot.geometry),
-        viewport_kind: viewport_kind_from_name(&snapshot.viewport_kind)?,
-        scrollback_offset_rows: snapshot.scrollback_offset_rows,
-        scrollbar: scrollbar_from_http(snapshot.scrollbar)?,
-        terminal_modes: terminal_modes_from_http(snapshot.terminal_modes)?,
-        render_generation: 0,
-        cells: snapshot
-            .cells
-            .into_iter()
-            .map(|cell| {
-                Ok(TerminalCell {
-                    graphemes: cell.graphemes,
-                    fg: TerminalRgb { r: cell.fg.r, g: cell.fg.g, b: cell.fg.b },
-                    bg: TerminalRgb { r: cell.bg.r, g: cell.bg.g, b: cell.bg.b },
-                    flags: TerminalCellFlags::from_bits_truncate(cell.flags),
-                    width: cell_width_from_name(&cell.width)?,
-                    ..TerminalCell::default()
-                })
-            })
-            .collect::<Result<Vec<_>, String>>()?,
-        cursor: TerminalCursor {
-            col: snapshot.cursor.col,
-            row: snapshot.cursor.row,
-            visible: snapshot.cursor.visible,
-            style: cursor_style_from_name(&snapshot.cursor.style)?,
-            blink: snapshot.cursor.blink,
-            wide_tail: snapshot.cursor.wide_tail,
-        },
-        dirty: dirty_from_name(&snapshot.dirty)?,
-        dirty_rows: Vec::new(),
-    })
-}
-
-fn scrollbar_from_http(scrollbar: http_uds::ScrollbarResponse) -> Result<TerminalScrollbarState, String> {
-    Ok(TerminalScrollbarState::new(
-        viewport_kind_from_name(&scrollbar.viewport_kind)?,
-        scrollbar.total_rows,
-        scrollbar.viewport_rows,
-        scrollbar.viewport_top_row,
-    ))
-}
-
-fn geometry_from_http(geometry: http_uds::GeometryResponse) -> TerminalGeometry {
-    TerminalGeometry {
-        cell_width_px: geometry.cell_width_px,
-        cell_height_px: geometry.cell_height_px,
-        content_x_px: geometry.content_x_px,
-        content_y_px: geometry.content_y_px,
-        content_width_px: geometry.content_width_px,
-        content_height_px: geometry.content_height_px,
-    }
-    .sanitized()
-}
-
-fn terminal_modes_from_http(modes: http_uds::TerminalModeResponse) -> Result<vt::TerminalModeState, String> {
-    let mouse_tracking_mode = mouse_tracking_mode_from_name(&modes.mouse_tracking_mode)?;
-    let mouse_report_format = mouse_report_format_from_name(&modes.mouse_report_format)?;
-    Ok(vt::TerminalModeState {
-        active_alternate_screen: modes.active_alternate_screen,
-        application_cursor_keys: modes.application_cursor_keys,
-        alternate_scroll: modes.alternate_scroll,
-        mouse_tracking: modes.mouse_tracking,
-        mouse_tracking_mode,
-        mouse_report_format,
-        mouse_sgr: modes.mouse_sgr,
-        mouse_sgr_pixels: modes.mouse_sgr_pixels,
-    })
-}
-
-fn dirty_from_name(name: &str) -> Result<DirtyState, String> {
-    match name {
-        "clean" => Ok(DirtyState::Clean),
-        "partial" => Ok(DirtyState::Partial),
-        "full" => Ok(DirtyState::Full),
-        other => Err(format!("unknown dirty state {other}")),
-    }
-}
-
-fn cell_width_from_name(name: &str) -> Result<TerminalCellWidth, String> {
-    match name {
-        "narrow" => Ok(TerminalCellWidth::Narrow),
-        "wide" => Ok(TerminalCellWidth::Wide),
-        "spacer_tail" => Ok(TerminalCellWidth::SpacerTail),
-        "spacer_head" => Ok(TerminalCellWidth::SpacerHead),
-        other => Err(format!("unknown cell width {other}")),
-    }
-}
-
-fn cursor_style_from_name(name: &str) -> Result<TerminalCursorStyle, String> {
-    match name {
-        "bar" => Ok(TerminalCursorStyle::Bar),
-        "block" => Ok(TerminalCursorStyle::Block),
-        "underline" => Ok(TerminalCursorStyle::Underline),
-        "block_hollow" => Ok(TerminalCursorStyle::BlockHollow),
-        other => Err(format!("unknown cursor style {other}")),
-    }
-}
-
-fn viewport_kind_from_name(name: &str) -> Result<TerminalViewportKind, String> {
-    match name {
-        "live_normal" => Ok(TerminalViewportKind::LiveNormal),
-        "live_alternate" => Ok(TerminalViewportKind::LiveAlternate),
-        "normal_scrollback" => Ok(TerminalViewportKind::NormalScrollback),
-        other => Err(format!("unknown viewport kind {other}")),
-    }
-}
-
-fn mouse_tracking_mode_from_name(name: &str) -> Result<vt::MouseTrackingMode, String> {
-    match name {
-        "none" => Ok(vt::MouseTrackingMode::None),
-        "x10" => Ok(vt::MouseTrackingMode::X10),
-        "normal" => Ok(vt::MouseTrackingMode::Normal),
-        "button" => Ok(vt::MouseTrackingMode::Button),
-        "any" => Ok(vt::MouseTrackingMode::Any),
-        other => Err(format!("unknown mouse tracking mode {other}")),
-    }
-}
-
-fn mouse_report_format_from_name(name: &str) -> Result<vt::MouseReportFormat, String> {
-    match name {
-        "legacy" => Ok(vt::MouseReportFormat::Legacy),
-        "sgr" => Ok(vt::MouseReportFormat::Sgr),
-        "sgr_pixels" => Ok(vt::MouseReportFormat::SgrPixels),
-        other => Err(format!("unknown mouse report format {other}")),
-    }
-}
-
-fn daemon_input_request(event: &CleatInputEvent) -> Result<Option<http_uds::InputRequest>, Utf8Error> {
-    match event.kind {
-        CLEAT_INPUT_TEXT => read_event_text(event).map(|text| Some(http_uds::InputRequest::Text { text })),
-        CLEAT_INPUT_PASTE => read_event_text(event).map(|text| Some(http_uds::InputRequest::Paste { text })),
-        CLEAT_INPUT_KEY => key_event_bytes(event).map(|bytes| bytes.map(|bytes| http_uds::InputRequest::RawBytes { bytes })),
-        CLEAT_INPUT_RESIZE => Ok(Some(http_uds::InputRequest::Resize { cols: event.cell_col.max(1), rows: event.cell_row.max(1) })),
-        CLEAT_INPUT_MOUSE | CLEAT_INPUT_FOCUS => Ok(None),
-        _ => Ok(None),
-    }
-}
-
 fn read_optional_utf8(ptr: *const u8, len: usize) -> Result<Option<String>, Utf8Error> {
     if ptr.is_null() || len == 0 {
         return Ok(None);
     }
     let bytes = unsafe { slice::from_raw_parts(ptr, len) };
     std::str::from_utf8(bytes).map(|value| Some(value.to_string()))
+}
+
+/// Map an FFI input event onto the packet-transported `TerminalInputEvent`.
+/// Key events are encoded to bytes locally (matching the in-process path) so
+/// both backends share one key-encoding implementation; mouse and paste events
+/// stay structured because their encoding is terminal-mode-dependent and the
+/// session actor resolves them daemon-side.
+fn packet_input_event(event: &CleatInputEvent) -> Result<Option<TerminalInputEvent>, Utf8Error> {
+    match event.kind {
+        CLEAT_INPUT_TEXT => read_event_text(event).map(|text| Some(TerminalInputEvent::Text(TerminalTextEvent { text }))),
+        CLEAT_INPUT_PASTE => read_event_text(event).map(|text| Some(TerminalInputEvent::Paste(TerminalPasteEvent { text }))),
+        CLEAT_INPUT_KEY => key_event_bytes(event).map(|bytes| bytes.map(TerminalInputEvent::RawBytes)),
+        CLEAT_INPUT_MOUSE => Ok(packet_mouse_event(event)),
+        CLEAT_INPUT_FOCUS => Ok(Some(TerminalInputEvent::Focus(TerminalFocusEvent { focused: event.focused }))),
+        CLEAT_INPUT_RESIZE => Ok(Some(TerminalInputEvent::Resize(crate::provider::TerminalResizeEvent {
+            cols: event.cell_col.max(1),
+            rows: event.cell_row.max(1),
+            cell_width_px: event.x_px,
+            cell_height_px: event.y_px,
+        }))),
+        _ => Ok(None),
+    }
+}
+
+fn packet_mouse_event(event: &CleatInputEvent) -> Option<TerminalInputEvent> {
+    let kind = match event.mouse_kind {
+        CLEAT_MOUSE_PRESS => TerminalMouseEventKind::Press,
+        CLEAT_MOUSE_RELEASE => TerminalMouseEventKind::Release,
+        CLEAT_MOUSE_MOVE => TerminalMouseEventKind::Move,
+        CLEAT_MOUSE_WHEEL => TerminalMouseEventKind::Wheel,
+        _ => return None,
+    };
+    let button = match event.mouse_button {
+        CLEAT_MOUSE_BUTTON_LEFT => Some(crate::provider::TerminalMouseButton::Left),
+        CLEAT_MOUSE_BUTTON_MIDDLE => Some(crate::provider::TerminalMouseButton::Middle),
+        CLEAT_MOUSE_BUTTON_RIGHT => Some(crate::provider::TerminalMouseButton::Right),
+        CLEAT_MOUSE_BUTTON_BACK => Some(crate::provider::TerminalMouseButton::Back),
+        CLEAT_MOUSE_BUTTON_FORWARD => Some(crate::provider::TerminalMouseButton::Forward),
+        _ => None,
+    };
+    Some(TerminalInputEvent::Mouse(TerminalMouseEvent {
+        kind,
+        button,
+        buttons: TerminalMouseButtons::from_bits_truncate(event.mouse_buttons),
+        modifiers: TerminalModifiers::from_bits_truncate(event.modifiers),
+        cell_col: event.cell_col,
+        cell_row: event.cell_row,
+        x_px: event.x_px,
+        y_px: event.y_px,
+        wheel_delta_x: event.wheel_delta_x,
+        wheel_delta_y: event.wheel_delta_y,
+    }))
 }
 
 fn input_event_bytes(event: &CleatInputEvent) -> Result<Option<Vec<u8>>, Utf8Error> {
@@ -2733,18 +2683,37 @@ mod tests {
     }
 
     #[test]
-    fn daemon_input_request_maps_ffi_text_and_named_key_events() {
+    fn packet_input_event_maps_ffi_text_named_key_and_mouse_events() {
         let text = b"hello";
         let text_event =
             CleatInputEvent { kind: CLEAT_INPUT_TEXT, text: text.as_ptr(), text_len: text.len(), ..CleatInputEvent::default() };
         assert_eq!(
-            daemon_input_request(&text_event).expect("text input"),
-            Some(http_uds::InputRequest::Text { text: "hello".to_string() })
+            packet_input_event(&text_event).expect("text input"),
+            Some(TerminalInputEvent::Text(TerminalTextEvent { text: "hello".to_string() }))
         );
 
         let key_event =
             CleatInputEvent { kind: CLEAT_INPUT_KEY, key_kind: CLEAT_KEY_NAMED, key_code: CLEAT_KEY_ENTER, ..CleatInputEvent::default() };
-        assert_eq!(daemon_input_request(&key_event).expect("key input"), Some(http_uds::InputRequest::RawBytes { bytes: b"\r".to_vec() }));
+        assert_eq!(packet_input_event(&key_event).expect("key input"), Some(TerminalInputEvent::RawBytes(b"\r".to_vec())));
+
+        let wheel_event = CleatInputEvent {
+            kind: CLEAT_INPUT_MOUSE,
+            mouse_kind: CLEAT_MOUSE_WHEEL,
+            modifiers: CLEAT_MOD_SHIFT,
+            cell_col: 3,
+            cell_row: 4,
+            wheel_delta_y: -2.5,
+            ..CleatInputEvent::default()
+        };
+        match packet_input_event(&wheel_event).expect("wheel input") {
+            Some(TerminalInputEvent::Mouse(mouse)) => {
+                assert_eq!(mouse.kind, TerminalMouseEventKind::Wheel);
+                assert_eq!(mouse.modifiers, TerminalModifiers::SHIFT);
+                assert_eq!((mouse.cell_col, mouse.cell_row), (3, 4));
+                assert_eq!(mouse.wheel_delta_y, -2.5);
+            }
+            other => panic!("expected mouse event, got {other:?}"),
+        }
     }
 
     #[test]
@@ -2871,7 +2840,6 @@ mod tests {
             ..CleatInputEvent::default()
         };
         assert_eq!(input_event_bytes(&event).expect("mouse input"), None);
-        assert_eq!(daemon_input_request(&event).expect("mouse daemon input"), None);
 
         unsafe {
             let provider = cleat_provider_open(ptr::null());
@@ -2976,6 +2944,7 @@ mod tests {
                 backend: CLEAT_PROVIDER_BACKEND_IN_PROCESS,
                 runtime_root: root.as_ptr(),
                 runtime_root_len: root.len(),
+                ..CleatProviderDesc::default()
             });
             assert!(!provider.is_null());
             cleat_provider_set_wake_callback(provider, Some(count_wake), &wake_count as *const AtomicUsize as *mut c_void);
@@ -3073,6 +3042,7 @@ mod tests {
                 backend: CLEAT_PROVIDER_BACKEND_IN_PROCESS,
                 runtime_root: root.as_ptr(),
                 runtime_root_len: root.len(),
+                ..CleatProviderDesc::default()
             });
             assert!(!provider.is_null());
 

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -1832,6 +1832,11 @@ pub unsafe extern "C" fn cleat_session_scroll_viewport(
     true
 }
 
+/// Always returns false for daemon-backed sessions: they are fed by render
+/// updates rather than snapshots, and no full-grid state is held client-side.
+/// Use `cleat_session_render_update` instead; the first update after a channel
+/// opens is full-dirty and carries the complete grid.
+///
 /// # Safety
 ///
 /// `session` must be a valid session pointer. `out` must point to writable

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -550,10 +550,11 @@ pub struct CleatDirectory {
     pub entry_count: usize,
 }
 
+/// Keeps the heap buffers behind `directory`'s FFI pointers alive.
 struct OwnedDirectory {
     directory: CleatDirectory,
-    entries: Vec<CleatDirectoryEntry>,
-    tag_lists: Vec<Vec<CleatStr>>,
+    _entries: Vec<CleatDirectoryEntry>,
+    _tag_lists: Vec<Vec<CleatStr>>,
     _strings: Vec<String>,
 }
 
@@ -611,18 +612,17 @@ impl OwnedDirectory {
                 rows: entry.rows,
             })
             .collect();
-        let mut owned = Box::new(Self {
-            directory: CleatDirectory { generation, entries: ptr::null(), entry_count: entries.len() },
-            entries,
-            tag_lists,
+        // Every pointer handed to the FFI targets a Vec/String HEAP buffer.
+        // Moving the owning headers into the struct/Box relocates only the
+        // headers, never the buffers, so the pointers computed above stay
+        // valid — nothing here is self-referential and no fix-up is needed.
+        let entries_ptr = if entries.is_empty() { ptr::null() } else { entries.as_ptr() };
+        Box::new(Self {
+            directory: CleatDirectory { generation, entries: entries_ptr, entry_count: entries.len() },
+            _entries: entries,
+            _tag_lists: tag_lists,
             _strings: strings,
-        });
-        // Self-referential fix-ups: the boxed vectors' addresses are stable now.
-        owned.directory.entries = if owned.entries.is_empty() { ptr::null() } else { owned.entries.as_ptr() };
-        for (entry, tags) in owned.entries.iter_mut().zip(owned.tag_lists.iter()) {
-            entry.tags = if tags.is_empty() { ptr::null() } else { tags.as_ptr() };
-        }
-        owned
+        })
     }
 }
 

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -1355,15 +1355,20 @@ pub unsafe extern "C" fn cleat_session_connection_state(session: *const CleatSes
     match &session.backend {
         SessionBackend::Mock(_) | SessionBackend::InProcess(_) => CLEAT_SESSION_STREAMING,
         SessionBackend::Daemon(daemon) => {
-            let slot = match daemon.slot.lock() {
-                Ok(slot) => slot,
+            // Copy the slot fields before checking connectivity:
+            // is_connected() takes the connection-state lock, and the reader
+            // thread takes connection-state -> slot (install_connection,
+            // request_role), so holding the slot across it would invert the
+            // lock order and deadlock the connection.
+            let (closed, streaming) = match daemon.slot.lock() {
+                Ok(slot) => (slot.closed.is_some(), slot.pending.is_some() || slot.last.render_generation > 0),
                 Err(_) => return CLEAT_SESSION_CLOSED,
             };
-            if slot.closed.is_some() {
+            if closed {
                 CLEAT_SESSION_CLOSED
             } else if !daemon.connection.is_connected() {
                 CLEAT_SESSION_DISCONNECTED
-            } else if slot.pending.is_some() || slot.last.render_generation > 0 {
+            } else if streaming {
                 CLEAT_SESSION_STREAMING
             } else {
                 CLEAT_SESSION_CONNECTING

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -35,6 +35,9 @@ pub const CLEAT_SESSION_CONNECTING: u32 = 0;
 pub const CLEAT_SESSION_STREAMING: u32 = 1;
 pub const CLEAT_SESSION_DISCONNECTED: u32 = 2;
 pub const CLEAT_SESSION_CLOSED: u32 = 3;
+pub const CLEAT_ROLE_UNKNOWN: u32 = 0;
+pub const CLEAT_ROLE_WATCHER: u32 = 1;
+pub const CLEAT_ROLE_CONTROLLER: u32 = 2;
 pub const CLEAT_INPUT_KEY: u32 = 1;
 pub const CLEAT_INPUT_TEXT: u32 = 2;
 pub const CLEAT_INPUT_MOUSE: u32 = 3;
@@ -193,6 +196,11 @@ pub struct CleatSessionDesc {
     pub colors: *const CleatSessionColors,
     pub tags: *const CleatStr,
     pub tag_count: usize,
+    /// Requested attachment role for daemon sessions: CLEAT_ROLE_UNKNOWN /
+    /// CLEAT_ROLE_CONTROLLER request control (the daemon may grant watcher if
+    /// another controller holds the session); CLEAT_ROLE_WATCHER attaches
+    /// read-only. Ignored by other backends.
+    pub role: u32,
 }
 
 #[repr(C)]
@@ -1188,6 +1196,7 @@ pub unsafe extern "C" fn cleat_session_create(provider: *mut CleatProvider, desc
         colors: ptr::null(),
         tags: ptr::null(),
         tag_count: 0,
+        role: CLEAT_ROLE_UNKNOWN,
     });
     let geometry = TerminalGeometry::from_cell_size(desc.cols.max(1), desc.rows.max(1), desc.cell_width_px, desc.cell_height_px);
     let backend = match provider.backend {
@@ -1277,6 +1286,52 @@ pub unsafe extern "C" fn cleat_session_id(session: *const CleatSession, out: *mu
         SessionBackend::Daemon(daemon) => {
             *out = CleatStr { ptr: daemon.id.as_ptr(), len: daemon.id.len() };
             true
+        }
+    }
+}
+
+/// Granted attachment role (CLEAT_ROLE_*). In-process and mock sessions are
+/// their own controllers. Daemon sessions report CLEAT_ROLE_UNKNOWN until the
+/// daemon's grant arrives, then the granted role — which may change later
+/// (another client can take control; the wake callback fires on the change).
+///
+/// # Safety
+///
+/// `session` must be a valid session pointer.
+#[no_mangle]
+pub unsafe extern "C" fn cleat_session_role(session: *const CleatSession) -> u32 {
+    let session = match unsafe { session.as_ref() } {
+        Some(session) => session,
+        None => return CLEAT_ROLE_UNKNOWN,
+    };
+    match &session.backend {
+        SessionBackend::Mock(_) | SessionBackend::InProcess(_) => CLEAT_ROLE_CONTROLLER,
+        SessionBackend::Daemon(daemon) => match daemon.slot.lock().ok().and_then(|slot| slot.granted_role) {
+            Some(crate::packet::ChannelRole::Controller) => CLEAT_ROLE_CONTROLLER,
+            Some(crate::packet::ChannelRole::Watcher) => CLEAT_ROLE_WATCHER,
+            None => CLEAT_ROLE_UNKNOWN,
+        },
+    }
+}
+
+/// Request the controller role, preempting another packet controller if one
+/// holds the session (a legacy stream controller is never preempted). The
+/// grant lands asynchronously: poll `cleat_session_role` after the wake
+/// callback fires. Returns false if the request could not be sent.
+///
+/// # Safety
+///
+/// `session` must be a valid session pointer.
+#[no_mangle]
+pub unsafe extern "C" fn cleat_session_take_control(session: *mut CleatSession) -> bool {
+    let session = match unsafe { session.as_mut() } {
+        Some(session) => session,
+        None => return false,
+    };
+    match &session.backend {
+        SessionBackend::Mock(_) | SessionBackend::InProcess(_) => true,
+        SessionBackend::Daemon(daemon) => {
+            daemon.connection.request_role(daemon.channel, crate::packet::ChannelRole::Controller, true).is_ok()
         }
     }
 }
@@ -1984,7 +2039,7 @@ fn session_scroll_viewport(session: &mut CleatSession, command: Option<ViewportC
         return ViewportCommandOutcome::Unsupported;
     };
     match &mut session.backend {
-        SessionBackend::Mock(_) | SessionBackend::Daemon(_) => match command {
+        SessionBackend::Mock(_) => match command {
             ViewportCommand::Top | ViewportCommand::Bottom | ViewportCommand::DeltaRows(_) => ViewportCommandOutcome::NoOp,
         },
         SessionBackend::InProcess(in_process) => {
@@ -1993,6 +2048,13 @@ fn session_scroll_viewport(session: &mut CleatSession, command: Option<ViewportC
                 Err(_) => ViewportCommandOutcome::Unsupported,
             }
         }
+        // Fire-and-forget over the packet connection: the true outcome shows
+        // up as viewport/scrollbar state in the next render packet, so report
+        // Moved optimistically on send.
+        SessionBackend::Daemon(daemon) => match daemon.connection.send_viewport(daemon.channel, command) {
+            Ok(()) => ViewportCommandOutcome::Moved,
+            Err(_) => ViewportCommandOutcome::NoOp,
+        },
     }
 }
 
@@ -2095,7 +2157,7 @@ fn create_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Re
         colors,
         tags,
     })?;
-    let (channel, slot) = connection.open_session_channel(metadata.id.clone(), cols, rows);
+    let (channel, slot) = connection.open_session_channel(metadata.id.clone(), cols, rows, channel_role_from_ffi(desc.role)?);
     Ok(DaemonSession { id: metadata.id, connection: Arc::clone(connection), channel, slot })
 }
 
@@ -2104,8 +2166,17 @@ fn attach_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Re
     let id = read_optional_utf8(desc.id, desc.id_len)
         .map_err(|err| format!("id is not valid UTF-8: {err}"))?
         .ok_or_else(|| "attach requires a session id".to_string())?;
-    let (channel, slot) = connection.open_session_channel(id.clone(), desc.cols.max(1), desc.rows.max(1));
+    let (channel, slot) =
+        connection.open_session_channel(id.clone(), desc.cols.max(1), desc.rows.max(1), channel_role_from_ffi(desc.role)?);
     Ok(DaemonSession { id, connection: Arc::clone(connection), channel, slot })
+}
+
+fn channel_role_from_ffi(role: u32) -> Result<crate::packet::ChannelRole, String> {
+    match role {
+        CLEAT_ROLE_UNKNOWN | CLEAT_ROLE_CONTROLLER => Ok(crate::packet::ChannelRole::Controller),
+        CLEAT_ROLE_WATCHER => Ok(crate::packet::ChannelRole::Watcher),
+        other => Err(format!("unsupported role tag {other}")),
+    }
 }
 
 fn vt_engine_from_tag(tag: u32) -> Result<VtEngineKind, String> {

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -31,6 +31,10 @@ pub const CLEAT_PROVIDER_BACKEND_DAEMON: u32 = 2;
 pub const CLEAT_PROVIDER_VT_DEFAULT: u32 = 0;
 pub const CLEAT_PROVIDER_VT_PASSTHROUGH: u32 = 1;
 pub const CLEAT_PROVIDER_VT_GHOSTTY: u32 = 2;
+pub const CLEAT_SESSION_CONNECTING: u32 = 0;
+pub const CLEAT_SESSION_STREAMING: u32 = 1;
+pub const CLEAT_SESSION_DISCONNECTED: u32 = 2;
+pub const CLEAT_SESSION_CLOSED: u32 = 3;
 pub const CLEAT_INPUT_KEY: u32 = 1;
 pub const CLEAT_INPUT_TEXT: u32 = 2;
 pub const CLEAT_INPUT_MOUSE: u32 = 3;
@@ -187,6 +191,8 @@ pub struct CleatSessionDesc {
     pub id_len: usize,
     pub record: bool,
     pub colors: *const CleatSessionColors,
+    pub tags: *const CleatStr,
+    pub tag_count: usize,
 }
 
 #[repr(C)]
@@ -511,6 +517,105 @@ pub struct CleatProvider {
     runtime_root: PathBuf,
     wake: Arc<Mutex<WakeCallback>>,
     daemon: Option<Arc<DaemonConnection>>,
+    last_directory: Option<Box<OwnedDirectory>>,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CleatDirectoryEntry {
+    pub session_id: CleatStr,
+    pub state: CleatStr,
+    pub tags: *const CleatStr,
+    pub tag_count: usize,
+    pub controller_count: u32,
+    pub watcher_count: u32,
+    pub recreatable: bool,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CleatDirectory {
+    pub generation: u64,
+    pub entries: *const CleatDirectoryEntry,
+    pub entry_count: usize,
+}
+
+struct OwnedDirectory {
+    directory: CleatDirectory,
+    entries: Vec<CleatDirectoryEntry>,
+    tag_lists: Vec<Vec<CleatStr>>,
+    _strings: Vec<String>,
+}
+
+impl OwnedDirectory {
+    fn from_state(generation: u64, mut sessions: Vec<crate::packet::DirectoryEntry>) -> Box<Self> {
+        struct EntryIndices {
+            session_id: usize,
+            state: usize,
+            tags: Vec<usize>,
+            controller_count: u32,
+            watcher_count: u32,
+            recreatable: bool,
+            cols: u16,
+            rows: u16,
+        }
+        sessions.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+        let mut strings = Vec::new();
+        let mut per_entry: Vec<EntryIndices> = Vec::with_capacity(sessions.len());
+        for entry in sessions {
+            let session_id = strings.len();
+            strings.push(entry.session_id);
+            let state = strings.len();
+            strings.push(entry.state);
+            let mut tags = Vec::with_capacity(entry.tags.len());
+            for tag in entry.tags {
+                tags.push(strings.len());
+                strings.push(tag);
+            }
+            per_entry.push(EntryIndices {
+                session_id,
+                state,
+                tags,
+                controller_count: entry.controller_count,
+                watcher_count: entry.watcher_count,
+                recreatable: entry.recreatable,
+                cols: entry.cols,
+                rows: entry.rows,
+            });
+        }
+        let str_ref = |index: usize| CleatStr { ptr: strings[index].as_ptr(), len: strings[index].len() };
+        let tag_lists: Vec<Vec<CleatStr>> =
+            per_entry.iter().map(|entry| entry.tags.iter().map(|&index| str_ref(index)).collect()).collect();
+        let entries: Vec<CleatDirectoryEntry> = per_entry
+            .iter()
+            .zip(tag_lists.iter())
+            .map(|(entry, tags)| CleatDirectoryEntry {
+                session_id: str_ref(entry.session_id),
+                state: str_ref(entry.state),
+                tags: if tags.is_empty() { ptr::null() } else { tags.as_ptr() },
+                tag_count: tags.len(),
+                controller_count: entry.controller_count,
+                watcher_count: entry.watcher_count,
+                recreatable: entry.recreatable,
+                cols: entry.cols,
+                rows: entry.rows,
+            })
+            .collect();
+        let mut owned = Box::new(Self {
+            directory: CleatDirectory { generation, entries: ptr::null(), entry_count: entries.len() },
+            entries,
+            tag_lists,
+            _strings: strings,
+        });
+        // Self-referential fix-ups: the boxed vectors' addresses are stable now.
+        owned.directory.entries = if owned.entries.is_empty() { ptr::null() } else { owned.entries.as_ptr() };
+        for (entry, tags) in owned.entries.iter_mut().zip(owned.tag_lists.iter()) {
+            entry.tags = if tags.is_empty() { ptr::null() } else { tags.as_ptr() };
+        }
+        owned
+    }
 }
 
 pub struct CleatSession {
@@ -945,7 +1050,72 @@ pub unsafe extern "C" fn cleat_provider_open(desc: *const CleatProviderDesc) -> 
     } else {
         None
     };
-    Box::into_raw(Box::new(CleatProvider { features, backend, runtime_root, wake, daemon }))
+    Box::into_raw(Box::new(CleatProvider { features, backend, runtime_root, wake, daemon, last_directory: None }))
+}
+
+/// Generation counter of the daemon directory subscription. Starts at 0
+/// before the first snapshot arrives and bumps on every snapshot or delta;
+/// callers poll it and re-read the directory when it changes. Always 0 for
+/// non-daemon providers.
+///
+/// # Safety
+///
+/// `provider` must be a valid provider pointer.
+#[no_mangle]
+pub unsafe extern "C" fn cleat_provider_directory_generation(provider: *const CleatProvider) -> u64 {
+    unsafe { provider.as_ref() }
+        .and_then(|provider| provider.daemon.as_ref())
+        .map(|daemon| daemon.with_directory(|directory| directory.generation))
+        .unwrap_or(0)
+}
+
+/// Copy the current daemon directory (session ids, opaque tags, state,
+/// controller/watcher counts, sizes) into caller-visible storage. Entries are
+/// sorted by session id. Only one directory may be live per provider; release
+/// the previous one first.
+///
+/// # Safety
+///
+/// `provider` must be a valid provider pointer. `out` must point to writable
+/// `CleatDirectory` storage. Pointers in `out` stay valid until
+/// `cleat_provider_directory_release`.
+#[no_mangle]
+pub unsafe extern "C" fn cleat_provider_directory_snapshot(provider: *mut CleatProvider, out: *mut CleatDirectory) -> bool {
+    let provider = match unsafe { provider.as_mut() } {
+        Some(provider) => provider,
+        None => return false,
+    };
+    if provider.last_directory.is_some() {
+        return false;
+    }
+    let out = match unsafe { out.as_mut() } {
+        Some(out) => out,
+        None => return false,
+    };
+    let Some(daemon) = provider.daemon.as_ref() else {
+        return false;
+    };
+    let (generation, sessions) =
+        daemon.with_directory(|directory| (directory.generation, directory.entries.values().cloned().collect::<Vec<_>>()));
+    let owned = OwnedDirectory::from_state(generation, sessions);
+    *out = owned.directory;
+    provider.last_directory = Some(owned);
+    true
+}
+
+/// # Safety
+///
+/// `provider` must be a valid provider pointer. `directory` must be the live
+/// directory returned by `cleat_provider_directory_snapshot`.
+#[no_mangle]
+pub unsafe extern "C" fn cleat_provider_directory_release(provider: *mut CleatProvider, directory: *mut CleatDirectory) {
+    let Some(provider) = (unsafe { provider.as_mut() }) else {
+        return;
+    };
+    if let Some(directory) = unsafe { directory.as_mut() } {
+        *directory = CleatDirectory::default();
+    }
+    provider.last_directory = None;
 }
 
 fn read_selector_strings(selectors: *const CleatStr, count: usize) -> Result<Vec<String>, Utf8Error> {
@@ -1016,6 +1186,8 @@ pub unsafe extern "C" fn cleat_session_create(provider: *mut CleatProvider, desc
         id_len: 0,
         record: false,
         colors: ptr::null(),
+        tags: ptr::null(),
+        tag_count: 0,
     });
     let geometry = TerminalGeometry::from_cell_size(desc.cols.max(1), desc.rows.max(1), desc.cell_width_px, desc.cell_height_px);
     let backend = match provider.backend {
@@ -1040,6 +1212,109 @@ pub unsafe extern "C" fn cleat_session_create(provider: *mut CleatProvider, desc
         last_snapshot: None,
         last_render_update: None,
     }))
+}
+
+/// Attach to an existing daemon session by id instead of creating one. The
+/// session must already exist in the daemon's directory; if it does not, the
+/// daemon reports an error on the channel and the session surfaces
+/// `CLEAT_SESSION_CLOSED`. Only `id`, `cols`, `rows`, `cell_width_px`, and
+/// `cell_height_px` of the desc are honored.
+///
+/// # Safety
+///
+/// `provider` must be a valid provider pointer opened with the daemon
+/// backend. `desc` must point to a valid `CleatSessionDesc` with a non-empty
+/// id.
+#[no_mangle]
+pub unsafe extern "C" fn cleat_session_attach(provider: *mut CleatProvider, desc: *const CleatSessionDesc) -> *mut CleatSession {
+    let provider = match unsafe { provider.as_ref() } {
+        Some(provider) => provider,
+        None => return ptr::null_mut(),
+    };
+    if provider.backend != ProviderBackend::Daemon {
+        return ptr::null_mut();
+    }
+    let desc = match unsafe { desc.as_ref() } {
+        Some(desc) => *desc,
+        None => return ptr::null_mut(),
+    };
+    let geometry = TerminalGeometry::from_cell_size(desc.cols.max(1), desc.rows.max(1), desc.cell_width_px, desc.cell_height_px);
+    let backend = match attach_daemon_session(provider, desc) {
+        Ok(session) => SessionBackend::Daemon(session),
+        Err(_) => return ptr::null_mut(),
+    };
+    Box::into_raw(Box::new(CleatSession {
+        backend,
+        geometry,
+        next_input_sequence: 1,
+        wake: provider.wake.clone(),
+        last_snapshot: None,
+        last_render_update: None,
+    }))
+}
+
+/// Daemon session id (the identity used for attach-by-id and shown in the
+/// directory). False for in-process and mock sessions, which have no daemon
+/// identity.
+///
+/// # Safety
+///
+/// `session` must be a valid session pointer. `out` must point to writable
+/// `CleatStr` storage. The returned pointer borrows from the session and stays
+/// valid until the session is destroyed.
+#[no_mangle]
+pub unsafe extern "C" fn cleat_session_id(session: *const CleatSession, out: *mut CleatStr) -> bool {
+    let session = match unsafe { session.as_ref() } {
+        Some(session) => session,
+        None => return false,
+    };
+    let out = match unsafe { out.as_mut() } {
+        Some(out) => out,
+        None => return false,
+    };
+    match &session.backend {
+        SessionBackend::Mock(_) | SessionBackend::InProcess(_) => false,
+        SessionBackend::Daemon(daemon) => {
+            *out = CleatStr { ptr: daemon.id.as_ptr(), len: daemon.id.len() };
+            true
+        }
+    }
+}
+
+/// Connection state of the session's transport. In-process and mock sessions
+/// are always `CLEAT_SESSION_STREAMING`. Daemon sessions report
+/// `CLEAT_SESSION_CONNECTING` until the first render packet arrives,
+/// `CLEAT_SESSION_DISCONNECTED` while the daemon connection is down (it
+/// reconnects with backoff and recovers the stream), and
+/// `CLEAT_SESSION_CLOSED` once the daemon reported the session gone.
+///
+/// # Safety
+///
+/// `session` must be a valid session pointer.
+#[no_mangle]
+pub unsafe extern "C" fn cleat_session_connection_state(session: *const CleatSession) -> u32 {
+    let session = match unsafe { session.as_ref() } {
+        Some(session) => session,
+        None => return CLEAT_SESSION_CLOSED,
+    };
+    match &session.backend {
+        SessionBackend::Mock(_) | SessionBackend::InProcess(_) => CLEAT_SESSION_STREAMING,
+        SessionBackend::Daemon(daemon) => {
+            let slot = match daemon.slot.lock() {
+                Ok(slot) => slot,
+                Err(_) => return CLEAT_SESSION_CLOSED,
+            };
+            if slot.closed.is_some() {
+                CLEAT_SESSION_CLOSED
+            } else if !daemon.connection.is_connected() {
+                CLEAT_SESSION_DISCONNECTED
+            } else if slot.pending.is_some() || slot.last.render_generation > 0 {
+                CLEAT_SESSION_STREAMING
+            } else {
+                CLEAT_SESSION_CONNECTING
+            }
+        }
+    }
 }
 
 /// # Safety
@@ -1813,14 +2088,24 @@ fn create_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Re
     let id = read_optional_utf8(desc.id, desc.id_len).map_err(|err| format!("id is not valid UTF-8: {err}"))?;
     let cols = desc.cols.max(1);
     let rows = desc.rows.max(1);
+    let tags = read_selector_strings(desc.tags, desc.tag_count).map_err(|err| format!("tag is not valid UTF-8: {err}"))?;
     let metadata = ensure_session_started(connection.layout(), id, Some(vt_engine), cwd, cmd, SessionStartOptions {
         record: desc.record,
         initial_size: TerminalSize { cols, rows },
         colors,
-        tags: Vec::new(),
+        tags,
     })?;
     let (channel, slot) = connection.open_session_channel(metadata.id.clone(), cols, rows);
     Ok(DaemonSession { id: metadata.id, connection: Arc::clone(connection), channel, slot })
+}
+
+fn attach_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Result<DaemonSession, String> {
+    let connection = provider.daemon.as_ref().ok_or_else(|| "provider has no daemon connection".to_string())?;
+    let id = read_optional_utf8(desc.id, desc.id_len)
+        .map_err(|err| format!("id is not valid UTF-8: {err}"))?
+        .ok_or_else(|| "attach requires a session id".to_string())?;
+    let (channel, slot) = connection.open_session_channel(id.clone(), desc.cols.max(1), desc.rows.max(1));
+    Ok(DaemonSession { id, connection: Arc::clone(connection), channel, slot })
 }
 
 fn vt_engine_from_tag(tag: u32) -> Result<VtEngineKind, String> {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -50,7 +50,7 @@ const SESSION_DAEMON_IDLE_LINGER: Duration = Duration::from_secs(120);
 const SESSION_HTTP_HANDSHAKE_DEADLINE: Duration = Duration::from_millis(250);
 const SESSION_HTTP_RESPONSE_WRITE_DEADLINE: Duration = Duration::from_millis(250);
 const TERMINATE_SIGNAL: i32 = 15;
-const SESSION_DAEMON_ROOT_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+const SESSION_DAEMON_REGISTRATION_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 const SCREEN_STABLE_CHANGED_CELL_TOLERANCE: usize = 16;
 
 #[derive(Debug)]
@@ -618,7 +618,8 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
         }
     };
     set_listener_nonblocking(&listener, true)?;
-    fs::write(layout.daemon_pid_path(), std::process::id().to_string()).map_err(|err| format!("write daemon pid: {err}"))?;
+    let daemon_pid = std::process::id().to_string();
+    fs::write(layout.daemon_pid_path(), &daemon_pid).map_err(|err| format!("write daemon pid: {err}"))?;
 
     let mut sessions: HashMap<String, HostedSession> = HashMap::new();
     let mut packet_clients: Vec<PacketClient> = Vec::new();
@@ -626,25 +627,29 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
     let mut exited_session: Option<(String, bool)> = None;
     let mut faulted_session: Option<String> = None;
     let mut idle_since = Some(Instant::now());
-    let mut last_root_check = Instant::now();
-    let mut root_was_missing = false;
+    let mut last_registration_check = Instant::now();
+    let mut registration_was_lost = false;
 
     loop {
-        // The runtime root owns this daemon's lifetime. If it disappears
-        // (e.g. a test tempdir was cleaned up), the socket and pid file went
-        // with it, so nothing can ever reach us again — terminate the hosted
-        // sessions and exit instead of servicing them forever. Two
-        // consecutive misses guard against a transient stat failure.
-        if last_root_check.elapsed() >= SESSION_DAEMON_ROOT_CHECK_INTERVAL {
-            last_root_check = Instant::now();
-            let root_missing = !layout.root().exists();
-            if root_missing && root_was_missing {
+        // Self-fencing watchdog: the pid file registers which process owns
+        // this daemon identity. If it no longer names us — the runtime root
+        // was deleted (e.g. a test tempdir was cleaned up), or another daemon
+        // reclaimed the socket — no client can ever route to us again, so
+        // terminate the hosted sessions and exit instead of servicing them
+        // forever. Two consecutive misses guard against transient read
+        // failures.
+        if last_registration_check.elapsed() >= SESSION_DAEMON_REGISTRATION_CHECK_INTERVAL {
+            last_registration_check = Instant::now();
+            let registered = fs::read_to_string(layout.daemon_pid_path()).map(|contents| contents.trim() == daemon_pid).unwrap_or(false);
+            if !registered && registration_was_lost {
                 for hosted in sessions.values() {
                     let _ = hosted.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Leader);
                 }
+                // Deliberately leave the socket and pid file alone on this
+                // path: they are either already gone or owned by a successor.
                 return Ok(());
             }
-            root_was_missing = root_missing;
+            registration_was_lost = !registered;
         }
 
         let mut did_work = false;

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1267,6 +1267,7 @@ fn handle_http_request(
             };
             let body: http_uds::AttachRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP attach request: {err}"))?;
+            vacate_dead_packet_controller(hosted, state.packet_clients);
             if hosted.active_client.is_some() || hosted.packet_controller.is_some() {
                 http_uds::write_error(stream, StatusCode::CONFLICT, "session already has a foreground client")
                     .map_err(|err| format!("write HTTP attach busy response: {err}"))?;
@@ -1852,6 +1853,20 @@ fn release_packet_client_roles(
     Ok(())
 }
 
+/// A dead client awaiting reaping must not hold the controller slot against
+/// a live requester (packet role grants and legacy attach alike).
+fn vacate_dead_packet_controller(hosted: &mut HostedSession, packet_clients: &[PacketClient]) {
+    if let Some(current) = hosted.packet_controller {
+        if !packet_controller_holder_is_live(current, packet_clients) {
+            hosted.packet_controller = None;
+        }
+    }
+}
+
+fn packet_controller_holder_is_live(current: PacketChannelRef, packet_clients: &[PacketClient]) -> bool {
+    packet_clients.iter().any(|client| client.id == current.client_id && !client.dead)
+}
+
 /// Resolve a controller/watcher request for `requester`, demoting the current
 /// packet controller when `take` is set. A legacy stream controller is never
 /// preempted (a raw attach cannot be demoted to read-only), so requests grant
@@ -1874,14 +1889,7 @@ fn grant_packet_role(
             if hosted.active_client.is_some() {
                 return Ok(ChannelRole::Watcher);
             }
-            // A dead client awaiting reaping must not hold the controller
-            // slot against a live requester.
-            if let Some(current) = hosted.packet_controller {
-                let holder_is_live = packet_clients.iter().any(|client| client.id == current.client_id && !client.dead);
-                if !holder_is_live {
-                    hosted.packet_controller = None;
-                }
-            }
+            vacate_dead_packet_controller(hosted, packet_clients);
             match hosted.packet_controller {
                 None => {
                     hosted.packet_controller = Some(requester);
@@ -2537,6 +2545,21 @@ mod tests {
 
         client.enqueue_frame(&frame).expect("enqueue to a dead client is a no-op");
         assert!(client.pending_output.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dead_packet_client_does_not_hold_the_controller_slot() {
+        let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
+        let mut client = super::PacketClient::new(7, stream, Vec::new(), &crate::packet::DirectorySnapshot { sessions: Vec::new() })
+            .expect("create packet client");
+        let holder = super::PacketChannelRef { client_id: 7, channel: 1 };
+
+        assert!(super::packet_controller_holder_is_live(holder, std::slice::from_ref(&client)));
+
+        client.dead = true;
+        assert!(!super::packet_controller_holder_is_live(holder, std::slice::from_ref(&client)));
+        assert!(!super::packet_controller_holder_is_live(holder, &[]), "a reaped holder is not live either");
     }
 
     #[test]

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1874,6 +1874,14 @@ fn grant_packet_role(
             if hosted.active_client.is_some() {
                 return Ok(ChannelRole::Watcher);
             }
+            // A dead client awaiting reaping must not hold the controller
+            // slot against a live requester.
+            if let Some(current) = hosted.packet_controller {
+                let holder_is_live = packet_clients.iter().any(|client| client.id == current.client_id && !client.dead);
+                if !holder_is_live {
+                    hosted.packet_controller = None;
+                }
+            }
             match hosted.packet_controller {
                 None => {
                     hosted.packet_controller = Some(requester);
@@ -1947,47 +1955,25 @@ fn handle_packet_frame(
         }
         (channel, MSG_SESSION_INPUT) if channel != CHANNEL_CONTROL => {
             let input = frame.decode::<Input>().map_err(|err| format!("decode input packet: {err}"))?;
-            if let Some((session_id, role)) =
-                packet_clients[index].channels.get(&channel).map(|session| (session.session_id.clone(), session.role))
-            {
-                // watcher input is dropped, not errored: read-only by role
-                if role == ChannelRole::Controller {
-                    if let Some(hosted) = sessions.get(&session_id) {
-                        route_packet_input_event(&hosted.actor, input.event)?;
-                    }
-                }
+            if let Some(hosted) = controller_session(sessions, packet_clients, index, channel) {
+                route_packet_input_event(&hosted.actor, input.event)?;
             }
         }
         (channel, MSG_SESSION_RESIZE) if channel != CHANNEL_CONTROL => {
             let resize = frame.decode::<Resize>().map_err(|err| format!("decode resize packet: {err}"))?;
-            if let Some((session_id, role)) =
-                packet_clients[index].channels.get(&channel).map(|session| (session.session_id.clone(), session.role))
-            {
-                // watchers never resize the session
-                if role == ChannelRole::Controller {
-                    if let Some(hosted) = sessions.get(&session_id) {
-                        hosted.actor.resize(resize.cols, resize.rows)?;
-                        updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
-                    }
-                }
+            if let Some(hosted) = controller_session(sessions, packet_clients, index, channel) {
+                hosted.actor.resize(resize.cols, resize.rows)?;
+                updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
             }
         }
         (channel, MSG_SESSION_VIEWPORT) if channel != CHANNEL_CONTROL => {
             let viewport = frame.decode::<crate::packet::Viewport>().map_err(|err| format!("decode viewport packet: {err}"))?;
-            if let Some((session_id, role)) =
-                packet_clients[index].channels.get(&channel).map(|session| (session.session_id.clone(), session.role))
-            {
-                // the viewport is session-global state; only the controller
-                // moves it. outcome flows back as viewport/scrollbar state in
-                // the next render packet; no reply message
-                if role == ChannelRole::Controller {
-                    if let Some(hosted) = sessions.get(&session_id) {
-                        let _ = hosted.actor.request_result(|reply| crate::host::actor::SessionCommand::ScrollViewport {
-                            command: viewport.command,
-                            reply,
-                        });
-                    }
-                }
+            // the viewport is session-global state; outcome flows back as
+            // viewport/scrollbar state in the next render packet; no reply
+            if let Some(hosted) = controller_session(sessions, packet_clients, index, channel) {
+                let _ = hosted
+                    .actor
+                    .request_result(|reply| crate::host::actor::SessionCommand::ScrollViewport { command: viewport.command, reply });
             }
         }
         (channel, MSG_SESSION_ROLE) if channel != CHANNEL_CONTROL => {
@@ -1997,6 +1983,22 @@ fn handle_packet_frame(
         _ => {}
     }
     Ok(updates)
+}
+
+/// The session a channel controls: `Some` only when the channel exists and
+/// holds the controller role. Watcher traffic on session-mutating messages
+/// is dropped by role, not errored.
+fn controller_session<'a>(
+    sessions: &'a HashMap<String, HostedSession>,
+    packet_clients: &[PacketClient],
+    index: usize,
+    channel: u32,
+) -> Option<&'a HostedSession> {
+    let session_channel = packet_clients[index].channels.get(&channel)?;
+    if session_channel.role != ChannelRole::Controller {
+        return None;
+    }
+    sessions.get(&session_channel.session_id)
 }
 
 fn apply_packet_role_request(

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -803,10 +803,21 @@ fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
 
 fn remove_packet_channels_for_session(session_id: &str, packet_clients: &mut [PacketClient]) {
     for client in packet_clients {
-        client.channels.retain(|_, channel| channel.session_id != session_id);
+        // Tell the client each affected channel is gone before dropping it.
+        // Directory deltas are selector-filtered, so an attached client may
+        // never see the remove delta; the channel-scoped error is the only
+        // guaranteed close signal. Enqueue failures mean the client transport
+        // is already dead and its teardown path will reap it.
+        let closed: Vec<u32> = client.channels.iter().filter(|(_, ch)| ch.session_id == session_id).map(|(id, _)| *id).collect();
+        for channel in closed {
+            let _ = client.enqueue_control(MSG_CONTROL_ERROR, &ControlError { channel, message: format!("session {session_id} exited") });
+            client.channels.remove(&channel);
+        }
     }
 }
 
+/// O(clients x channels) scan, run on every directory-entry build. Fine at
+/// expected client counts; cache per-session counters if that ever grows.
 fn packet_role_counts(session_id: &str, packet_clients: &[PacketClient]) -> (u32, u32) {
     let mut controllers = 0u32;
     let mut watchers = 0u32;
@@ -1997,10 +2008,22 @@ fn open_packet_channel(
         return Ok(());
     };
 
+    // Probe render state before granting a role: a session whose VT engine
+    // cannot serve it (e.g. the passthrough placeholder) must fail this one
+    // channel, not demote the current controller or tear down the daemon.
+    let update = match hosted.actor.full_render_update() {
+        Ok(update) => update,
+        Err(err) => {
+            packet_clients[index].enqueue_control(MSG_CONTROL_ERROR, &ControlError {
+                channel: open.channel,
+                message: format!("open channel for session {}: {err}", open.session_id),
+            })?;
+            return Ok(());
+        }
+    };
     let requester = PacketChannelRef { client_id: packet_clients[index].id, channel: open.channel };
     let granted = grant_packet_role(hosted, packet_clients, requester, open.role, open.take)?;
     let session_id = open.session_id;
-    let update = hosted.actor.full_render_update()?;
     let generation = update.render_generation;
     hosted.packet_render_cache.store(update.clone());
     let client = &mut packet_clients[index];

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -640,7 +640,14 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
         // failures.
         if last_registration_check.elapsed() >= SESSION_DAEMON_REGISTRATION_CHECK_INTERVAL {
             last_registration_check = Instant::now();
-            let registered = fs::read_to_string(layout.daemon_pid_path()).map(|contents| contents.trim() == daemon_pid).unwrap_or(false);
+            // Only a definitively missing pid file (or one naming another
+            // process) counts as deregistration. A transient read failure
+            // (EIO, permissions blip) must not self-terminate a healthy
+            // daemon — that would drop every hosted session.
+            let registered = match fs::read_to_string(layout.daemon_pid_path()) {
+                Ok(contents) => contents.trim() == daemon_pid,
+                Err(err) => err.kind() != std::io::ErrorKind::NotFound,
+            };
             if !registered && registration_was_lost {
                 for hosted in sessions.values() {
                     let _ = hosted.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Leader);
@@ -725,7 +732,7 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
                     None
                 };
                 Ok((session_did_work, should_keep_session_dir))
-            })?;
+            });
             match service_result {
                 Some((session_did_work, Some(should_keep_session_dir))) => {
                     did_work |= session_did_work;
@@ -778,15 +785,22 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
     Ok(())
 }
 
-fn contain_session_unwind<T, F>(id: &str, action: F) -> Result<Option<T>, String>
+/// Contains both panics and errors from servicing one session: either way
+/// the caller faults that session and the daemon keeps serving the others.
+/// `None` means the session must be faulted.
+fn contain_session_unwind<T, F>(id: &str, action: F) -> Option<T>
 where
     F: FnOnce() -> Result<T, String>,
 {
     match panic::catch_unwind(AssertUnwindSafe(action)) {
-        Ok(result) => result.map(Some),
+        Ok(Ok(result)) => Some(result),
+        Ok(Err(err)) => {
+            eprintln!("contained error while servicing session {id}: {err}");
+            None
+        }
         Err(payload) => {
             eprintln!("contained panic while servicing session {id}: {}", panic_payload_message(payload.as_ref()));
-            Ok(None)
+            None
         }
     }
 }
@@ -1095,7 +1109,7 @@ fn finish_exited_session(
     layout: &RuntimeLayout,
     id: &str,
     hosted: &mut HostedSession,
-    packet_clients: &mut Vec<PacketClient>,
+    packet_clients: &mut [PacketClient],
 ) -> Result<bool, String> {
     drain_raw_output_tap(layout, id, &hosted.actor, &mut hosted.raw_output_tap, &mut hosted.active_client, &mut hosted.watchers)?;
     for mut wait in hosted.pending_waits.drain(..) {
@@ -1652,6 +1666,10 @@ struct PacketClient {
     channels: HashMap<u32, PacketSessionChannel>,
     selectors: Vec<String>,
     known_directory_sessions: HashSet<String>,
+    /// Marked when this client's transport fails or its output backlog
+    /// overflows. Client failures are never daemon-fatal: the client is
+    /// reaped (with role release) on the next servicing pass.
+    dead: bool,
 }
 
 struct PacketSessionChannel {
@@ -1692,6 +1710,7 @@ impl PacketClient {
             channels: HashMap::new(),
             selectors,
             known_directory_sessions: initial_directory.sessions.iter().map(|entry| entry.session_id.clone()).collect(),
+            dead: false,
         })
     }
 
@@ -1700,11 +1719,20 @@ impl PacketClient {
         self.enqueue_frame(&frame)
     }
 
+    /// Errors only on encode failures (a programming error in frame
+    /// construction). A reader that stalls long enough to overflow its
+    /// backlog is a client-scoped failure: the client is marked dead and
+    /// reaped later, never surfaced as a daemon-level error.
     fn enqueue_frame(&mut self, frame: &PacketFrame) -> Result<(), String> {
+        if self.dead {
+            return Ok(());
+        }
         let mut encoded = Vec::new();
         frame.write(&mut encoded).map_err(|err| format!("buffer packet frame: {err}"))?;
         if self.pending_output.len().saturating_add(encoded.len()) > MAX_PENDING_CLIENT_OUTPUT_BYTES {
-            return Err(format!("packet client output backlog exceeded {} bytes", MAX_PENDING_CLIENT_OUTPUT_BYTES));
+            self.dead = true;
+            self.pending_output = Vec::new();
+            return Ok(());
         }
         self.pending_output.extend_from_slice(&encoded);
         Ok(())
@@ -1757,9 +1785,10 @@ fn service_packet_clients(
     let mut index = 0;
     while index < packet_clients.len() {
         let mut pending = VecDeque::new();
-        let connected = packet_clients[index]
-            .drain_input_frames(&mut pending, Duration::ZERO)
-            .map_err(|err| format!("read packet client frame: {err}"))?;
+        // A transport read error is a client-scoped failure, exactly like a
+        // clean disconnect: drop the one client, never the daemon.
+        let connected =
+            !packet_clients[index].dead && packet_clients[index].drain_input_frames(&mut pending, Duration::ZERO).unwrap_or(false);
         if !connected {
             let removed = packet_clients.swap_remove(index);
             release_packet_client_roles(layout, sessions, &removed, packet_clients)?;
@@ -1769,9 +1798,20 @@ fn service_packet_clients(
 
         while let Some(frame) = pending.pop_front() {
             did_work = true;
-            let updates = handle_packet_frame(layout, sessions, packet_clients, index, frame)?;
-            for entry in updates {
-                broadcast_directory_upsert(entry, packet_clients)?;
+            // A frame-handling error is scoped to the client that sent the
+            // frame (its channel bookkeeping is suspect from here on): drop
+            // that client, keep the daemon and its sessions running.
+            match handle_packet_frame(layout, sessions, packet_clients, index, frame) {
+                Ok(updates) => {
+                    for entry in updates {
+                        broadcast_directory_upsert(entry, packet_clients)?;
+                    }
+                }
+                Err(err) => {
+                    eprintln!("dropping packet client after frame error: {err}");
+                    packet_clients[index].dead = true;
+                    break;
+                }
             }
         }
         index += 1;
@@ -1800,8 +1840,13 @@ fn release_packet_client_roles(
     affected.dedup();
     for session_id in affected {
         if let Some(hosted) = sessions.get(session_id) {
-            let entry = directory_entry_for_session(layout, hosted, packet_clients)?;
-            broadcast_directory_upsert(entry, packet_clients)?;
+            // A failing session actor must not turn role release into a
+            // daemon-fatal error; the session faults on its own servicing
+            // pass and broadcasts its removal there.
+            match directory_entry_for_session(layout, hosted, packet_clients) {
+                Ok(entry) => broadcast_directory_upsert(entry, packet_clients)?,
+                Err(err) => eprintln!("skipping directory update for session {session_id}: {err}"),
+            }
         }
     }
     Ok(())
@@ -2216,8 +2261,18 @@ fn packet_named_key_bytes(key: TerminalNamedKey) -> Vec<u8> {
     }
 }
 
-fn flush_packet_clients(packet_clients: &mut Vec<PacketClient>) {
-    packet_clients.retain_mut(|client| client.flush_pending_output().unwrap_or(false));
+/// Flush failures mark the client dead rather than dropping it here:
+/// removal happens in `service_packet_clients`, which also releases any
+/// controller role the client held.
+fn flush_packet_clients(packet_clients: &mut [PacketClient]) {
+    for client in packet_clients {
+        if client.dead {
+            continue;
+        }
+        if !client.flush_pending_output().unwrap_or(false) {
+            client.dead = true;
+        }
+    }
 }
 
 struct ActiveClient {
@@ -2462,6 +2517,33 @@ mod tests {
     fn graceful_socket_shutdown_classifies_broken_pipe_disconnects() {
         let err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "broken pipe");
         assert!(super::is_graceful_socket_shutdown(&err));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn packet_client_backlog_overflow_marks_client_dead_not_daemon_fatal() {
+        let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
+        let mut client = super::PacketClient::new(1, stream, Vec::new(), &crate::packet::DirectorySnapshot { sessions: Vec::new() })
+            .expect("create packet client");
+        client.pending_output = vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1];
+
+        let frame = crate::packet::PacketFrame { channel: 1, msg_type: 0, payload: vec![0; 64] };
+        client.enqueue_frame(&frame).expect("overflow must not surface as a daemon-level error");
+
+        assert!(client.dead, "overflowing client should be marked dead for reaping");
+        assert!(client.pending_output.is_empty(), "backlog should be released");
+
+        client.enqueue_frame(&frame).expect("enqueue to a dead client is a no-op");
+        assert!(client.pending_output.is_empty());
+    }
+
+    #[test]
+    fn contain_session_unwind_contains_errors_as_faults() {
+        let contained = super::contain_session_unwind("alpha", || -> Result<(), String> { Err("actor died".into()) });
+        assert!(contained.is_none(), "a servicing error should fault the session, not the daemon");
+
+        let ok = super::contain_session_unwind("alpha", || Ok(7));
+        assert_eq!(ok, Some(7));
     }
 
     #[cfg(unix)]

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -20,10 +20,10 @@ use crate::{
     host::actor::{RawOutputTap, SessionActor, SessionMouseEvent, SessionWheelEvent},
     http_uds,
     packet::{
-        Ack, CloseChannel, ControlError, ControlHello, DirectoryDelta, DirectoryEntry, DirectorySnapshot, Input, OpenChannel, PacketFrame,
-        RenderPacket, Resize, CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL, MSG_CONTROL_DIRECTORY_DELTA, MSG_CONTROL_DIRECTORY_SNAPSHOT,
-        MSG_CONTROL_ERROR, MSG_CONTROL_HELLO, MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT, MSG_SESSION_RENDER,
-        MSG_SESSION_RESIZE,
+        Ack, ChannelRole, CloseChannel, ControlError, ControlHello, DirectoryDelta, DirectoryEntry, DirectorySnapshot, Input, OpenChannel,
+        PacketFrame, RenderPacket, Resize, RoleRequest, RoleState, CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL, MSG_CONTROL_DIRECTORY_DELTA,
+        MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_ERROR, MSG_CONTROL_HELLO, MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT,
+        MSG_SESSION_RENDER, MSG_SESSION_RESIZE, MSG_SESSION_ROLE, MSG_SESSION_VIEWPORT,
     },
     platform::{
         daemon::{is_session_daemon_alive, spawn_daemon_process},
@@ -50,6 +50,7 @@ const SESSION_DAEMON_IDLE_LINGER: Duration = Duration::from_secs(120);
 const SESSION_HTTP_HANDSHAKE_DEADLINE: Duration = Duration::from_millis(250);
 const SESSION_HTTP_RESPONSE_WRITE_DEADLINE: Duration = Duration::from_millis(250);
 const TERMINATE_SIGNAL: i32 = 15;
+const SESSION_DAEMON_ROOT_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 const SCREEN_STABLE_CHANGED_CELL_TOLERANCE: usize = 16;
 
 #[derive(Debug)]
@@ -491,11 +492,22 @@ struct PendingExpect {
     registered_at: Instant,
 }
 
+/// Identity of a session channel on a packet connection, stable across the
+/// packet_clients vec's swap_remove reordering.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PacketChannelRef {
+    client_id: u64,
+    channel: u32,
+}
+
 struct HostedSession {
     actor: SessionActor,
     raw_output_tap: RawOutputTap,
     active_client: Option<ActiveClient>,
     watchers: Vec<ActiveClient>,
+    /// Packet channel currently holding the controller role. Mutually
+    /// exclusive with `active_client` (the legacy stream controller).
+    packet_controller: Option<PacketChannelRef>,
     packet_render_cache: PacketRenderCache,
     had_foreground_client: bool,
     pending_waits: Vec<PendingWait>,
@@ -516,6 +528,7 @@ impl HostedSession {
             raw_output_tap,
             active_client: None,
             watchers: Vec::new(),
+            packet_controller: None,
             packet_render_cache: PacketRenderCache::default(),
             had_foreground_client: false,
             pending_waits: Vec::new(),
@@ -607,13 +620,33 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
     set_listener_nonblocking(&listener, true)?;
     fs::write(layout.daemon_pid_path(), std::process::id().to_string()).map_err(|err| format!("write daemon pid: {err}"))?;
 
-    let mut sessions = HashMap::new();
+    let mut sessions: HashMap<String, HostedSession> = HashMap::new();
     let mut packet_clients: Vec<PacketClient> = Vec::new();
+    let mut next_packet_client_id: u64 = 1;
     let mut exited_session: Option<(String, bool)> = None;
     let mut faulted_session: Option<String> = None;
     let mut idle_since = Some(Instant::now());
+    let mut last_root_check = Instant::now();
+    let mut root_was_missing = false;
 
     loop {
+        // The runtime root owns this daemon's lifetime. If it disappears
+        // (e.g. a test tempdir was cleaned up), the socket and pid file went
+        // with it, so nothing can ever reach us again — terminate the hosted
+        // sessions and exit instead of servicing them forever. Two
+        // consecutive misses guard against a transient stat failure.
+        if last_root_check.elapsed() >= SESSION_DAEMON_ROOT_CHECK_INTERVAL {
+            last_root_check = Instant::now();
+            let root_missing = !layout.root().exists();
+            if root_missing && root_was_missing {
+                for hosted in sessions.values() {
+                    let _ = hosted.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Leader);
+                }
+                return Ok(());
+            }
+            root_was_missing = root_missing;
+        }
+
         let mut did_work = false;
 
         loop {
@@ -654,7 +687,12 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
                         }
                     };
 
-                    let mut http_state = HttpRequestState { layout: &layout, sessions: &mut sessions, packet_clients: &mut packet_clients };
+                    let mut http_state = HttpRequestState {
+                        layout: &layout,
+                        sessions: &mut sessions,
+                        packet_clients: &mut packet_clients,
+                        next_packet_client_id: &mut next_packet_client_id,
+                    };
                     if let Err(err) = handle_http_request(root, daemon_name, &mut stream, request, &mut http_state) {
                         let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &err);
                     }
@@ -764,14 +802,35 @@ fn remove_packet_channels_for_session(session_id: &str, packet_clients: &mut [Pa
     }
 }
 
-fn directory_entry_for_session(layout: &RuntimeLayout, hosted: &HostedSession) -> Result<DirectoryEntry, String> {
+fn packet_role_counts(session_id: &str, packet_clients: &[PacketClient]) -> (u32, u32) {
+    let mut controllers = 0u32;
+    let mut watchers = 0u32;
+    for client in packet_clients {
+        for session_channel in client.channels.values() {
+            if session_channel.session_id == session_id {
+                match session_channel.role {
+                    ChannelRole::Controller => controllers = controllers.saturating_add(1),
+                    ChannelRole::Watcher => watchers = watchers.saturating_add(1),
+                }
+            }
+        }
+    }
+    (controllers, watchers)
+}
+
+fn directory_entry_for_session(
+    layout: &RuntimeLayout,
+    hosted: &HostedSession,
+    packet_clients: &[PacketClient],
+) -> Result<DirectoryEntry, String> {
     let inspect = hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?;
+    let (packet_controllers, packet_watchers) = packet_role_counts(&inspect.session.id, packet_clients);
     Ok(DirectoryEntry {
         session_id: inspect.session.id.clone(),
         tags: inspect.session.tags,
         state: inspect.session.state,
-        controller_count: if hosted.active_client.is_some() { 1 } else { 0 },
-        watcher_count: u32::try_from(hosted.watchers.len()).unwrap_or(u32::MAX),
+        controller_count: (if hosted.active_client.is_some() { 1 } else { 0 }) + packet_controllers,
+        watcher_count: u32::try_from(hosted.watchers.len()).unwrap_or(u32::MAX).saturating_add(packet_watchers),
         recreatable: crate::recreate::session_is_recreatable(&layout.session_dir(&inspect.session.id)),
         cols: inspect.terminal.cols,
         rows: inspect.terminal.rows,
@@ -781,11 +840,12 @@ fn directory_entry_for_session(layout: &RuntimeLayout, hosted: &HostedSession) -
 fn directory_snapshot_for_sessions(
     layout: &RuntimeLayout,
     sessions: &HashMap<String, HostedSession>,
+    packet_clients: &[PacketClient],
     selectors: &[String],
 ) -> Result<DirectorySnapshot, String> {
     let mut entries = Vec::new();
     for hosted in sessions.values() {
-        let entry = directory_entry_for_session(layout, hosted)?;
+        let entry = directory_entry_for_session(layout, hosted, packet_clients)?;
         if directory_entry_matches_selectors(&entry, selectors) {
             entries.push(entry);
         }
@@ -910,7 +970,7 @@ fn service_hosted_session(
     push_due_packet_renders(id, &hosted.actor, packet_clients, &mut hosted.packet_render_cache)?;
 
     if resized || previous_controller_count != hosted.active_client.is_some() || previous_watcher_count != hosted.watchers.len() {
-        broadcast_directory_upsert(directory_entry_for_session(layout, hosted)?, packet_clients)?;
+        broadcast_directory_upsert(directory_entry_for_session(layout, hosted, packet_clients)?, packet_clients)?;
     }
 
     service_pending_waits(&hosted.actor, &mut hosted.pending_waits);
@@ -1047,6 +1107,7 @@ struct HttpRequestState<'a> {
     layout: &'a RuntimeLayout,
     sessions: &'a mut HashMap<String, HostedSession>,
     packet_clients: &'a mut Vec<PacketClient>,
+    next_packet_client_id: &'a mut u64,
 }
 
 struct HttpHandshakeReader<'a> {
@@ -1120,7 +1181,10 @@ fn handle_http_request(
             }
             if created {
                 if let Some(hosted) = state.sessions.get(&session.id) {
-                    broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
+                    broadcast_directory_upsert(
+                        directory_entry_for_session(state.layout, hosted, state.packet_clients)?,
+                        state.packet_clients,
+                    )?;
                 }
             }
             http_uds::write_json(stream, StatusCode::OK, &http_uds::CreateSessionResponse { session })
@@ -1140,12 +1204,14 @@ fn handle_http_request(
             };
             let mut selectors = subscribe.selectors;
             crate::runtime::normalize_tags(&mut selectors);
-            let directory = directory_snapshot_for_sessions(state.layout, state.sessions, &selectors)?;
+            let directory = directory_snapshot_for_sessions(state.layout, state.sessions, state.packet_clients, &selectors)?;
             http_uds::write_packet_switching_protocols(stream).map_err(|err| format!("write HTTP packet upgrade response: {err}"))?;
             let packet_stream = stream.try_clone().map_err(|err| format!("clone HTTP packet stream: {err}"))?;
             #[cfg(unix)]
             set_stream_nonblocking(&packet_stream, true).map_err(|err| format!("set HTTP packet stream nonblocking: {err}"))?;
-            let mut client = PacketClient::new(packet_stream, selectors, &directory)?;
+            let client_id = *state.next_packet_client_id;
+            *state.next_packet_client_id += 1;
+            let mut client = PacketClient::new(client_id, packet_stream, selectors, &directory)?;
             client.enqueue_control(MSG_CONTROL_HELLO, &ControlHello::current())?;
             client.enqueue_control(MSG_CONTROL_DIRECTORY_SNAPSHOT, &directory)?;
             state.packet_clients.push(client);
@@ -1171,7 +1237,7 @@ fn handle_http_request(
             };
             let body: http_uds::AttachRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP attach request: {err}"))?;
-            if hosted.active_client.is_some() {
+            if hosted.active_client.is_some() || hosted.packet_controller.is_some() {
                 http_uds::write_error(stream, StatusCode::CONFLICT, "session already has a foreground client")
                     .map_err(|err| format!("write HTTP attach busy response: {err}"))?;
                 break 'attach Ok(());
@@ -1197,7 +1263,7 @@ fn handle_http_request(
             hosted.had_foreground_client = true;
             hosted.actor.set_client_presence(true)?;
             hosted.actor.record_attach()?;
-            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
             Ok(())
         }
         http_uds::Route::SessionWatch { id } => {
@@ -1219,7 +1285,7 @@ fn handle_http_request(
                 }
             }
             hosted.watchers.push(watcher);
-            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
             Ok(())
         }
         http_uds::Route::SessionDetach { id } => {
@@ -1232,7 +1298,7 @@ fn handle_http_request(
             }
             hosted.actor.set_client_presence(false)?;
             hosted.active_client = None;
-            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP detach response: {err}"))
         }
         http_uds::Route::SessionExpect { id } => 'expect: {
@@ -1302,7 +1368,10 @@ fn handle_http_request(
                 }
                 http_uds::InputRequest::Resize { cols, rows } => {
                     hosted.actor.resize(cols, rows)?;
-                    broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
+                    broadcast_directory_upsert(
+                        directory_entry_for_session(state.layout, hosted, state.packet_clients)?,
+                        state.packet_clients,
+                    )?;
                 }
             }
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP input response: {err}"))
@@ -1352,7 +1421,7 @@ fn handle_http_request(
             let body: http_uds::TagRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP tag request: {err}"))?;
             let tags = hosted.actor.update_tags(body.add, body.remove)?;
-            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::TagResponse { tags })
                 .map_err(|err| format!("write HTTP tag response: {err}"))
         }
@@ -1397,7 +1466,7 @@ fn handle_http_request(
             let body: http_uds::ResizeRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP resize request: {err}"))?;
             hosted.actor.resize(body.cols, body.rows)?;
-            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted)?, state.packet_clients)?;
+            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP resize response: {err}"))
         }
         http_uds::Route::SessionScreen { id } => {
@@ -1559,6 +1628,7 @@ fn http_input_key_bytes(key: http_uds::KeyRequest) -> Vec<u8> {
 }
 
 struct PacketClient {
+    id: u64,
     stream: SessionStream,
     pending_output: Vec<u8>,
     input_reader: ActiveClientReader,
@@ -1570,6 +1640,7 @@ struct PacketClient {
 
 struct PacketSessionChannel {
     session_id: String,
+    role: ChannelRole,
     in_flight_generation: Option<u64>,
     last_sent_generation: u64,
 }
@@ -1594,9 +1665,10 @@ impl PacketRenderCache {
 }
 
 impl PacketClient {
-    fn new(stream: SessionStream, selectors: Vec<String>, initial_directory: &DirectorySnapshot) -> Result<Self, String> {
+    fn new(id: u64, stream: SessionStream, selectors: Vec<String>, initial_directory: &DirectorySnapshot) -> Result<Self, String> {
         let input_reader = ActiveClientReader::new(&stream)?;
         Ok(Self {
+            id,
             stream,
             pending_output: Vec::new(),
             input_reader,
@@ -1673,14 +1745,16 @@ fn service_packet_clients(
             .drain_input_frames(&mut pending, Duration::ZERO)
             .map_err(|err| format!("read packet client frame: {err}"))?;
         if !connected {
-            packet_clients.swap_remove(index);
+            let removed = packet_clients.swap_remove(index);
+            release_packet_client_roles(layout, sessions, &removed, packet_clients)?;
             did_work = true;
             continue;
         }
 
         while let Some(frame) = pending.pop_front() {
             did_work = true;
-            if let Some(entry) = handle_packet_frame(layout, sessions, &mut packet_clients[index], frame)? {
+            let updates = handle_packet_frame(layout, sessions, packet_clients, index, frame)?;
+            for entry in updates {
                 broadcast_directory_upsert(entry, packet_clients)?;
             }
         }
@@ -1689,24 +1763,117 @@ fn service_packet_clients(
     Ok(did_work)
 }
 
+/// Free controller slots held by a disconnected packet client and re-announce
+/// the affected sessions' attachment counts.
+fn release_packet_client_roles(
+    layout: &RuntimeLayout,
+    sessions: &mut HashMap<String, HostedSession>,
+    removed: &PacketClient,
+    packet_clients: &mut Vec<PacketClient>,
+) -> Result<(), String> {
+    let mut affected: Vec<&String> = Vec::new();
+    for (channel, session_channel) in &removed.channels {
+        if let Some(hosted) = sessions.get_mut(&session_channel.session_id) {
+            if hosted.packet_controller == Some(PacketChannelRef { client_id: removed.id, channel: *channel }) {
+                hosted.packet_controller = None;
+            }
+        }
+        affected.push(&session_channel.session_id);
+    }
+    affected.sort();
+    affected.dedup();
+    for session_id in affected {
+        if let Some(hosted) = sessions.get(session_id) {
+            let entry = directory_entry_for_session(layout, hosted, packet_clients)?;
+            broadcast_directory_upsert(entry, packet_clients)?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a controller/watcher request for `requester`, demoting the current
+/// packet controller when `take` is set. A legacy stream controller is never
+/// preempted (a raw attach cannot be demoted to read-only), so requests grant
+/// Watcher while one is attached.
+fn grant_packet_role(
+    hosted: &mut HostedSession,
+    packet_clients: &mut [PacketClient],
+    requester: PacketChannelRef,
+    role: ChannelRole,
+    take: bool,
+) -> Result<ChannelRole, String> {
+    match role {
+        ChannelRole::Watcher => {
+            if hosted.packet_controller == Some(requester) {
+                hosted.packet_controller = None;
+            }
+            Ok(ChannelRole::Watcher)
+        }
+        ChannelRole::Controller => {
+            if hosted.active_client.is_some() {
+                return Ok(ChannelRole::Watcher);
+            }
+            match hosted.packet_controller {
+                None => {
+                    hosted.packet_controller = Some(requester);
+                    Ok(ChannelRole::Controller)
+                }
+                Some(current) if current == requester => Ok(ChannelRole::Controller),
+                Some(current) => {
+                    if !take {
+                        return Ok(ChannelRole::Watcher);
+                    }
+                    for client in packet_clients.iter_mut() {
+                        if client.id != current.client_id {
+                            continue;
+                        }
+                        if let Some(session_channel) = client.channels.get_mut(&current.channel) {
+                            session_channel.role = ChannelRole::Watcher;
+                        }
+                        client.enqueue_frame(
+                            &PacketFrame::new(current.channel, MSG_SESSION_ROLE, &RoleState { role: ChannelRole::Watcher })
+                                .map_err(|err| format!("encode role demotion packet: {err}"))?,
+                        )?;
+                        break;
+                    }
+                    hosted.packet_controller = Some(requester);
+                    Ok(ChannelRole::Controller)
+                }
+            }
+        }
+    }
+}
+
 fn handle_packet_frame(
     layout: &RuntimeLayout,
     sessions: &mut HashMap<String, HostedSession>,
-    client: &mut PacketClient,
+    packet_clients: &mut [PacketClient],
+    index: usize,
     frame: PacketFrame,
-) -> Result<Option<DirectoryEntry>, String> {
-    let mut directory_update = None;
+) -> Result<Vec<DirectoryEntry>, String> {
+    let mut updates = Vec::new();
     match (frame.channel, frame.msg_type) {
         (CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL) => {
             let open = frame.decode::<OpenChannel>().map_err(|err| format!("decode open-channel packet: {err}"))?;
-            open_packet_channel(sessions, client, open)?;
+            open_packet_channel(layout, sessions, packet_clients, index, open, &mut updates)?;
         }
         (CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL) => {
             let close = frame.decode::<CloseChannel>().map_err(|err| format!("decode close-channel packet: {err}"))?;
-            client.channels.remove(&close.channel);
+            let client_id = packet_clients[index].id;
+            if let Some(removed) = packet_clients[index].channels.remove(&close.channel) {
+                if let Some(hosted) = sessions.get_mut(&removed.session_id) {
+                    if hosted.packet_controller == Some(PacketChannelRef { client_id, channel: close.channel }) {
+                        hosted.packet_controller = None;
+                    }
+                }
+                if let Some(hosted) = sessions.get(&removed.session_id) {
+                    updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
+                }
+            }
         }
         (channel, MSG_SESSION_ACK) if channel != CHANNEL_CONTROL => {
             let ack = frame.decode::<Ack>().map_err(|err| format!("decode ack packet: {err}"))?;
+            let client = &mut packet_clients[index];
             let session_id = client.channels.get(&channel).map(|session| session.session_id.clone());
             if let Some(session_channel) = client.channels.get_mut(&channel) {
                 if session_channel.in_flight_generation == Some(ack.generation) {
@@ -1719,55 +1886,136 @@ fn handle_packet_frame(
         }
         (channel, MSG_SESSION_INPUT) if channel != CHANNEL_CONTROL => {
             let input = frame.decode::<Input>().map_err(|err| format!("decode input packet: {err}"))?;
-            if let Some(session_id) = client.channels.get(&channel).map(|session| session.session_id.clone()) {
-                if let Some(hosted) = sessions.get(&session_id) {
-                    route_packet_input_event(&hosted.actor, input.event)?;
+            if let Some((session_id, role)) =
+                packet_clients[index].channels.get(&channel).map(|session| (session.session_id.clone(), session.role))
+            {
+                // watcher input is dropped, not errored: read-only by role
+                if role == ChannelRole::Controller {
+                    if let Some(hosted) = sessions.get(&session_id) {
+                        route_packet_input_event(&hosted.actor, input.event)?;
+                    }
                 }
             }
         }
         (channel, MSG_SESSION_RESIZE) if channel != CHANNEL_CONTROL => {
             let resize = frame.decode::<Resize>().map_err(|err| format!("decode resize packet: {err}"))?;
-            if let Some(session_id) = client.channels.get(&channel).map(|session| session.session_id.clone()) {
-                if let Some(hosted) = sessions.get(&session_id) {
-                    hosted.actor.resize(resize.cols, resize.rows)?;
-                    directory_update = Some(directory_entry_for_session(layout, hosted)?);
+            if let Some((session_id, role)) =
+                packet_clients[index].channels.get(&channel).map(|session| (session.session_id.clone(), session.role))
+            {
+                // watchers never resize the session
+                if role == ChannelRole::Controller {
+                    if let Some(hosted) = sessions.get(&session_id) {
+                        hosted.actor.resize(resize.cols, resize.rows)?;
+                        updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
+                    }
                 }
             }
         }
+        (channel, MSG_SESSION_VIEWPORT) if channel != CHANNEL_CONTROL => {
+            let viewport = frame.decode::<crate::packet::Viewport>().map_err(|err| format!("decode viewport packet: {err}"))?;
+            if let Some((session_id, role)) =
+                packet_clients[index].channels.get(&channel).map(|session| (session.session_id.clone(), session.role))
+            {
+                // the viewport is session-global state; only the controller
+                // moves it. outcome flows back as viewport/scrollbar state in
+                // the next render packet; no reply message
+                if role == ChannelRole::Controller {
+                    if let Some(hosted) = sessions.get(&session_id) {
+                        let _ = hosted.actor.request_result(|reply| crate::host::actor::SessionCommand::ScrollViewport {
+                            command: viewport.command,
+                            reply,
+                        });
+                    }
+                }
+            }
+        }
+        (channel, MSG_SESSION_ROLE) if channel != CHANNEL_CONTROL => {
+            let request = frame.decode::<RoleRequest>().map_err(|err| format!("decode role request packet: {err}"))?;
+            apply_packet_role_request(layout, sessions, packet_clients, index, channel, request, &mut updates)?;
+        }
         _ => {}
     }
-    Ok(directory_update)
+    Ok(updates)
 }
 
-fn open_packet_channel(sessions: &mut HashMap<String, HostedSession>, client: &mut PacketClient, open: OpenChannel) -> Result<(), String> {
+fn apply_packet_role_request(
+    layout: &RuntimeLayout,
+    sessions: &mut HashMap<String, HostedSession>,
+    packet_clients: &mut [PacketClient],
+    index: usize,
+    channel: u32,
+    request: RoleRequest,
+    updates: &mut Vec<DirectoryEntry>,
+) -> Result<(), String> {
+    let Some(session_id) = packet_clients[index].channels.get(&channel).map(|session| session.session_id.clone()) else {
+        return Ok(());
+    };
+    let Some(hosted) = sessions.get_mut(&session_id) else {
+        return Ok(());
+    };
+    let requester = PacketChannelRef { client_id: packet_clients[index].id, channel };
+    let granted = grant_packet_role(hosted, packet_clients, requester, request.role, request.take)?;
+    let client = &mut packet_clients[index];
+    if let Some(session_channel) = client.channels.get_mut(&channel) {
+        session_channel.role = granted;
+    }
+    client.enqueue_frame(
+        &PacketFrame::new(channel, MSG_SESSION_ROLE, &RoleState { role: granted })
+            .map_err(|err| format!("encode role state packet: {err}"))?,
+    )?;
+    if let Some(hosted) = sessions.get(&session_id) {
+        updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
+    }
+    Ok(())
+}
+
+fn open_packet_channel(
+    layout: &RuntimeLayout,
+    sessions: &mut HashMap<String, HostedSession>,
+    packet_clients: &mut [PacketClient],
+    index: usize,
+    open: OpenChannel,
+    updates: &mut Vec<DirectoryEntry>,
+) -> Result<(), String> {
     if open.channel == CHANNEL_CONTROL {
-        client.enqueue_control(MSG_CONTROL_ERROR, &ControlError {
+        packet_clients[index].enqueue_control(MSG_CONTROL_ERROR, &ControlError {
             channel: open.channel,
             message: "session channel must be non-zero".to_string(),
         })?;
         return Ok(());
     }
     let Some(hosted) = sessions.get_mut(&open.session_id) else {
-        client.enqueue_control(MSG_CONTROL_ERROR, &ControlError {
+        packet_clients[index].enqueue_control(MSG_CONTROL_ERROR, &ControlError {
             channel: open.channel,
             message: format!("unknown session {}", open.session_id),
         })?;
         return Ok(());
     };
 
+    let requester = PacketChannelRef { client_id: packet_clients[index].id, channel: open.channel };
+    let granted = grant_packet_role(hosted, packet_clients, requester, open.role, open.take)?;
     let session_id = open.session_id;
     let update = hosted.actor.full_render_update()?;
     let generation = update.render_generation;
     hosted.packet_render_cache.store(update.clone());
+    let client = &mut packet_clients[index];
+    client.enqueue_frame(
+        &PacketFrame::new(open.channel, MSG_SESSION_ROLE, &RoleState { role: granted })
+            .map_err(|err| format!("encode role state packet: {err}"))?,
+    )?;
     client.enqueue_frame(
         &PacketFrame::new(open.channel, MSG_SESSION_RENDER, &RenderPacket { update })
             .map_err(|err| format!("encode initial render packet: {err}"))?,
     )?;
     client.channels.insert(open.channel, PacketSessionChannel {
-        session_id,
+        session_id: session_id.clone(),
+        role: granted,
         in_flight_generation: Some(generation),
         last_sent_generation: generation,
     });
+    if let Some(hosted) = sessions.get(&session_id) {
+        updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
+    }
     Ok(())
 }
 

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -33,7 +33,10 @@ use cleat::{
 };
 #[cfg(feature = "ghostty-vt")]
 use cleat::{
-    packet::{Ack, Input, OpenChannel, RenderPacket, MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT, MSG_SESSION_RENDER},
+    packet::{
+        Ack, ChannelRole, Input, OpenChannel, RenderPacket, RoleRequest, RoleState, MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK,
+        MSG_SESSION_INPUT, MSG_SESSION_RENDER, MSG_SESSION_ROLE,
+    },
     provider::{TerminalInputEvent, TerminalPasteEvent, TerminalRenderUpdate, TerminalTextEvent},
 };
 
@@ -115,7 +118,87 @@ fn packet_write<T: serde::Serialize>(stream: &mut UnixStream, channel: u32, msg_
 
 #[cfg(feature = "ghostty-vt")]
 fn packet_open_channel(stream: &mut UnixStream, channel: u32, session_id: &str) {
-    packet_write(stream, CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL, &OpenChannel { channel, session_id: session_id.to_string() });
+    packet_open_channel_role(stream, channel, session_id, ChannelRole::Controller, false);
+}
+
+#[cfg(feature = "ghostty-vt")]
+fn packet_open_channel_role(stream: &mut UnixStream, channel: u32, session_id: &str, role: ChannelRole, take: bool) {
+    packet_write(stream, CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL, &OpenChannel {
+        channel,
+        session_id: session_id.to_string(),
+        role,
+        take,
+    });
+}
+
+/// Frame reader with a persistent buffer. The free-standing read helpers each
+/// use a private buffer and silently drop any frame that arrived in the same
+/// chunk as the one they return; when consecutive frames matter (role state
+/// followed by a render), reads must share one buffer.
+#[cfg(feature = "ghostty-vt")]
+struct PacketReader<'a> {
+    stream: &'a mut UnixStream,
+    buffer: Vec<u8>,
+}
+
+#[cfg(feature = "ghostty-vt")]
+impl<'a> PacketReader<'a> {
+    fn new(stream: &'a mut UnixStream) -> Self {
+        stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
+        Self { stream, buffer: Vec::new() }
+    }
+
+    fn next_matching(&mut self, timeout: Duration, mut keep: impl FnMut(&PacketFrame) -> bool, label: &str) -> PacketFrame {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            while let Some(frame) = PacketFrame::read_from_buffer(&mut self.buffer).expect("parse packet buffer") {
+                if keep(&frame) {
+                    return frame;
+                }
+            }
+            let mut chunk = [0; 4096];
+            match self.stream.read(&mut chunk) {
+                Ok(0) => panic!("packet stream closed while waiting for {label}"),
+                Ok(n) => self.buffer.extend_from_slice(&chunk[..n]),
+                Err(err) if packet_read_would_wait(&err) => {}
+                Err(err) => panic!("read packet frame: {err}"),
+            }
+        }
+        panic!("timed out waiting for {label}");
+    }
+
+    fn role(&mut self, channel: u32, timeout: Duration) -> ChannelRole {
+        self.next_matching(timeout, |frame| frame.channel == channel && frame.msg_type == MSG_SESSION_ROLE, "role state packet")
+            .decode::<RoleState>()
+            .expect("decode role state packet")
+            .role
+    }
+
+    fn render(&mut self, channel: u32, timeout: Duration) -> TerminalRenderUpdate {
+        self.next_matching(timeout, |frame| frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER, "render packet")
+            .decode::<RenderPacket>()
+            .expect("decode render packet")
+            .update
+    }
+
+    fn expect_no_render(&mut self, channel: u32, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            while let Some(frame) = PacketFrame::read_from_buffer(&mut self.buffer).expect("parse packet buffer") {
+                assert!(
+                    !(frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER),
+                    "unexpected render packet on channel {channel}"
+                );
+            }
+            let mut chunk = [0; 4096];
+            match self.stream.read(&mut chunk) {
+                Ok(0) => return,
+                Ok(n) => self.buffer.extend_from_slice(&chunk[..n]),
+                Err(err) if packet_read_would_wait(&err) => {}
+                Err(err) => panic!("read packet frame: {err}"),
+            }
+        }
+    }
 }
 
 #[cfg(feature = "ghostty-vt")]
@@ -129,12 +212,11 @@ fn packet_input(stream: &mut UnixStream, channel: u32, event: TerminalInputEvent
 }
 
 #[cfg(feature = "ghostty-vt")]
-fn read_packet_render(stream: &mut UnixStream, channel: u32, timeout: Duration) -> TerminalRenderUpdate {
+fn read_packet_render(stream: &mut UnixStream, buffer: &mut Vec<u8>, channel: u32, timeout: Duration) -> TerminalRenderUpdate {
     stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
     let deadline = Instant::now() + timeout;
-    let mut buffer = Vec::new();
     while Instant::now() < deadline {
-        while let Some(frame) = PacketFrame::read_from_buffer(&mut buffer).expect("parse packet buffer") {
+        while let Some(frame) = PacketFrame::read_from_buffer(buffer).expect("parse packet buffer") {
             if frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER {
                 return frame.decode::<RenderPacket>().expect("decode render packet").update;
             }
@@ -150,12 +232,11 @@ fn read_packet_render(stream: &mut UnixStream, channel: u32, timeout: Duration) 
     panic!("timed out waiting for render packet on channel {channel}");
 }
 
-fn read_directory_delta_named(stream: &mut UnixStream, timeout: Duration, label: &str) -> DirectoryDelta {
+fn read_directory_delta_named(stream: &mut UnixStream, buffer: &mut Vec<u8>, timeout: Duration, label: &str) -> DirectoryDelta {
     stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
     let deadline = Instant::now() + timeout;
-    let mut buffer = Vec::new();
     while Instant::now() < deadline {
-        while let Some(frame) = PacketFrame::read_from_buffer(&mut buffer).expect("parse packet buffer") {
+        while let Some(frame) = PacketFrame::read_from_buffer(buffer).expect("parse packet buffer") {
             if frame.channel == CHANNEL_CONTROL && frame.msg_type == MSG_CONTROL_DIRECTORY_DELTA {
                 return frame.decode::<DirectoryDelta>().expect("decode directory delta");
             }
@@ -171,11 +252,11 @@ fn read_directory_delta_named(stream: &mut UnixStream, timeout: Duration, label:
     panic!("timed out waiting for {label}");
 }
 
-fn read_until_directory_remove(stream: &mut UnixStream, session_id: &str, timeout: Duration) -> DirectoryDelta {
+fn read_until_directory_remove(stream: &mut UnixStream, buffer: &mut Vec<u8>, session_id: &str, timeout: Duration) -> DirectoryDelta {
     let deadline = Instant::now() + timeout;
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
-        let delta = read_directory_delta_named(stream, remaining, &format!("remove delta for {session_id}"));
+        let delta = read_directory_delta_named(stream, buffer, remaining, &format!("remove delta for {session_id}"));
         if delta.removed_session_ids.iter().any(|id| id == session_id) {
             return delta;
         }
@@ -184,13 +265,12 @@ fn read_until_directory_remove(stream: &mut UnixStream, session_id: &str, timeou
 }
 
 #[cfg(feature = "ghostty-vt")]
-fn expect_no_packet(stream: &mut UnixStream, timeout: Duration) {
+fn expect_no_render(stream: &mut UnixStream, buffer: &mut Vec<u8>, timeout: Duration) {
     stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
     let deadline = Instant::now() + timeout;
-    let mut buffer = Vec::new();
     while Instant::now() < deadline {
-        if let Some(frame) = PacketFrame::read_from_buffer(&mut buffer).expect("parse packet buffer") {
-            panic!("unexpected packet frame: {frame:?}");
+        if let Some(frame) = PacketFrame::read_from_buffer(buffer).expect("parse packet buffer") {
+            assert!(frame.msg_type != MSG_SESSION_RENDER, "unexpected render packet frame: {frame:?}");
         }
         let mut chunk = [0; 4096];
         match stream.read(&mut chunk) {
@@ -566,6 +646,7 @@ fn directory_subscription_filters_and_emits_lifecycle_deltas() {
         )
         .expect("create alpha");
     let mut stream = http_packet_stream_with_selectors(temp.path(), "alpha", std::slice::from_ref(&selector));
+    let mut buffer = Vec::new();
     stream.set_read_timeout(Some(Duration::from_secs(2))).expect("set read timeout");
     let hello_frame = PacketFrame::read(&mut stream).expect("read hello");
     let directory_frame = PacketFrame::read(&mut stream).expect("read directory");
@@ -591,17 +672,17 @@ fn directory_subscription_filters_and_emits_lifecycle_deltas() {
             },
         )
         .expect("create gamma");
-    let delta = read_directory_delta_named(&mut stream, Duration::from_secs(30), "gamma create delta");
+    let delta = read_directory_delta_named(&mut stream, &mut buffer, Duration::from_secs(30), "gamma create delta");
     assert_eq!(delta.removed_session_ids, Vec::<String>::new());
     assert_eq!(delta.upserted.iter().map(|entry| entry.session_id.as_str()).collect::<Vec<_>>(), vec!["gamma"]);
 
     service.create(Some("beta".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create beta");
     service.update_tags("beta", vec![selector.clone()], Vec::new()).expect("tag beta");
-    let delta = read_directory_delta_named(&mut stream, Duration::from_secs(30), "beta retag delta");
+    let delta = read_directory_delta_named(&mut stream, &mut buffer, Duration::from_secs(30), "beta retag delta");
     assert_eq!(delta.upserted.iter().map(|entry| entry.session_id.as_str()).collect::<Vec<_>>(), vec!["beta"]);
 
     let (_info, attach) = service.attach(Some("beta".into()), None, None, None, true).expect("attach beta");
-    let delta = read_directory_delta_named(&mut stream, Duration::from_secs(30), "beta attach delta");
+    let delta = read_directory_delta_named(&mut stream, &mut buffer, Duration::from_secs(30), "beta attach delta");
     assert_eq!(delta.upserted[0].session_id, "beta");
     assert_eq!(delta.upserted[0].controller_count, 1);
     drop(attach);
@@ -620,11 +701,11 @@ fn directory_subscription_filters_and_emits_lifecycle_deltas() {
             },
         )
         .expect("create short");
-    let delta = read_until_directory_remove(&mut stream, "short", Duration::from_secs(30));
+    let delta = read_until_directory_remove(&mut stream, &mut buffer, "short", Duration::from_secs(30));
     assert_eq!(delta.removed_session_ids, vec!["short"]);
 
     service.update_tags("alpha", Vec::new(), vec![selector]).expect("untag alpha");
-    let delta = read_until_directory_remove(&mut stream, "alpha", Duration::from_secs(30));
+    let delta = read_until_directory_remove(&mut stream, &mut buffer, "alpha", Duration::from_secs(30));
     assert_eq!(delta.removed_session_ids, vec!["alpha"]);
 }
 
@@ -975,20 +1056,89 @@ fn packet_channel_initial_render_and_packet_input_flow() {
         .expect("create alpha");
 
     let mut stream = http_packet_stream(temp.path(), "alpha");
+    let mut buffer = Vec::new();
     let _hello = PacketFrame::read(&mut stream).expect("read hello");
     let _directory = PacketFrame::read(&mut stream).expect("read directory");
 
     packet_open_channel(&mut stream, 1, "alpha");
-    let initial = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    let initial = read_packet_render(&mut stream, &mut buffer, 1, Duration::from_secs(2));
     assert_eq!(initial.dirty, cleat::provider::DirtyState::Full);
     assert!(!initial.ops.is_empty());
     packet_ack(&mut stream, 1, initial.render_generation);
 
     std::thread::sleep(Duration::from_millis(500));
     packet_input(&mut stream, 1, TerminalInputEvent::Paste(TerminalPasteEvent { text: "packet paste".to_string() }));
-    let update = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    let update = read_packet_render(&mut stream, &mut buffer, 1, Duration::from_secs(2));
     assert!(update.render_generation > initial.render_generation);
     assert!(!update.ops.is_empty());
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn packet_roles_gate_input_and_take_control_demotes() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(Some("alpha".into()), Some(VtEngineKind::Ghostty), None, Some("sh -c 'stty raw; exec cat'".into()), false)
+        .expect("create alpha");
+
+    // first client requests and receives control
+    let mut controller_stream = http_packet_stream(temp.path(), "alpha");
+    let _hello = PacketFrame::read(&mut controller_stream).expect("read hello");
+    let _directory = PacketFrame::read(&mut controller_stream).expect("read directory");
+    packet_open_channel_role(&mut controller_stream, 1, "alpha", ChannelRole::Controller, false);
+    let mut controller = PacketReader::new(&mut controller_stream);
+    assert_eq!(controller.role(1, Duration::from_secs(2)), ChannelRole::Controller);
+    let initial = controller.render(1, Duration::from_secs(2));
+    packet_write(controller.stream, 1, MSG_SESSION_ACK, &Ack { generation: initial.render_generation });
+    std::thread::sleep(Duration::from_millis(500));
+
+    // second client also asks for control without take: granted watcher
+    let mut watcher_stream = http_packet_stream(temp.path(), "alpha");
+    let _hello = PacketFrame::read(&mut watcher_stream).expect("read hello");
+    let _directory = PacketFrame::read(&mut watcher_stream).expect("read directory");
+    packet_open_channel_role(&mut watcher_stream, 1, "alpha", ChannelRole::Controller, false);
+    let mut watcher = PacketReader::new(&mut watcher_stream);
+    assert_eq!(watcher.role(1, Duration::from_secs(2)), ChannelRole::Watcher);
+    let watcher_initial = watcher.render(1, Duration::from_secs(2));
+    packet_write(watcher.stream, 1, MSG_SESSION_ACK, &Ack { generation: watcher_initial.render_generation });
+
+    // watcher input is dropped: the raw-mode cat would echo it back as output
+    packet_write(watcher.stream, 1, MSG_SESSION_INPUT, &Input {
+        event: TerminalInputEvent::Paste(TerminalPasteEvent { text: "blocked".to_string() }),
+    });
+    watcher.expect_no_render(1, Duration::from_millis(700));
+
+    // a fresh subscriber sees both attachments in the directory counts
+    {
+        let mut observer = http_packet_stream(temp.path(), "alpha");
+        let _hello = PacketFrame::read(&mut observer).expect("read hello");
+        let directory = PacketFrame::read(&mut observer).expect("read directory");
+        let directory = directory.decode::<DirectorySnapshot>().expect("decode directory snapshot");
+        let alpha = directory.sessions.iter().find(|entry| entry.session_id == "alpha").expect("alpha in directory");
+        assert_eq!((alpha.controller_count, alpha.watcher_count), (1, 1));
+    }
+
+    // take-control: the requester is granted controller, the old controller
+    // is demoted and told so
+    packet_write(watcher.stream, 1, MSG_SESSION_ROLE, &RoleRequest { role: ChannelRole::Controller, take: true });
+    assert_eq!(watcher.role(1, Duration::from_secs(2)), ChannelRole::Controller);
+    assert_eq!(controller.role(1, Duration::from_secs(2)), ChannelRole::Watcher);
+
+    // input from the new controller flows
+    packet_write(watcher.stream, 1, MSG_SESSION_INPUT, &Input {
+        event: TerminalInputEvent::Paste(TerminalPasteEvent { text: "allowed".to_string() }),
+    });
+    let update = watcher.render(1, Duration::from_secs(2));
+    assert!(update.render_generation > watcher_initial.render_generation);
+
+    // ...and input from the demoted client no longer does
+    packet_write(watcher.stream, 1, MSG_SESSION_ACK, &Ack { generation: update.render_generation });
+    packet_write(controller.stream, 1, MSG_SESSION_INPUT, &Input {
+        event: TerminalInputEvent::Paste(TerminalPasteEvent { text: "stale".to_string() }),
+    });
+    watcher.expect_no_render(1, Duration::from_millis(700));
 }
 
 #[cfg(feature = "ghostty-vt")]
@@ -1008,13 +1158,14 @@ fn packet_mode_only_change_produces_zero_row_ops() {
         .expect("create alpha");
 
     let mut stream = http_packet_stream(temp.path(), "alpha");
+    let mut buffer = Vec::new();
     let _hello = PacketFrame::read(&mut stream).expect("read hello");
     let _directory = PacketFrame::read(&mut stream).expect("read directory");
     packet_open_channel(&mut stream, 1, "alpha");
-    let initial = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    let initial = read_packet_render(&mut stream, &mut buffer, 1, Duration::from_secs(2));
     packet_ack(&mut stream, 1, initial.render_generation);
 
-    let update = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    let update = read_packet_render(&mut stream, &mut buffer, 1, Duration::from_secs(2));
 
     assert!(update.terminal_modes.mouse_tracking);
     assert_eq!(update.terminal_modes.mouse_tracking_mode, vt::MouseTrackingMode::Any);
@@ -1032,24 +1183,25 @@ fn packet_render_ack_enforces_one_in_flight_and_coalesces_slow_clients() {
         .expect("create alpha");
 
     let mut stream = http_packet_stream(temp.path(), "alpha");
+    let mut buffer = Vec::new();
     let _hello = PacketFrame::read(&mut stream).expect("read hello");
     let _directory = PacketFrame::read(&mut stream).expect("read directory");
     packet_open_channel(&mut stream, 1, "alpha");
-    let initial = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    let initial = read_packet_render(&mut stream, &mut buffer, 1, Duration::from_secs(2));
     packet_ack(&mut stream, 1, initial.render_generation);
 
     std::thread::sleep(Duration::from_millis(500));
     packet_input(&mut stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "a".to_string() }));
-    let first = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    let first = read_packet_render(&mut stream, &mut buffer, 1, Duration::from_secs(2));
     packet_ack(&mut stream, 1, initial.render_generation);
     packet_input(&mut stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "b".to_string() }));
-    expect_no_packet(&mut stream, Duration::from_millis(120));
+    expect_no_render(&mut stream, &mut buffer, Duration::from_millis(120));
 
     packet_ack(&mut stream, 1, first.render_generation);
-    let coalesced = read_packet_render(&mut stream, 1, Duration::from_secs(2));
+    let coalesced = read_packet_render(&mut stream, &mut buffer, 1, Duration::from_secs(2));
     assert!(coalesced.render_generation > first.render_generation);
     packet_ack(&mut stream, 1, coalesced.render_generation);
-    expect_no_packet(&mut stream, Duration::from_millis(120));
+    expect_no_render(&mut stream, &mut buffer, Duration::from_millis(120));
 }
 
 #[cfg(feature = "ghostty-vt")]
@@ -1063,23 +1215,25 @@ fn packet_concurrent_channels_receive_same_dirty_generation() {
         .expect("create alpha");
 
     let mut first_stream = http_packet_stream(temp.path(), "alpha");
+    let mut first_buffer = Vec::new();
     let _hello = PacketFrame::read(&mut first_stream).expect("read first hello");
     let _directory = PacketFrame::read(&mut first_stream).expect("read first directory");
     packet_open_channel(&mut first_stream, 1, "alpha");
-    let first_initial = read_packet_render(&mut first_stream, 1, Duration::from_secs(2));
+    let first_initial = read_packet_render(&mut first_stream, &mut first_buffer, 1, Duration::from_secs(2));
     packet_ack(&mut first_stream, 1, first_initial.render_generation);
 
     let mut second_stream = http_packet_stream(temp.path(), "alpha");
+    let mut second_buffer = Vec::new();
     let _hello = PacketFrame::read(&mut second_stream).expect("read second hello");
     let _directory = PacketFrame::read(&mut second_stream).expect("read second directory");
     packet_open_channel(&mut second_stream, 1, "alpha");
-    let second_initial = read_packet_render(&mut second_stream, 1, Duration::from_secs(2));
+    let second_initial = read_packet_render(&mut second_stream, &mut second_buffer, 1, Duration::from_secs(2));
     packet_ack(&mut second_stream, 1, second_initial.render_generation);
 
     std::thread::sleep(Duration::from_millis(500));
     packet_input(&mut first_stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "x".to_string() }));
-    let first_update = read_packet_render(&mut first_stream, 1, Duration::from_secs(2));
-    let second_update = read_packet_render(&mut second_stream, 1, Duration::from_secs(2));
+    let first_update = read_packet_render(&mut first_stream, &mut first_buffer, 1, Duration::from_secs(2));
+    let second_update = read_packet_render(&mut second_stream, &mut second_buffer, 1, Duration::from_secs(2));
 
     assert_eq!(first_update.render_generation, second_update.render_generation);
     assert!(!first_update.ops.is_empty(), "first viewer should receive row content");
@@ -1097,22 +1251,24 @@ fn packet_lagging_channel_receives_cached_generation_after_session_goes_clean() 
         .expect("create alpha");
 
     let mut fast_stream = http_packet_stream(temp.path(), "alpha");
+    let mut fast_buffer = Vec::new();
     let _hello = PacketFrame::read(&mut fast_stream).expect("read fast hello");
     let _directory = PacketFrame::read(&mut fast_stream).expect("read fast directory");
     packet_open_channel(&mut fast_stream, 1, "alpha");
-    let fast_initial = read_packet_render(&mut fast_stream, 1, Duration::from_secs(2));
+    let fast_initial = read_packet_render(&mut fast_stream, &mut fast_buffer, 1, Duration::from_secs(2));
     packet_ack(&mut fast_stream, 1, fast_initial.render_generation);
 
     let mut slow_stream = http_packet_stream(temp.path(), "alpha");
+    let mut slow_buffer = Vec::new();
     let _hello = PacketFrame::read(&mut slow_stream).expect("read slow hello");
     let _directory = PacketFrame::read(&mut slow_stream).expect("read slow directory");
     packet_open_channel(&mut slow_stream, 1, "alpha");
-    let slow_initial = read_packet_render(&mut slow_stream, 1, Duration::from_secs(2));
+    let slow_initial = read_packet_render(&mut slow_stream, &mut slow_buffer, 1, Duration::from_secs(2));
 
     std::thread::sleep(Duration::from_millis(500));
     packet_input(&mut fast_stream, 1, TerminalInputEvent::Text(TerminalTextEvent { text: "y".to_string() }));
     let fast_update = loop {
-        let update = read_packet_render(&mut fast_stream, 1, Duration::from_secs(2));
+        let update = read_packet_render(&mut fast_stream, &mut fast_buffer, 1, Duration::from_secs(2));
         if !update.ops.is_empty() {
             break update;
         }
@@ -1121,7 +1277,7 @@ fn packet_lagging_channel_receives_cached_generation_after_session_goes_clean() 
     packet_ack(&mut fast_stream, 1, fast_update.render_generation);
 
     packet_ack(&mut slow_stream, 1, slow_initial.render_generation);
-    let slow_update = read_packet_render(&mut slow_stream, 1, Duration::from_secs(2));
+    let slow_update = read_packet_render(&mut slow_stream, &mut slow_buffer, 1, Duration::from_secs(2));
 
     assert_eq!(slow_update.render_generation, fast_update.render_generation);
     assert!(!slow_update.ops.is_empty(), "lagging viewer should receive cached row content after fast ack");
@@ -1731,6 +1887,36 @@ fn stale_foreground_file_does_not_block_attach() {
     std::fs::write(foreground_path(temp.path(), "alpha"), b"999999").expect("write stale foreground marker");
 
     let (_session, _attach) = service.attach(Some("alpha".into()), None, None, None, false).expect("attach with stale foreground marker");
+}
+
+#[test]
+fn daemon_exits_when_runtime_root_is_removed() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("cat".into()), false).expect("create alpha");
+
+    let pid: i32 =
+        std::fs::read_to_string(daemon_pid_path(temp.path(), "alpha")).expect("read daemon pid").trim().parse().expect("parse daemon pid");
+
+    // Delete the runtime root out from under the daemon, exactly as a dropped
+    // test tempdir would. The hosted `cat` never exits on its own, so only
+    // the root watchdog can reap this daemon.
+    std::fs::remove_dir_all(temp.path()).expect("remove runtime root");
+
+    // The daemon is our direct child, so poll with waitpid rather than
+    // kill(pid, 0): an exited-but-unreaped zombie still answers signals.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let mut status: libc::c_int = 0;
+        let rc = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+        if rc == pid {
+            break;
+        }
+        assert!(rc == 0, "waitpid on session daemon failed: {rc}");
+        assert!(Instant::now() < deadline, "daemon should exit after its runtime root is removed");
+        std::thread::sleep(Duration::from_millis(100));
+    }
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -1901,11 +1901,32 @@ fn daemon_exits_when_runtime_root_is_removed() {
 
     // Delete the runtime root out from under the daemon, exactly as a dropped
     // test tempdir would. The hosted `cat` never exits on its own, so only
-    // the root watchdog can reap this daemon.
+    // the registration watchdog can reap this daemon.
     std::fs::remove_dir_all(temp.path()).expect("remove runtime root");
 
-    // The daemon is our direct child, so poll with waitpid rather than
-    // kill(pid, 0): an exited-but-unreaped zombie still answers signals.
+    wait_for_daemon_exit(pid, "daemon should exit after its runtime root is removed");
+}
+
+#[test]
+fn daemon_exits_when_pid_file_names_another_process() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("cat".into()), false).expect("create alpha");
+
+    let pid_path = daemon_pid_path(temp.path(), "alpha");
+    let pid: i32 = std::fs::read_to_string(&pid_path).expect("read daemon pid").trim().parse().expect("parse daemon pid");
+
+    // Simulate a successor daemon reclaiming the identity: the pid file no
+    // longer names this daemon, so it should fence itself off and exit.
+    std::fs::write(&pid_path, "999999999").expect("overwrite daemon pid");
+
+    wait_for_daemon_exit(pid, "daemon should exit after losing its pid-file registration");
+}
+
+/// The daemon is our direct child, so poll with waitpid rather than
+/// kill(pid, 0): an exited-but-unreaped zombie still answers signals.
+fn wait_for_daemon_exit(pid: i32, message: &str) {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         let mut status: libc::c_int = 0;
@@ -1914,7 +1935,7 @@ fn daemon_exits_when_runtime_root_is_removed() {
             break;
         }
         assert!(rc == 0, "waitpid on session daemon failed: {rc}");
-        assert!(Instant::now() < deadline, "daemon should exit after its runtime root is removed");
+        assert!(Instant::now() < deadline, "{message}");
         std::thread::sleep(Duration::from_millis(100));
     }
 }

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -162,23 +162,8 @@ impl<'a> PacketReader<'a> {
         Self { stream, buffer: Vec::new() }
     }
 
-    fn next_matching(&mut self, timeout: Duration, mut keep: impl FnMut(&PacketFrame) -> bool, label: &str) -> PacketFrame {
-        let deadline = Instant::now() + timeout;
-        while Instant::now() < deadline {
-            while let Some(frame) = PacketFrame::read_from_buffer(&mut self.buffer).expect("parse packet buffer") {
-                if keep(&frame) {
-                    return frame;
-                }
-            }
-            let mut chunk = [0; 4096];
-            match self.stream.read(&mut chunk) {
-                Ok(0) => panic!("packet stream closed while waiting for {label}"),
-                Ok(n) => self.buffer.extend_from_slice(&chunk[..n]),
-                Err(err) if packet_read_would_wait(&err) => {}
-                Err(err) => panic!("read packet frame: {err}"),
-            }
-        }
-        panic!("timed out waiting for {label}");
+    fn next_matching(&mut self, timeout: Duration, keep: impl FnMut(&PacketFrame) -> bool, label: &str) -> PacketFrame {
+        next_matching_packet_frame(self.stream, &mut self.buffer, timeout, keep, label)
     }
 
     fn role(&mut self, channel: u32, timeout: Duration) -> ChannelRole {
@@ -196,21 +181,66 @@ impl<'a> PacketReader<'a> {
     }
 
     fn expect_no_render(&mut self, channel: u32, timeout: Duration) {
-        let deadline = Instant::now() + timeout;
-        while Instant::now() < deadline {
-            while let Some(frame) = PacketFrame::read_from_buffer(&mut self.buffer).expect("parse packet buffer") {
-                assert!(
-                    !(frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER),
-                    "unexpected render packet on channel {channel}"
-                );
+        assert_no_matching_packet_frame(
+            self.stream,
+            &mut self.buffer,
+            timeout,
+            |frame| frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER,
+            "render packet",
+        );
+    }
+}
+
+/// The single read/parse/timeout loop behind every packet-frame test helper.
+/// Frames not selected by `keep` are consumed and discarded.
+fn next_matching_packet_frame(
+    stream: &mut UnixStream,
+    buffer: &mut Vec<u8>,
+    timeout: Duration,
+    mut keep: impl FnMut(&PacketFrame) -> bool,
+    label: &str,
+) -> PacketFrame {
+    stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        while let Some(frame) = PacketFrame::read_from_buffer(buffer).expect("parse packet buffer") {
+            if keep(&frame) {
+                return frame;
             }
-            let mut chunk = [0; 4096];
-            match self.stream.read(&mut chunk) {
-                Ok(0) => return,
-                Ok(n) => self.buffer.extend_from_slice(&chunk[..n]),
-                Err(err) if packet_read_would_wait(&err) => {}
-                Err(err) => panic!("read packet frame: {err}"),
-            }
+        }
+        let mut chunk = [0; 4096];
+        match stream.read(&mut chunk) {
+            Ok(0) => panic!("packet stream closed while waiting for {label}"),
+            Ok(n) => buffer.extend_from_slice(&chunk[..n]),
+            Err(err) if packet_read_would_wait(&err) => {}
+            Err(err) => panic!("read packet frame: {err}"),
+        }
+    }
+    panic!("timed out waiting for {label}");
+}
+
+/// Companion to `next_matching_packet_frame`: asserts no frame selected by
+/// `reject` arrives before the timeout (or the stream closes).
+#[cfg(feature = "ghostty-vt")]
+fn assert_no_matching_packet_frame(
+    stream: &mut UnixStream,
+    buffer: &mut Vec<u8>,
+    timeout: Duration,
+    mut reject: impl FnMut(&PacketFrame) -> bool,
+    label: &str,
+) {
+    stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        while let Some(frame) = PacketFrame::read_from_buffer(buffer).expect("parse packet buffer") {
+            assert!(!reject(&frame), "unexpected {label}: {frame:?}");
+        }
+        let mut chunk = [0; 4096];
+        match stream.read(&mut chunk) {
+            Ok(0) => return,
+            Ok(n) => buffer.extend_from_slice(&chunk[..n]),
+            Err(err) if packet_read_would_wait(&err) => {}
+            Err(err) => panic!("read packet frame: {err}"),
         }
     }
 }
@@ -227,43 +257,28 @@ fn packet_input(stream: &mut UnixStream, channel: u32, event: TerminalInputEvent
 
 #[cfg(feature = "ghostty-vt")]
 fn read_packet_render(stream: &mut UnixStream, buffer: &mut Vec<u8>, channel: u32, timeout: Duration) -> TerminalRenderUpdate {
-    stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        while let Some(frame) = PacketFrame::read_from_buffer(buffer).expect("parse packet buffer") {
-            if frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER {
-                return frame.decode::<RenderPacket>().expect("decode render packet").update;
-            }
-        }
-        let mut chunk = [0; 4096];
-        match stream.read(&mut chunk) {
-            Ok(0) => panic!("packet stream closed while waiting for render packet"),
-            Ok(n) => buffer.extend_from_slice(&chunk[..n]),
-            Err(err) if packet_read_would_wait(&err) => {}
-            Err(err) => panic!("read packet frame: {err}"),
-        }
-    }
-    panic!("timed out waiting for render packet on channel {channel}");
+    next_matching_packet_frame(
+        stream,
+        buffer,
+        timeout,
+        |frame| frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER,
+        &format!("render packet on channel {channel}"),
+    )
+    .decode::<RenderPacket>()
+    .expect("decode render packet")
+    .update
 }
 
 fn read_directory_delta_named(stream: &mut UnixStream, buffer: &mut Vec<u8>, timeout: Duration, label: &str) -> DirectoryDelta {
-    stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        while let Some(frame) = PacketFrame::read_from_buffer(buffer).expect("parse packet buffer") {
-            if frame.channel == CHANNEL_CONTROL && frame.msg_type == MSG_CONTROL_DIRECTORY_DELTA {
-                return frame.decode::<DirectoryDelta>().expect("decode directory delta");
-            }
-        }
-        let mut chunk = [0; 4096];
-        match stream.read(&mut chunk) {
-            Ok(0) => panic!("packet stream closed while waiting for directory delta"),
-            Ok(n) => buffer.extend_from_slice(&chunk[..n]),
-            Err(err) if packet_read_would_wait(&err) => {}
-            Err(err) => panic!("read packet frame: {err}"),
-        }
-    }
-    panic!("timed out waiting for {label}");
+    next_matching_packet_frame(
+        stream,
+        buffer,
+        timeout,
+        |frame| frame.channel == CHANNEL_CONTROL && frame.msg_type == MSG_CONTROL_DIRECTORY_DELTA,
+        label,
+    )
+    .decode::<DirectoryDelta>()
+    .expect("decode directory delta")
 }
 
 fn read_until_directory_remove(stream: &mut UnixStream, buffer: &mut Vec<u8>, session_id: &str, timeout: Duration) -> DirectoryDelta {
@@ -280,20 +295,7 @@ fn read_until_directory_remove(stream: &mut UnixStream, buffer: &mut Vec<u8>, se
 
 #[cfg(feature = "ghostty-vt")]
 fn expect_no_render(stream: &mut UnixStream, buffer: &mut Vec<u8>, timeout: Duration) {
-    stream.set_read_timeout(Some(Duration::from_millis(50))).expect("set read timeout");
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if let Some(frame) = PacketFrame::read_from_buffer(buffer).expect("parse packet buffer") {
-            assert!(frame.msg_type != MSG_SESSION_RENDER, "unexpected render packet frame: {frame:?}");
-        }
-        let mut chunk = [0; 4096];
-        match stream.read(&mut chunk) {
-            Ok(0) => return,
-            Ok(n) => buffer.extend_from_slice(&chunk[..n]),
-            Err(err) if packet_read_would_wait(&err) => {}
-            Err(err) => panic!("read packet frame: {err}"),
-        }
-    }
+    assert_no_matching_packet_frame(stream, buffer, timeout, |frame| frame.msg_type == MSG_SESSION_RENDER, "render packet");
 }
 
 fn packet_read_would_wait(err: &std::io::Error) -> bool {

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -790,6 +790,7 @@ fn daemon_provider_keeps_session_alive_after_provider_close() {
             backend: CLEAT_PROVIDER_BACKEND_DAEMON,
             runtime_root: root.as_ptr(),
             runtime_root_len: root.len(),
+            ..CleatProviderDesc::default()
         });
         assert!(!provider.is_null());
 
@@ -829,6 +830,7 @@ fn daemon_provider_uses_client_supplied_id() {
             backend: CLEAT_PROVIDER_BACKEND_DAEMON,
             runtime_root: root.as_ptr(),
             runtime_root_len: root.len(),
+            ..CleatProviderDesc::default()
         });
         assert!(!provider.is_null());
 

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -22,8 +22,10 @@ use cleat::{
     protocol::{Frame, SessionInfo},
     provider::ProviderFeatures,
     provider_ffi::{
-        cleat_provider_close, cleat_provider_open, cleat_session_create, cleat_session_destroy, cleat_session_write_bytes,
-        CleatProviderDesc, CleatSessionDesc, CLEAT_PROVIDER_ABI_VERSION, CLEAT_PROVIDER_BACKEND_DAEMON, CLEAT_PROVIDER_VT_PASSTHROUGH,
+        cleat_provider_close, cleat_provider_directory_generation, cleat_provider_directory_release, cleat_provider_directory_snapshot,
+        cleat_provider_open, cleat_session_connection_state, cleat_session_create, cleat_session_destroy, cleat_session_id,
+        cleat_session_write_bytes, CleatDirectory, CleatProviderDesc, CleatSessionDesc, CleatStr, CLEAT_PROVIDER_ABI_VERSION,
+        CLEAT_PROVIDER_BACKEND_DAEMON, CLEAT_PROVIDER_VT_PASSTHROUGH, CLEAT_SESSION_CLOSED,
     },
     recording::{SessionRecorder, CAST_FILE_NAME},
     runtime::{RuntimeLayout, TerminalSize},
@@ -38,6 +40,10 @@ use cleat::{
         MSG_SESSION_INPUT, MSG_SESSION_RENDER, MSG_SESSION_ROLE,
     },
     provider::{TerminalInputEvent, TerminalPasteEvent, TerminalRenderUpdate, TerminalTextEvent},
+    provider_ffi::{
+        cleat_session_attach, cleat_session_role, cleat_session_take_control, CLEAT_PROVIDER_VT_GHOSTTY, CLEAT_ROLE_CONTROLLER,
+        CLEAT_ROLE_WATCHER, CLEAT_SESSION_STREAMING,
+    },
 };
 
 fn service_for(path: &std::path::Path) -> SessionService {
@@ -47,6 +53,14 @@ fn service_for(path: &std::path::Path) -> SessionService {
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn wait_until(what: &str, mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !condition() {
+        assert!(Instant::now() < deadline, "timed out waiting for {what}");
+        std::thread::sleep(Duration::from_millis(20));
+    }
 }
 
 fn wait_for_socket(path: &std::path::Path) {
@@ -936,6 +950,152 @@ fn daemon_provider_uses_client_supplied_id() {
     assert_eq!(sessions.len(), 1);
     assert_eq!(sessions[0].id, "client-chosen-id");
     service.kill("client-chosen-id").expect("kill daemon session");
+}
+
+// Drives the daemon FFI surface end to end through the C ABI functions:
+// session identity, role grant, directory snapshot, attach-by-id,
+// take-control preemption, and closed-channel notification when the session
+// exits out from under attached clients.
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn daemon_provider_ffi_attach_roles_directory_and_close() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::Builder::new().prefix("cleat-provider-").tempdir_in("/tmp").expect("tempdir");
+    let root = temp.path().to_string_lossy();
+    let command = b"cat";
+    let id = b"ffi-alpha";
+
+    unsafe {
+        let provider = cleat_provider_open(&CleatProviderDesc {
+            abi_version: CLEAT_PROVIDER_ABI_VERSION,
+            requested_features: ProviderFeatures::CELL_SNAPSHOTS.bits(),
+            backend: CLEAT_PROVIDER_BACKEND_DAEMON,
+            runtime_root: root.as_ptr(),
+            runtime_root_len: root.len(),
+            ..CleatProviderDesc::default()
+        });
+        assert!(!provider.is_null());
+
+        let controller = cleat_session_create(provider, &CleatSessionDesc {
+            cols: 80,
+            rows: 24,
+            vt_engine: CLEAT_PROVIDER_VT_GHOSTTY,
+            command: command.as_ptr(),
+            command_len: command.len(),
+            id: id.as_ptr(),
+            id_len: id.len(),
+            ..CleatSessionDesc::default()
+        });
+        assert!(!controller.is_null());
+
+        let mut id_out = CleatStr::default();
+        assert!(cleat_session_id(controller, &mut id_out));
+        assert_eq!(std::slice::from_raw_parts(id_out.ptr, id_out.len), id);
+
+        wait_until("controller role grant", || cleat_session_role(controller) == CLEAT_ROLE_CONTROLLER);
+        wait_until("streaming connection state", || cleat_session_connection_state(controller) == CLEAT_SESSION_STREAMING);
+        wait_until("directory generation bump", || cleat_provider_directory_generation(provider) > 0);
+        wait_until("directory lists the session with a controller", || {
+            let mut directory = CleatDirectory::default();
+            if !cleat_provider_directory_snapshot(provider, &mut directory) {
+                return false;
+            }
+            let entries = std::slice::from_raw_parts(directory.entries, directory.entry_count);
+            let found = entries
+                .iter()
+                .any(|entry| std::slice::from_raw_parts(entry.session_id.ptr, entry.session_id.len) == id && entry.controller_count >= 1);
+            cleat_provider_directory_release(provider, &mut directory);
+            found
+        });
+
+        let watcher = cleat_session_attach(provider, &CleatSessionDesc {
+            cols: 80,
+            rows: 24,
+            id: id.as_ptr(),
+            id_len: id.len(),
+            role: CLEAT_ROLE_WATCHER,
+            ..CleatSessionDesc::default()
+        });
+        assert!(!watcher.is_null());
+        wait_until("watcher role grant", || cleat_session_role(watcher) == CLEAT_ROLE_WATCHER);
+
+        assert!(cleat_session_take_control(watcher));
+        wait_until("take-control grant", || cleat_session_role(watcher) == CLEAT_ROLE_CONTROLLER);
+        wait_until("preempted controller demoted", || cleat_session_role(controller) == CLEAT_ROLE_WATCHER);
+
+        // Kill the session out of band: both attachments must observe the
+        // channel close rather than reporting stale STREAMING forever.
+        service_for(temp.path()).kill("ffi-alpha").expect("kill session");
+        wait_until("controller observes close", || cleat_session_connection_state(controller) == CLEAT_SESSION_CLOSED);
+        wait_until("watcher observes close", || cleat_session_connection_state(watcher) == CLEAT_SESSION_CLOSED);
+
+        cleat_session_destroy(watcher);
+        cleat_session_destroy(controller);
+        cleat_provider_close(provider);
+    }
+}
+
+// A session whose VT engine cannot serve render state (passthrough is a
+// placeholder engine) must fail its packet channel with a channel-scoped
+// error, not tear down the daemon that hosts every other session.
+#[test]
+fn daemon_provider_passthrough_channel_failure_is_contained() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::Builder::new().prefix("cleat-provider-").tempdir_in("/tmp").expect("tempdir");
+    let root = temp.path().to_string_lossy();
+    let command = b"cat";
+    let id = b"ffi-passthrough";
+
+    unsafe {
+        let provider = cleat_provider_open(&CleatProviderDesc {
+            abi_version: CLEAT_PROVIDER_ABI_VERSION,
+            requested_features: ProviderFeatures::CELL_SNAPSHOTS.bits(),
+            backend: CLEAT_PROVIDER_BACKEND_DAEMON,
+            runtime_root: root.as_ptr(),
+            runtime_root_len: root.len(),
+            ..CleatProviderDesc::default()
+        });
+        assert!(!provider.is_null());
+
+        let session = cleat_session_create(provider, &CleatSessionDesc {
+            cols: 80,
+            rows: 24,
+            vt_engine: CLEAT_PROVIDER_VT_PASSTHROUGH,
+            command: command.as_ptr(),
+            command_len: command.len(),
+            id: id.as_ptr(),
+            id_len: id.len(),
+            ..CleatSessionDesc::default()
+        });
+        assert!(!session.is_null());
+
+        let mut id_out = CleatStr::default();
+        assert!(cleat_session_id(session, &mut id_out));
+        assert_eq!(std::slice::from_raw_parts(id_out.ptr, id_out.len), id);
+
+        // The channel open fails daemon-side and surfaces as CLOSED (not
+        // DISCONNECTED, which would mean the daemon itself went down).
+        wait_until("channel failure surfaces as closed", || cleat_session_connection_state(session) == CLEAT_SESSION_CLOSED);
+
+        // The daemon survived: the directory subscription still answers and
+        // lists the session.
+        wait_until("directory generation bump", || cleat_provider_directory_generation(provider) > 0);
+        wait_until("directory lists the session", || {
+            let mut directory = CleatDirectory::default();
+            if !cleat_provider_directory_snapshot(provider, &mut directory) {
+                return false;
+            }
+            let entries = std::slice::from_raw_parts(directory.entries, directory.entry_count);
+            let found = entries.iter().any(|entry| std::slice::from_raw_parts(entry.session_id.ptr, entry.session_id.len) == id);
+            cleat_provider_directory_release(provider, &mut directory);
+            found
+        });
+
+        cleat_session_destroy(session);
+        cleat_provider_close(provider);
+    }
+
+    service_for(temp.path()).kill("ffi-passthrough").expect("kill session via a live daemon");
 }
 
 // A crashed daemon leaves its socket and PID files behind without going through


### PR DESCRIPTION
Four commits that move the FFI provider onto the packet protocol and close the daemon-leak hole found along the way.

## Packet backend for the FFI provider (ec166e1, ff5333e)
- Replaces the HTTP request/response daemon backend with a per-daemon multiplexed packet connection: channel-0 directory subscription plus per-session render/input channels, a provider-owned reader thread with reconnect/backoff, size replay, and input queued across disconnects.
- New FFI surface: attach-by-id (create-vs-adopt), session identity for reattach, connection state for reconnect-aware UIs, opaque creation tags, and a poll-generation directory snapshot API.

## Protocol: viewport commands + channel roles (7ca13e2)
- `MSG_SESSION_VIEWPORT` (#115): Top/Bottom/DeltaRows routed to the session actor; outcome returns as viewport/scrollbar state in the next render packet.
- Channel roles with take-control (#116): one controller per session across packet and legacy clients, watcher input dropped, explicit `take` preemption (never demoting a legacy attach), RoleState notifications, and packet attachments counted in directory controller/watcher fields. `PROTOCOL_VERSION` 1 → 2.

## Daemon self-fencing watchdog (d9689ad, plus groundwork in 7ca13e2)
Session daemons could leak permanently: a daemon only exited after 120s with zero sessions, so a never-exiting session (`cat`, a shell) pinned it forever — even after its runtime root, socket and pid file included, was deleted. Test runs had accumulated ~365 orphaned daemons and ~280 `cat` children on a dev machine.

The serve loop now polls its own pid file every second and exits (terminating hosted sessions) unless the file exists and names its pid, with two consecutive misses required to tolerate transient read failures. This fences against root deletion, root delete-and-recreate, and a successor daemon reclaiming the socket. Lifecycle tests cover the root-removal and foreign-pid cases via `waitpid` polling.

Follow-ups filed: event-driven detection instead of the 1s poll (#119), `SignalTarget::Tree` for full-tree teardown (#120).

## Validation
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --locked` green; `cargo test -p cleat --features ghostty-vt` green
- Post-suite process sweep shows zero leaked daemons, where each feature-on run previously stranded ~15