### PR TITLE
cleat-sessions skill: 'remote work today' section; installer owns the skill adapters

### DIFF
--- a/docs/skills/cleat-sessions/README.md
+++ b/docs/skills/cleat-sessions/README.md
@@ -123,6 +123,62 @@ Approval-churn tip: when the hosted agent offers "don't ask again for
 commands starting with …", prefer prefixes that will recur; ask the agent
 to put one-off probe scripts in a file so a single prefix covers them.
 
+## Remote work today (ssh inside a session)
+
+The zero-install way to work on another host: a **local** session whose
+command is ssh. Nothing cleat-aware runs on the remote — ssh is just bytes
+in the middle, and every verb above works unchanged on the local grid.
+
+Worked example (real: the porthole agent driving codex on paneer):
+
+```sh
+cleat launch codex-paneer --tag project=porthole --tag purpose=agent \
+    --size 200x50 --cmd "ssh -t paneer 'cd ~/dev/porthole && exec codex'"
+cleat wait codex-paneer --text "OpenAI Codex" --timeout 30
+cleat send codex-paneer --submit "<task brief>"
+# ... same supervise loop as any hosted agent; watch/capture/transcript all local
+```
+
+`-t` matters: it forces PTY allocation so the remote agent gets a real
+terminal.
+
+**Caveats — know what you're not getting:**
+
+- **The remote end is bare.** Recording, capture, wait, recreation — all of
+  it lives on the *local* host. There is no session, no recording, no
+  cleat on the remote; if you need artifacts there, make the remote command
+  produce them.
+- **Lifetime is chained to the local host and the ssh connection.** Local
+  daemon death, local reboot, or a dropped connection kills the child ssh —
+  and the remote agent gets SIGHUP with it. Remote host reboot likewise
+  ends the session's child. Contrast: a *native* session survives client
+  death because the daemon owns it; here the daemon is on the wrong side
+  of the wire for that guarantee to cover the remote process.
+- **Recreation replays history; it does not resurrect.** Relaunching the
+  id replays the recorded scrollback, then runs a *fresh* `ssh … codex`.
+  The old remote process is gone; the hosted agent's own resume mechanism
+  (e.g. codex session resume) is your recovery path, not cleat's.
+- **Signals stop at the local ssh client.** `signal --target tree` reaches
+  the local process tree (i.e. ssh); it cannot signal the remote tree.
+  `interrupt <id>` works — Ctrl-C travels as bytes over ssh like any
+  keystroke.
+- The grid lags by network RTT; `wait`/`capture` themselves stay local and
+  fast.
+
+Dogfood record: the porthole agent ran this pattern for real (codex on
+paneer, 2026-07-06/07) — the skill's "real task by a non-cleat agent"
+criterion — and the friction it surfaced is filed: daemon starvation under
+TUI output floods (**fixed**, cleat#123), version-skew detectability
+(cleat#113 — the probe above stays until it lands), watcher shimmer
+flicker (cleat#108).
+
+These caveats are not accidents; they are the shape of the fallback. The
+accepted **Delegated Environments v0 contract** (project-map: `specs/
+delegated-environments-v0-provider-contract.md`) exists to remove them —
+`cleat launch --aboard <ref>` puts the daemon *on* the target so the
+session, recording, and lifetime live there. Until that ships, this
+section is the honest way to work remotely.
+
 ## Gotchas
 
 - **Detached capability synthesis**: with no attached client, the child's

--- a/docs/skills/cleat-sessions/README.md
+++ b/docs/skills/cleat-sessions/README.md
@@ -54,7 +54,7 @@ cleat kill build                     # ends it; recording survives
 | Structured state | `inspect <id>` — size, leader pid, **foreground pgid** (`fg_pgid != leader_pid` ⇒ a command is running), attachments, recording |
 | Recorded output since a point | `mark <id> name` … `transcript <id> --since-marker name` ; `expect <id> "text"` blocks on recorded output |
 | Interactive use (human) | `attach <id>` (controller), `watch <id>` (read-only) |
-| Signals | `interrupt <id>` (byte Ctrl-C) vs `signal <id> INT` (real signal, `--target foreground|leader|tree`) |
+| Signals | `interrupt <id>` (byte Ctrl-C) vs `signal <id> INT` (real signal, `--target foreground|leader`; `tree` not yet implemented) |
 | End it | `kill <id>` — **recording is preserved**; `kill --purge` discards |
 | Enumerate | `list [--selector k=v]... [--watch] [--all]` |
 
@@ -158,10 +158,11 @@ terminal.
   id replays the recorded scrollback, then runs a *fresh* `ssh … codex`.
   The old remote process is gone; the hosted agent's own resume mechanism
   (e.g. codex session resume) is your recovery path, not cleat's.
-- **Signals stop at the local ssh client.** `signal --target tree` reaches
-  the local process tree (i.e. ssh); it cannot signal the remote tree.
+- **Signals stop at the local ssh client.** `signal --target
+  foreground|leader` hits the local process (i.e. ssh), never the remote
+  tree (`--target tree` is not yet implemented at all — cleat#120).
   `interrupt <id>` works — Ctrl-C travels as bytes over ssh like any
-  keystroke.
+  keystroke, so it *does* reach the remote program.
 - The grid lags by network RTT; `wait`/`capture` themselves stay local and
   fast.
 

--- a/docs/skills/cleat-sessions/SKILL.md
+++ b/docs/skills/cleat-sessions/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: cleat-sessions
+description: Host interactive/TUI programs in persistent, recorded cleat terminal sessions - launch, drive, wait on, capture, and retire them; includes driving another agent (codex/claude TUI) inside a session, locally or over ssh. Use when running interactive or TUI programs (REPLs, debuggers, installers, menuconfig), when work should survive the current session or be watchable/recorded, or when asked to drive, supervise, or babysit another agent in a terminal.
+---
+
+# cleat sessions
+
+Cleat hosts programs in persistent, recorded terminal sessions with a
+structured control plane. Prefer it over backgrounding interactive
+programs or parsing raw escapes. Canonical guide (conventions, gotchas,
+full verb set): `docs/skills/cleat-sessions/README.md` in the cleat repo,
+if checked out locally.
+
+**Prerequisite probe** (version strings can't distinguish builds yet): the
+installed binary must support the modern surface — check once with
+`cleat launch --help | grep -q -- --tag`. If that fails, the binary
+predates this skill; do not proceed with these commands — report the stale
+binary instead.
+
+## Quick start
+
+```sh
+cleat launch build --tag project=myrepo --tag purpose=build \
+    --size 200x50 --cwd ~/dev/myrepo --cmd "make menuconfig"
+cleat wait build --text "Main menu" --timeout 20
+cleat capture build                # rendered screen, plain text
+cleat send build --submit "..."    # type + reliably submit into a TUI
+cleat kill build                   # recording survives (--purge discards)
+```
+
+`launch <id>` reuses a live session with that id. Set a realistic `--size`
+— TUIs behave differently at 80×24. Recording is on by default.
+
+## Key verbs
+
+- `capture <id>` — rendered grid as text (never parse escapes)
+- `send <id> "text"` (adds Enter) · `send --submit` for TUI composers
+  (plain text+Enter gets swallowed by paste heuristics) · `send-keys <id>
+  C-c Enter Escape ...`
+- `wait <id> --text "str" --screen-stable 30 --idle-time 5 --timeout 600`
+  — conditions OR together; **`--timeout` is bare seconds**; spinners
+  defeat `--idle-time`, use `--screen-stable` for TUIs
+- `inspect <id>` — `fg_pgid != leader_pid` ⇒ a command is running
+- `mark <id> m1` … `transcript <id> --since-marker m1` — recorded output
+  slices; `expect <id> "text"` blocks until text is output
+- `interrupt <id>` (Ctrl-C byte) vs `signal <id> INT --target foreground`
+- `list [--selector k=v]... [--watch]` · `tag <id> +t -t`
+- `kill <id>` preserves the recording; `--purge` discards
+
+## Tags (portfolio conventions)
+
+Opaque strings, `key=value` by convention, AND-only exact-match selectors.
+Set `project=<repo>` and `purpose=<build|test|probe|agent>`. Never set
+`vessel=…` (reserved for flotilla adoption).
+
+## Driving another agent (proven pattern)
+
+```sh
+cleat launch codex-task --tag purpose=agent --size 200x50 --cwd <worktree> --cmd codex
+cleat wait codex-task --text "OpenAI Codex" --timeout 30
+cleat send codex-task --submit "<task brief>"
+# supervise loop:
+cleat wait codex-task --text "Press enter to confirm" --screen-stable 180 --timeout 3600
+cleat capture codex-task   # see WHY it stopped: approval → send-keys Enter; question → send --submit
+```
+
+Humans can `cleat watch <id>` read-only throughout; the recording is the
+audit trail.
+
+## Remote work today (ssh inside a session)
+
+Zero-install remote: a local session whose command is
+`ssh -t <host> '<agent>'` (`-t` forces a real PTY). All verbs work
+unchanged on the local grid; ssh is just bytes in the middle.
+
+```sh
+cleat launch codex-paneer --tag purpose=agent --size 200x50 \
+    --cmd "ssh -t paneer 'cd ~/dev/porthole && exec codex'"
+```
+
+Know the limits: the remote end is bare (recording and all verbs live
+locally); local daemon death or a dropped connection SIGHUPs the remote
+agent; recreation replays history but runs a **fresh** ssh — the hosted
+agent's own resume is the recovery path; `signal --target tree` stops at
+the local ssh client (`interrupt` travels as bytes and works). Full caveat
+list: README §"Remote work today".
+
+## Gotchas
+
+- Detached sessions get capability answers from the VT engine, not a real
+  terminal — capability-sensitive programs may act differently detached.
+- One controller at a time; watchers are read-only and never resize.
+- Daemons are invisible plumbing: auto-start, 120 s linger. Use
+  `--server NAME` only for hard isolation; grouping is tags' job.

--- a/docs/skills/cleat-sessions/SKILL.md
+++ b/docs/skills/cleat-sessions/SKILL.md
@@ -81,9 +81,10 @@ cleat launch codex-paneer --tag purpose=agent --size 200x50 \
 Know the limits: the remote end is bare (recording and all verbs live
 locally); local daemon death or a dropped connection SIGHUPs the remote
 agent; recreation replays history but runs a **fresh** ssh — the hosted
-agent's own resume is the recovery path; `signal --target tree` stops at
-the local ssh client (`interrupt` travels as bytes and works). Full caveat
-list: README §"Remote work today".
+agent's own resume is the recovery path; `signal` hits the local ssh
+client only (and `--target tree` is not yet implemented) — `interrupt`
+travels as bytes and reaches the remote program. Full caveat list: README
+§"Remote work today".
 
 ## Gotchas
 

--- a/docs/skills/cleat-sessions/prompt-fragment.md
+++ b/docs/skills/cleat-sessions/prompt-fragment.md
@@ -31,5 +31,10 @@ raw terminal escapes.
 - Tags are opaque strings, `key=value` by convention; never set
   `vessel=…` (reserved for flotilla).
 - Humans can `cleat watch <id>` read-only while you drive.
+- Remote work: host ssh in a local session — `cleat launch <id> --cmd
+  "ssh -t <host> '<agent>'"` — every verb works on the local grid. The
+  remote end is bare: recording lives locally, connection drop SIGHUPs
+  the remote process, and relaunching replays history but starts a fresh
+  ssh (use the hosted agent's own resume to recover).
 
 Full guide: `docs/skills/cleat-sessions/README.md` in the cleat repo.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -40,3 +40,16 @@ if [[ ! -f "$GHOSTTY_PREFIX/lib/libghostty-vt.a" ]]; then
 fi
 
 echo "Installed cleat to $BIN_DIR/cleat"
+
+# Install the cleat-sessions agent-skill adapter to both skill locations:
+# ~/.claude/skills (Claude Code) and ~/.agents/skills (the agentskills.io
+# shared dir that pi and codex read). The repo copy is canonical; this
+# owns sync from here (decision log 2026-07-06).
+SKILL_SRC="$REPO_ROOT/docs/skills/cleat-sessions/SKILL.md"
+if [[ -f "$SKILL_SRC" ]]; then
+  for SKILLS_DIR in "$HOME/.claude/skills" "$HOME/.agents/skills"; do
+    mkdir -p "$SKILLS_DIR/cleat-sessions"
+    cp "$SKILL_SRC" "$SKILLS_DIR/cleat-sessions/SKILL.md"
+    echo "Installed cleat-sessions skill to $SKILLS_DIR/cleat-sessions/"
+  done
+fi


### PR DESCRIPTION
Closes out [project-map#7](https://forgejo.lab.flotilla.work/robert/project-map/issues/7) (wayfinder: Delegated Environments v0).

## Remote work today (README + SKILL.md + prompt-fragment)
Documents the zero-install remote pattern — a **local** session hosting `ssh -t <host> <agent>` — with the real worked example from the porthole agent's dogfood run (codex on paneer) and the honest caveat list:
- remote end is bare (recording/verbs all local)
- lifetime chained to the local host and the connection (drop = SIGHUP to the remote agent)
- recreation replays history, does not resurrect (hosted agent's own resume is the recovery path)
- `signal --target tree` stops at the local ssh client; `interrupt` travels as bytes and works

Records the dogfood run as the skill's outstanding "real task by a non-cleat agent" criterion, with its filed friction: #123 (daemon starvation — fixed), #113 (skew — probe stays until it lands), #108 (watcher shimmer). Ends with the contrast: these caveats are the shape of the fallback, and the accepted Delegated Environments v0 contract (`--aboard`) exists to remove them.

## Installer ride-along
`docs/skills/cleat-sessions/SKILL.md` is now the canonical adapter (previously hand-copied to machines), and `tools/install.sh` installs it to **both** `~/.claude/skills/` and `~/.agents/skills/` (pi/codex read the latter), owning sync per the portfolio decision-log entry (2026-07-06).