### PR TITLE
Daemon survives PTY output floods: never-blocked servicing loop + optimized VT build

### DIFF
--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -486,6 +486,13 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             if !no_create && !crate::vt::functional_vt_available() {
                 return ExecResult::Err(crate::vt::nonfunctional_build_error());
             }
+            // Install signal handlers before the handshake: the daemon
+            // considers us attached (and observers may act on it) the moment
+            // the grant lands, which can precede the relay starting.
+            let signal_handlers = match crate::platform::terminal::AttachSignalHandlers::install() {
+                Ok(handlers) => handlers,
+                Err(e) => return ExecResult::Err(e),
+            };
             let (attached, guard) = match service.attach(id, vt, cwd, cmd, no_create) {
                 Ok(v) => v,
                 Err(e) => return ExecResult::Err(e),
@@ -495,17 +502,21 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                     return ExecResult::Err(e);
                 }
             }
-            match guard.relay_stdio() {
+            match guard.relay_stdio_with_handlers(signal_handlers) {
                 Ok(()) => ExecResult::Ok(None),
                 Err(e) => ExecResult::Err(e),
             }
         }
         Command::Watch { id } => {
+            let signal_handlers = match crate::platform::terminal::AttachSignalHandlers::install() {
+                Ok(handlers) => handlers,
+                Err(e) => return ExecResult::Err(e),
+            };
             let guard = match service.watch(&id) {
                 Ok(v) => v,
                 Err(e) => return ExecResult::Err(e),
             };
-            match guard.relay_stdio() {
+            match guard.relay_stdio_with_handlers(signal_handlers) {
                 Ok(()) => ExecResult::Ok(None),
                 Err(e) => ExecResult::Err(e),
             }

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -3,7 +3,7 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::{
     io,
     sync::{
-        atomic::{AtomicU64, AtomicU8, Ordering as AtomicOrdering},
+        atomic::{AtomicI64, AtomicU64, AtomicU8, Ordering as AtomicOrdering},
         mpsc,
         mpsc::{Receiver, SyncSender},
         Arc,
@@ -208,7 +208,7 @@ pub(crate) struct ObservationMirror {
     /// Exit code recorded by the actor when it reaps the child; lets the
     /// daemon's servicing loop poll for exit without a blocking round-trip
     /// into a possibly-busy actor (ADR 0004: never-blocked servicing side).
-    exit_code: std::sync::atomic::AtomicI64,
+    exit_code: AtomicI64,
 }
 
 impl ObservationMirror {
@@ -217,7 +217,7 @@ impl ObservationMirror {
             render_generation: AtomicU64::new(0),
             observed_generation: AtomicU64::new(0),
             dirty: AtomicU8::new(dirty_state_to_u8(DirtyState::Clean)),
-            exit_code: std::sync::atomic::AtomicI64::new(EXIT_CODE_UNSET),
+            exit_code: AtomicI64::new(EXIT_CODE_UNSET),
         }
     }
 

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -9,7 +9,7 @@ use std::{
         Arc,
     },
     thread,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 #[cfg(all(unix, not(any(target_os = "macos", target_os = "linux"))))]
@@ -36,6 +36,14 @@ use crate::{
 };
 
 const POSIX_SIGTERM: i32 = 15;
+/// Ceiling on any reply wait against a session actor. The actor's pump slice
+/// is budgeted (see `PTY_READ_BUDGET_PER_PUMP`), so healthy replies arrive in
+/// milliseconds even under output flood; hitting this deadline means the
+/// actor is genuinely wedged (stuck VT engine, blocked disk). Callers get an
+/// error — and the daemon's servicing loop faults that one session — instead
+/// of one actor freezing the entire control plane (ADR 0004: the servicing
+/// side is never blocked).
+const ACTOR_REPLY_DEADLINE: Duration = Duration::from_secs(5);
 const RAW_OUTPUT_TAP_CHUNKS: usize = 64;
 
 pub(crate) type WakeCallback = Arc<dyn Fn() + Send + Sync + 'static>;
@@ -123,6 +131,17 @@ impl ObservationState {
         was_clean
     }
 
+    /// Publish the child's exit code to the mirror (once), waking observers
+    /// on the transition.
+    pub(crate) fn record_exit(&mut self, code: i32, wake: &WakeCallback) {
+        if let Some(mirror) = &self.mirror {
+            if mirror.exit_code().is_none() {
+                mirror.record_exit(code);
+                wake();
+            }
+        }
+    }
+
     pub(crate) fn sync_terminal_modes(&mut self, terminal_modes: vt::TerminalModeState) -> bool {
         let previous = self.terminal_modes.replace(terminal_modes);
         match previous {
@@ -177,11 +196,19 @@ impl ObservationState {
     }
 }
 
+/// Sentinel for "the session has not exited"; exit codes are i32, so this
+/// value is unreachable.
+const EXIT_CODE_UNSET: i64 = i64::MIN;
+
 #[derive(Debug)]
 pub(crate) struct ObservationMirror {
     render_generation: AtomicU64,
     observed_generation: AtomicU64,
     dirty: AtomicU8,
+    /// Exit code recorded by the actor when it reaps the child; lets the
+    /// daemon's servicing loop poll for exit without a blocking round-trip
+    /// into a possibly-busy actor (ADR 0004: never-blocked servicing side).
+    exit_code: std::sync::atomic::AtomicI64,
 }
 
 impl ObservationMirror {
@@ -190,6 +217,18 @@ impl ObservationMirror {
             render_generation: AtomicU64::new(0),
             observed_generation: AtomicU64::new(0),
             dirty: AtomicU8::new(dirty_state_to_u8(DirtyState::Clean)),
+            exit_code: std::sync::atomic::AtomicI64::new(EXIT_CODE_UNSET),
+        }
+    }
+
+    pub(crate) fn record_exit(&self, code: i32) {
+        self.exit_code.store(code as i64, AtomicOrdering::SeqCst);
+    }
+
+    pub(crate) fn exit_code(&self) -> Option<i32> {
+        match self.exit_code.load(AtomicOrdering::SeqCst) {
+            EXIT_CODE_UNSET => None,
+            code => Some(code as i32),
         }
     }
 
@@ -282,7 +321,6 @@ pub(crate) enum SessionCommand {
     ResolveMarker { name: String, reply: mpsc::Sender<Result<Option<u64>, String>> },
     ResolveNextMarker { after: u64, reply: mpsc::Sender<Result<Option<u64>, String>> },
     DispatchSignal { signal: i32, target: SignalTarget, reply: mpsc::Sender<Result<(), String>> },
-    ExitCode { reply: mpsc::Sender<Result<Option<i32>, String>> },
     ShouldKeepSessionDir { reply: mpsc::Sender<Result<bool, String>> },
     MarkObserved { generation: u64, reply: mpsc::Sender<bool> },
     ScrollbackExtent { reply: mpsc::Sender<TerminalScrollbackExtent> },
@@ -586,12 +624,19 @@ impl SessionActor {
         &self.observation
     }
 
+    /// True when the actor's worker thread has stopped. Combined with a
+    /// missing mirror exit code this means the actor died without reaping
+    /// its child — the session must be faulted.
+    pub(crate) fn worker_finished(&self) -> bool {
+        self.worker.as_ref().map(|worker| worker.is_finished()).unwrap_or(true)
+    }
+
     pub(crate) fn request<T>(&self, make_command: impl FnOnce(mpsc::Sender<T>) -> SessionCommand, fallback: T) -> T {
         let (reply, recv) = mpsc::channel();
         if self.tx.send(make_command(reply)).is_err() {
             return fallback;
         }
-        recv.recv().unwrap_or(fallback)
+        recv.recv_timeout(ACTOR_REPLY_DEADLINE).unwrap_or(fallback)
     }
 
     pub(crate) fn request_result<T>(
@@ -600,7 +645,11 @@ impl SessionActor {
     ) -> Result<T, String> {
         let (reply, recv) = mpsc::channel();
         self.tx.send(make_command(reply)).map_err(|_| "session actor is not running".to_string())?;
-        recv.recv().map_err(|_| "session actor did not reply".to_string())?
+        match recv.recv_timeout(ACTOR_REPLY_DEADLINE) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(format!("session actor did not reply within {ACTOR_REPLY_DEADLINE:?}")),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err("session actor did not reply".to_string()),
+        }
     }
 
     pub(crate) fn set_client_presence(&self, active: bool) -> Result<(), String> {
@@ -729,10 +778,6 @@ impl SessionActor {
         self.request_result(|reply| SessionCommand::DispatchSignal { signal, target, reply })
     }
 
-    pub(crate) fn exit_code(&self) -> Result<Option<i32>, String> {
-        self.request_result(|reply| SessionCommand::ExitCode { reply })
-    }
-
     pub(crate) fn should_keep_session_dir(&self) -> Result<bool, String> {
         self.request_result(|reply| SessionCommand::ShouldKeepSessionDir { reply })
     }
@@ -742,7 +787,18 @@ impl Drop for SessionActor {
     fn drop(&mut self) {
         let _ = self.tx.send(SessionCommand::Stop { terminate: true });
         if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
+            // Bounded join: drop runs on the daemon's servicing thread, which
+            // must never block indefinitely on one session (ADR 0004). The
+            // worker honors Stop between pump slices; if it is wedged past
+            // the deadline, detach — the thread still runs its own teardown
+            // (child terminate, recording flush) whenever it gets unstuck.
+            let deadline = Instant::now() + ACTOR_REPLY_DEADLINE;
+            while !worker.is_finished() && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+            if worker.is_finished() {
+                let _ = worker.join();
+            }
         }
     }
 }
@@ -1041,9 +1097,6 @@ fn session_actor_handle_command(
         SessionCommand::DispatchSignal { signal, target, reply } => {
             let _ = reply.send(runtime.dispatch_signal(signal, target));
         }
-        SessionCommand::ExitCode { reply } => {
-            let _ = reply.send(Ok(state.exit_code));
-        }
         SessionCommand::ShouldKeepSessionDir { reply } => {
             let _ = reply.send(Ok(runtime.should_keep_session_dir()));
         }
@@ -1090,6 +1143,12 @@ fn session_actor_pump(runtime: &mut SessionRuntime, state: &mut SessionActorLoop
     match pump_session_runtime(runtime, &mut state.exited, &mut state.exit_code, state.has_active_client) {
         Ok(result) => {
             publish_raw_output(&mut state.raw_output_taps, &result.chunks);
+            // Flush actor-side after each pump slice: the servicing loop no
+            // longer round-trips into the actor for it, and recording only
+            // grows when the pump runs.
+            if !result.chunks.is_empty() || state.exited {
+                runtime.flush_recording();
+            }
             match result.outcome {
                 PumpOutcome::Clean => {}
                 PumpOutcome::PartialUnknown => mark_partial_unknown_and_wake(&mut state.observation, wake),
@@ -1102,6 +1161,11 @@ fn session_actor_pump(runtime: &mut SessionRuntime, state: &mut SessionActorLoop
         Err(_) => {
             let rows = runtime.inspect(false, 0).terminal.rows;
             mark_full_and_wake(&mut state.observation, rows, wake);
+        }
+    }
+    if state.exited {
+        if let Some(code) = state.exit_code {
+            state.observation.record_exit(code, wake);
         }
     }
     sync_terminal_modes_and_wake(runtime, &mut state.observation, wake);

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -783,21 +783,32 @@ impl SessionActor {
     }
 }
 
+/// How long `Drop` waits inline for the worker before handing the join to a
+/// reaper thread. Covers the common case (the worker honors Stop within one
+/// pump slice, tens of ms) without ever stalling the servicing thread on a
+/// wedged worker.
+const ACTOR_DROP_INLINE_WAIT: Duration = Duration::from_millis(100);
+
 impl Drop for SessionActor {
     fn drop(&mut self) {
         let _ = self.tx.send(SessionCommand::Stop { terminate: true });
         if let Some(worker) = self.worker.take() {
-            // Bounded join: drop runs on the daemon's servicing thread, which
-            // must never block indefinitely on one session (ADR 0004). The
-            // worker honors Stop between pump slices; if it is wedged past
-            // the deadline, detach — the thread still runs its own teardown
-            // (child terminate, recording flush) whenever it gets unstuck.
-            let deadline = Instant::now() + ACTOR_REPLY_DEADLINE;
+            // Drop runs on the daemon's servicing thread, which must never
+            // block long on one session (ADR 0004) — the residual inline
+            // bound here is deliberately small and the slow path moves off
+            // the shared thread entirely. The worker still runs its own
+            // teardown (child terminate, recording flush) whenever it
+            // finishes; the reaper just collects it.
+            let deadline = Instant::now() + ACTOR_DROP_INLINE_WAIT;
             while !worker.is_finished() && Instant::now() < deadline {
                 thread::sleep(Duration::from_millis(5));
             }
             if worker.is_finished() {
                 let _ = worker.join();
+            } else {
+                thread::spawn(move || {
+                    let _ = worker.join();
+                });
             }
         }
     }
@@ -1139,9 +1150,27 @@ fn session_actor_handle_command(
     stop
 }
 
+#[cfg(not(debug_assertions))]
+fn maybe_panic_actor_for_test(_session_id: &str) {}
+
+/// Test hook mirroring `maybe_panic_for_containment_test`: lets a lifecycle
+/// test kill the actor worker thread without recording an exit, to exercise
+/// the daemon's worker-died fault path.
+#[cfg(debug_assertions)]
+fn maybe_panic_actor_for_test(session_id: &str) {
+    if std::env::var("CLEAT_TEST_PANIC_ACTOR").as_deref() == Ok(session_id) {
+        panic!("test-requested actor panic for session {session_id}");
+    }
+}
+
 fn session_actor_pump(runtime: &mut SessionRuntime, state: &mut SessionActorLoopState, wake: &WakeCallback) {
     match pump_session_runtime(runtime, &mut state.exited, &mut state.exit_code, state.has_active_client) {
         Ok(result) => {
+            // Fires only on pumps that read output, so session creation
+            // (whose command handling also pumps) completes first.
+            if !result.chunks.is_empty() {
+                maybe_panic_actor_for_test(runtime.session_id());
+            }
             publish_raw_output(&mut state.raw_output_taps, &result.chunks);
             // Flush actor-side after each pump slice: the servicing loop no
             // longer round-trips into the actor for it, and recording only

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -68,9 +68,19 @@ pub struct SessionStartOptions {
 
 impl ForegroundAttach {
     pub fn relay_stdio(self) -> Result<(), String> {
+        let signal_handlers = AttachSignalHandlers::install()?;
+        self.relay_stdio_with_handlers(signal_handlers)
+    }
+
+    /// Relay with handlers the caller installed *before* the attach
+    /// handshake. The daemon writes the foreground marker at attach grant;
+    /// a signal delivered between that grant and the relay starting must
+    /// already be caught, or the process dies with default disposition
+    /// (observed as a test race once the daemon got fast enough).
+    pub fn relay_stdio_with_handlers(self, signal_handlers: AttachSignalHandlers) -> Result<(), String> {
+        let _signal_handlers = signal_handlers;
         let mut cleanup = AttachCleanupGuard::stdout();
         let mut terminal = ForegroundTerminal::enter()?;
-        let _signal_handlers = AttachSignalHandlers::install()?;
         let read_handle = {
             let stream = self.stream.lock().map_err(|_| "attach stream lock poisoned".to_string())?;
             stream.try_clone().map_err(|err| format!("clone attach stream: {err}"))?

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -726,7 +726,13 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
             let service_result = contain_session_unwind(&session_id, || -> Result<(bool, Option<bool>), String> {
                 maybe_panic_for_containment_test(&session_id);
                 let session_did_work = service_hosted_session(&layout, &session_id, hosted, &mut packet_clients)?;
-                let should_keep_session_dir = if hosted.actor.exit_code()?.is_some() {
+                // Exit state is read from the observation mirror — never a
+                // blocking round-trip into a possibly-busy actor.
+                let exit_code = hosted.actor.observation().exit_code();
+                if exit_code.is_none() && hosted.actor.worker_finished() {
+                    return Err("session actor stopped without reporting an exit".to_string());
+                }
+                let should_keep_session_dir = if exit_code.is_some() {
                     Some(finish_exited_session(&layout, &session_id, hosted, &mut packet_clients)?)
                 } else {
                     None
@@ -1005,7 +1011,8 @@ fn service_hosted_session(
 
     service_pending_waits(&hosted.actor, &mut hosted.pending_waits);
     service_pending_expects(layout, id, &hosted.actor, &mut hosted.pending_expects)?;
-    hosted.actor.flush_recording()?;
+    // Recording flush happens actor-side after each pump slice; no per-tick
+    // round-trip here (ADR 0004: the servicing side is never blocked).
 
     Ok(did_work)
 }

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -394,6 +394,10 @@ impl SessionRuntime {
         self.recorder.is_some()
     }
 
+    pub(crate) fn session_id(&self) -> &str {
+        &self.session.id
+    }
+
     fn read_available_output_inner(&mut self, has_active_client: bool, after_exit: bool) -> Result<PtyOutput, String> {
         let mut chunks = Vec::new();
         let mut budget = PTY_READ_BUDGET_PER_PUMP;
@@ -404,7 +408,10 @@ impl SessionRuntime {
                 break;
             }
             let mut buf = [0u8; PTY_READ_BUFFER_SIZE];
-            match self.pty_child.read_output(&mut buf) {
+            // Cap the final read to the remaining budget so the slice bound
+            // is hard, not "budget plus one buffer".
+            let want = if after_exit { buf.len() } else { buf.len().min(budget) };
+            match self.pty_child.read_output(&mut buf[..want]) {
                 Ok(0) => break,
                 Ok(n) => {
                     budget = budget.saturating_sub(n);

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -21,6 +21,14 @@ use crate::{
 
 const PTY_READ_BUFFER_SIZE: usize = 64 * 1024;
 const SNAPSHOT_INTERVAL_BYTES: u64 = 256 * 1024;
+/// Per-pump read budget. A PTY child that produces output faster than the
+/// VT engine consumes it (`yes` at saturation) would otherwise keep one
+/// `read_available_output` call spinning forever, starving the actor's
+/// command channel — and with it the daemon's whole control plane. The
+/// actor's readiness poll re-arms immediately, so bounding the slice costs
+/// no throughput; it only guarantees commands drain between slices. Two
+/// reads keeps a slice around ~100ms even for a debug-build VT engine.
+const PTY_READ_BUDGET_PER_PUMP: usize = 2 * PTY_READ_BUFFER_SIZE;
 
 pub(crate) struct SessionRuntime {
     session: SessionMetadata,
@@ -388,11 +396,18 @@ impl SessionRuntime {
 
     fn read_available_output_inner(&mut self, has_active_client: bool, after_exit: bool) -> Result<PtyOutput, String> {
         let mut chunks = Vec::new();
+        let mut budget = PTY_READ_BUDGET_PER_PUMP;
         loop {
+            // Draining after exit is finite (the child is gone), so the
+            // budget applies only to live pumps.
+            if !after_exit && budget == 0 {
+                break;
+            }
             let mut buf = [0u8; PTY_READ_BUFFER_SIZE];
             match self.pty_child.read_output(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
+                    budget = budget.saturating_sub(n);
                     let bytes = &buf[..n];
                     self.last_pty_output_at = Some(Instant::now());
                     self.vt_engine.feed(bytes)?;

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -2051,6 +2051,51 @@ fn stale_foreground_file_does_not_block_attach() {
     let (_session, _attach) = service.attach(Some("alpha".into()), None, None, None, false).expect("attach with stale foreground marker");
 }
 
+// A session flooding output at PTY saturation (`yes`) must not starve the
+// daemon's control plane: the actor's pump slice is budgeted so commands
+// keep draining, and the serve loop's actor requests carry a deadline
+// (ADR 0004: the servicing side is never blocked). Probes use a raw
+// socket with a read timeout because the CLI client would hang forever
+// in the failure mode this guards against.
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn control_socket_answers_while_a_session_floods_output() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    // The delay lets the create response escape before the flood begins.
+    service.create(Some("flood".into()), None, None, Some("sh -c 'sleep 0.3; exec yes'".into()), false).expect("create flood session");
+    std::thread::sleep(Duration::from_millis(700));
+
+    for probe in 0..5 {
+        let start = Instant::now();
+        let socket = session_socket_path(temp.path(), "flood");
+        let mut stream = UnixStream::connect(&socket).expect("connect control socket");
+        stream.set_read_timeout(Some(Duration::from_secs(2))).expect("set read timeout");
+        stream.write_all(b"GET /sessions HTTP/1.1\r\nHost: cleat\r\n\r\n").expect("write list request");
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            match stream.read(&mut chunk) {
+                Ok(0) => panic!("probe {probe}: daemon closed the control socket"),
+                Ok(n) => {
+                    buf.extend_from_slice(&chunk[..n]);
+                    if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    panic!("probe {probe}: control plane starved by output flood after {:?}: {err}", start.elapsed())
+                }
+            }
+        }
+        assert!(start.elapsed() < Duration::from_secs(2), "probe {probe}: control response took {:?} under output flood", start.elapsed());
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    service.kill("flood").expect("kill flood session");
+}
+
 #[test]
 fn daemon_exits_when_runtime_root_is_removed() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -189,6 +189,31 @@ impl<'a> PacketReader<'a> {
             "render packet",
         );
     }
+
+    /// Drain (and ack) renders until the channel has been quiet for `quiet`.
+    /// Use before a negative render assertion: late startup output (e.g. a
+    /// `stty raw` mode change) or the tail of a split echo would otherwise
+    /// race into the no-render window on a slow machine.
+    fn settle_renders(&mut self, channel: u32, quiet: Duration, max: Duration) {
+        let deadline = Instant::now() + max;
+        let mut last_render = Instant::now();
+        while Instant::now() < deadline && last_render.elapsed() < quiet {
+            while let Some(frame) = PacketFrame::read_from_buffer(&mut self.buffer).expect("parse packet buffer") {
+                if frame.channel == channel && frame.msg_type == MSG_SESSION_RENDER {
+                    let update = frame.decode::<RenderPacket>().expect("decode render packet").update;
+                    packet_write(self.stream, channel, MSG_SESSION_ACK, &Ack { generation: update.render_generation });
+                    last_render = Instant::now();
+                }
+            }
+            let mut chunk = [0; 4096];
+            match self.stream.read(&mut chunk) {
+                Ok(0) => return,
+                Ok(n) => self.buffer.extend_from_slice(&chunk[..n]),
+                Err(err) if packet_read_would_wait(&err) => {}
+                Err(err) => panic!("read packet frame: {err}"),
+            }
+        }
+    }
 }
 
 /// The single read/parse/timeout loop behind every packet-frame test helper.
@@ -1207,6 +1232,34 @@ fn contained_session_panic_does_not_stop_sibling_session() {
     service.kill("beta").expect("kill sibling session");
 }
 
+// An actor worker thread that dies without recording an exit (VT engine
+// panic, readiness-poll failure) must fault its one session — via the failed
+// actor request or the worker_finished backstop — and leave the daemon
+// serving.
+#[test]
+fn actor_worker_death_faults_the_session_and_daemon_survives() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let _panic = EnvVarGuard::set("CLEAT_TEST_PANIC_ACTOR", "doomed");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+
+    // Silent command: creation completes cleanly (the hook only fires on
+    // pumps that read output). PTY echo of the sent keys then arms it.
+    service.create(Some("doomed".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create doomed");
+    service.send_keys("doomed", b"boom\n").expect("send keys to doomed");
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while service.inspect("doomed").is_ok() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(service.inspect("doomed").is_err(), "worker-dead session should be faulted, not wedge the daemon");
+
+    service
+        .create(Some("survivor".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+        .expect("daemon should still serve after a worker death");
+    service.kill("survivor").expect("kill survivor");
+}
+
 #[cfg(feature = "ghostty-vt")]
 #[test]
 fn packet_channel_initial_render_and_packet_input_flow() {
@@ -1266,6 +1319,10 @@ fn packet_roles_gate_input_and_take_control_demotes() {
     let watcher_initial = watcher.render(1, Duration::from_secs(2));
     packet_write(watcher.stream, 1, MSG_SESSION_ACK, &Ack { generation: watcher_initial.render_generation });
 
+    // Let late startup output (the `stty raw` mode change) settle before the
+    // negative assertion below.
+    watcher.settle_renders(1, Duration::from_millis(300), Duration::from_secs(2));
+
     // watcher input is dropped: the raw-mode cat would echo it back as output
     packet_write(watcher.stream, 1, MSG_SESSION_INPUT, &Input {
         event: TerminalInputEvent::Paste(TerminalPasteEvent { text: "blocked".to_string() }),
@@ -1295,8 +1352,11 @@ fn packet_roles_gate_input_and_take_control_demotes() {
     let update = watcher.render(1, Duration::from_secs(2));
     assert!(update.render_generation > watcher_initial.render_generation);
 
-    // ...and input from the demoted client no longer does
+    // ...and input from the demoted client no longer does. Settle first: the
+    // "allowed" echo may split across renders, and its tail would race into
+    // the no-render window.
     packet_write(watcher.stream, 1, MSG_SESSION_ACK, &Ack { generation: update.render_generation });
+    watcher.settle_renders(1, Duration::from_millis(300), Duration::from_secs(2));
     packet_write(controller.stream, 1, MSG_SESSION_INPUT, &Input {
         event: TerminalInputEvent::Paste(TerminalPasteEvent { text: "stale".to_string() }),
     });

--- a/tools/ghostty-toolchain.toml
+++ b/tools/ghostty-toolchain.toml
@@ -15,4 +15,7 @@ version = "0.15.2"
 [ghostty]
 repo = "https://github.com/rjwittams/ghostty.git"
 ref = "64daa599c531e6938bc4c52d9198a91f1e6ce8cf"
-build_step = "-Demit-lib-vt=true -Dsimd=true"
+# -Doptimize matters: zig defaults to Debug, and a Debug libghostty-vt feeds
+# scroll-heavy output at ~KB/s — slow enough to wedge session actors behind
+# PTY floods. ReleaseSafe keeps bounds checks on untrusted terminal input.
+build_step = "-Demit-lib-vt=true -Dsimd=true -Doptimize=ReleaseSafe"


### PR DESCRIPTION
Fixes the live wedge the porthole agent reported dogfooding cleat on kiwi (daemon unresponsive while sessions produce output; `launch`/`list` hang; recovers when the flood pauses). Diagnosed against the wedged daemon itself before it was restarted — thread samples pinned each link in the chain.

## The causal chain (all three links fixed)

1. **libghostty-vt was a Debug build.** `tools/ghostty-toolchain.toml` had no `-Doptimize` flag and zig defaults to Debug: `feed` ran at **~7KB/s** on scroll-heavy output. Any TUI redraw burst outran the VT engine by orders of magnitude. Now `ReleaseSafe` (bounds checks retained for untrusted terminal input): **~11MB/s measured, 1600×**.
2. **Unbounded pump slice.** `read_available_output` looped until `WouldBlock`, which a saturating producer never delivers — one slice ran forever, so the actor never drained its command channel. Now budgeted at 2 reads/slice; the readiness poll re-arms immediately so throughput is unchanged (worst slice measured 59ms under full `yes` flood).
3. **The serve loop blocked on actors.** `flush_recording` + `exit_code` round-tripped into every session's actor every tick, and HTTP `inspect` blocked unboundedly — one busy actor froze the entire control plane, violating ADR 0004's "never-blocked servicing side". Recording flush moved actor-side (post-slice); exit state rides the `ObservationMirror` atomically (with a `worker_finished` fault check for actors that die without reaping); remaining actor requests carry a 5s deadline; `SessionActor::drop` joins bounded and detaches a wedged worker.

## Validation
- New regression test `control_socket_answers_while_a_session_floods_output`: raw-socket probes with a 2s deadline against a `yes`-flood session (a raw probe because the CLI client hangs forever in the failure mode — its missing read timeouts are already tracked in the delegated-environments contract asks).
- Shell harness repro: 7/7 probe timeouts before → 55/55 probes ≤80ms after, under sustained flood.
- fmt / clippy clean and all suites green on both default and ghostty-vt feature sets.

## Deploy note
The fleet's installed binaries link the shared dylib path, so rebuilding via `tools/prepare-ghostty-vt.sh` (now ReleaseSafe) benefits existing installs; CI's Ghostty VT job builds the optimized dylib from this change onward.