### PR TITLE
fix: detach auto-started daemon from launcher session

### DIFF
--- a/crates/cleat/src/platform/daemon.rs
+++ b/crates/cleat/src/platform/daemon.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -19,6 +21,14 @@ pub fn spawn_daemon_process(root: &Path, daemon_name: &str) -> Result<(), String
     let mut command = Command::new(exe);
     command.arg("--runtime-root").arg(root).arg("--server").arg(daemon_name).arg("serve");
     command.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    #[cfg(unix)]
+    // The daemon must outlive launchers that clean up their whole process
+    // group (agent harnesses, CI runners, and similar supervisors).
+    // SAFETY: `setsid` is called in the child after fork and before exec; it
+    // does not access shared Rust state.
+    unsafe {
+        command.pre_exec(|| if libc::setsid() == -1 { Err(std::io::Error::last_os_error()) } else { Ok(()) });
+    }
     command.spawn().map_err(|err| format!("spawn daemon {daemon_name}: {err}"))?;
     Ok(())
 }

--- a/crates/cleat/src/platform/daemon.rs
+++ b/crates/cleat/src/platform/daemon.rs
@@ -27,7 +27,7 @@ pub fn spawn_daemon_process(root: &Path, daemon_name: &str) -> Result<(), String
     // SAFETY: `setsid` is called in the child after fork and before exec; it
     // does not access shared Rust state.
     unsafe {
-        command.pre_exec(|| if libc::setsid() == -1 { Err(std::io::Error::last_os_error()) } else { Ok(()) });
+        command.pre_exec(|| nix::unistd::setsid().map(|_| ()).map_err(std::io::Error::from));
     }
     command.spawn().map_err(|err| format!("spawn daemon {daemon_name}: {err}"))?;
     Ok(())

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -1,11 +1,15 @@
 #![cfg(unix)]
 
 #[cfg(feature = "ghostty-vt")]
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::{
     io::{Read, Write},
-    os::unix::net::UnixStream,
+    os::unix::{
+        net::UnixStream,
+        process::{CommandExt, ExitStatusExt},
+    },
     path::PathBuf,
+    process::Command,
     sync::{Mutex, OnceLock},
     time::{Duration, Instant},
 };
@@ -2154,6 +2158,58 @@ fn control_socket_answers_while_a_session_floods_output() {
     }
 
     service.kill("flood").expect("kill flood session");
+}
+
+const DAEMON_LAUNCHER_ROOT: &str = "CLEAT_TEST_DAEMON_LAUNCHER_ROOT";
+
+#[test]
+#[ignore = "helper process for auto_started_daemon_survives_launcher_process_group_cleanup"]
+fn daemon_process_group_launcher_helper() {
+    let Some(root) = std::env::var_os(DAEMON_LAUNCHER_ROOT) else {
+        return;
+    };
+    let service = service_for(std::path::Path::new(&root));
+    service
+        .create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+        .expect("create session from launcher process");
+    std::fs::write(std::path::Path::new(&root).join("launcher.ready"), b"").expect("write launcher readiness marker");
+    loop {
+        std::thread::park();
+    }
+}
+
+#[test]
+fn auto_started_daemon_survives_launcher_process_group_cleanup() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut launcher = Command::new(std::env::current_exe().expect("current lifecycle test executable"));
+    launcher
+        .args(["--ignored", "--exact", "daemon_process_group_launcher_helper", "--nocapture"])
+        .env(DAEMON_LAUNCHER_ROOT, temp.path())
+        .process_group(0);
+    let mut launcher = launcher.spawn().expect("spawn isolated daemon launcher");
+    let launcher_process_group = launcher.id() as i32;
+    let ready_path = temp.path().join("launcher.ready");
+    let ready_deadline = Instant::now() + Duration::from_secs(10);
+    while !ready_path.exists() {
+        if let Some(status) = launcher.try_wait().expect("poll daemon launcher") {
+            panic!("daemon launcher exited before reporting readiness: {status:?}");
+        }
+        assert!(Instant::now() < ready_deadline, "timed out waiting for daemon launcher readiness");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let kill_result = unsafe { libc::killpg(launcher_process_group, libc::SIGKILL) };
+    assert_eq!(kill_result, 0, "kill launcher process group: {}", std::io::Error::last_os_error());
+    let status = launcher.wait().expect("reap daemon launcher");
+    assert_eq!(status.signal(), Some(libc::SIGKILL), "daemon launcher should be killed with its process group");
+    std::thread::sleep(Duration::from_millis(100));
+
+    let service = service_for(temp.path());
+    let inspected = service.inspect("alpha").expect("auto-started daemon should survive cleanup of the launcher process group");
+    assert_eq!(inspected.session.id, "alpha");
+
+    service.kill("alpha").expect("kill test session");
+    cleat::platform::daemon::terminate_session_daemon_if_expected(temp.path(), "default");
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -2165,6 +2165,7 @@ const DAEMON_LAUNCHER_ROOT: &str = "CLEAT_TEST_DAEMON_LAUNCHER_ROOT";
 #[test]
 #[ignore = "helper process for auto_started_daemon_survives_launcher_process_group_cleanup"]
 fn daemon_process_group_launcher_helper() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let Some(root) = std::env::var_os(DAEMON_LAUNCHER_ROOT) else {
         return;
     };
@@ -2180,6 +2181,7 @@ fn daemon_process_group_launcher_helper() {
 
 #[test]
 fn auto_started_daemon_survives_launcher_process_group_cleanup() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");
     let mut launcher = Command::new(std::env::current_exe().expect("current lifecycle test executable"));
     launcher

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -32,7 +32,7 @@ use cleat::{
         CLEAT_PROVIDER_BACKEND_DAEMON, CLEAT_PROVIDER_VT_PASSTHROUGH, CLEAT_SESSION_CLOSED,
     },
     recording::{SessionRecorder, CAST_FILE_NAME},
-    runtime::{RuntimeLayout, TerminalSize},
+    runtime::{RuntimeLayout, TerminalSize, DEFAULT_DAEMON_NAME},
     server::{EndBound, SessionService, StartBound},
     session::{daemon_pid_path, session_socket_path},
     vt::{self, ClientCapabilities, ColorLevel, VtEngineKind},
@@ -2211,7 +2211,7 @@ fn auto_started_daemon_survives_launcher_process_group_cleanup() {
     assert_eq!(inspected.session.id, "alpha");
 
     service.kill("alpha").expect("kill test session");
-    cleat::platform::daemon::terminate_session_daemon_if_expected(temp.path(), "default");
+    cleat::platform::daemon::terminate_session_daemon_if_expected(temp.path(), DEFAULT_DAEMON_NAME);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- detach auto-started Unix daemons into a new session before exec
- add a lifecycle regression test that kills the launcher's entire process group
- verify the daemon and its session remain usable after launcher cleanup

## Root cause

The daemon process inherited the launcher's process group. Agent harnesses and similar command runners can clean up that whole process group after a command invocation completes, killing the otherwise orphaned daemon and leaving later cleat commands unable to connect.

Calling `setsid()` in the child before exec gives the daemon its own session and process group, so its lifecycle is independent of the launcher.

## User impact

Launching a session from an agent harness now leaves the cleat daemon running for subsequent `capture`, `wait`, and `send` invocations.

Closes #130.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p cleat --locked --features ghostty-vt`
- reproduced the original Ghostty launch/capture flow across separate command invocations
