### PR TITLE
fix: implement SignalTarget::Tree and use it for session kill

### DIFF
--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -298,7 +298,7 @@ resolved through the live daemon socket. \n\
     Signal {
         id: String,
         signal: String,
-        #[arg(long, default_value = "foreground", help = "Signal target: foreground (default) or leader")]
+        #[arg(long, default_value = "foreground", help = "Signal target: foreground (default), leader, or tree")]
         target: String,
     },
     /// Enable output recording
@@ -1206,7 +1206,7 @@ fn parse_signal_target(target: &str) -> Result<crate::protocol::SignalTarget, St
     match target {
         "foreground" => Ok(crate::protocol::SignalTarget::Foreground),
         "leader" => Ok(crate::protocol::SignalTarget::Leader),
-        "tree" => Err("tree signal target is not yet implemented".to_string()),
+        "tree" => Ok(crate::protocol::SignalTarget::Tree),
         other => Err(format!("unknown signal target: {other}")),
     }
 }

--- a/crates/cleat/src/platform/unix.rs
+++ b/crates/cleat/src/platform/unix.rs
@@ -102,8 +102,26 @@ impl PtyChild {
                 killpg(fg_pgid, signal).map_err(|err| format!("killpg: {err}"))
             }
             SignalTarget::Leader => nix::sys::signal::kill(self.pid, signal).map_err(|err| format!("kill: {err}")),
-            SignalTarget::Tree => Err("tree signal target is not yet implemented".to_string()),
+            SignalTarget::Tree => {
+                // The forkpty child is a session leader, so its pid doubles as its
+                // process-group id. Children stay in that group unless they setsid.
+                let leader_pgid = self.pid;
+                killpg_ignoring_dead(leader_pgid, signal)?;
+                if let Ok(fg_pgid) = tcgetpgrp(borrow_raw(self.master_fd)) {
+                    if fg_pgid != leader_pgid {
+                        killpg_ignoring_dead(fg_pgid, signal)?;
+                    }
+                }
+                Ok(())
+            }
         }
+    }
+}
+
+fn killpg_ignoring_dead(pgid: Pid, signal: Signal) -> Result<(), String> {
+    match killpg(pgid, signal) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+        Err(err) => Err(format!("killpg: {err}")),
     }
 }
 

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1275,7 +1275,7 @@ fn handle_http_request(
             let Some(hosted) = state.sessions.get(&id) else {
                 return write_http_not_found(stream);
             };
-            hosted.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Leader)?;
+            hosted.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Tree)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP delete response: {err}"))
         }
         http_uds::Route::SessionAttach { id } => 'attach: {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -844,7 +844,10 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
             };
             if !registered && registration_was_lost {
                 for hosted in sessions.values() {
-                    let _ = hosted.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Leader);
+                    // Tree, not Leader: this path has the same orphaned-child
+                    // problem as SessionDelete — a background child in the
+                    // leader's process group must not outlive the fenced daemon.
+                    let _ = hosted.actor.dispatch_signal(TERMINATE_SIGNAL, crate::protocol::SignalTarget::Tree);
                 }
                 // Deliberately leave the socket and pid file alone on this
                 // path: they are either already gone or owned by a successor.

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -2524,6 +2524,42 @@ fn signal_term_to_leader_terminates_session() {
 }
 
 #[test]
+fn kill_terminates_background_children_in_leader_process_group() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let pid_file = temp.path().join("child.pid");
+    // Non-interactive sh has no job control, so the background sleep stays in
+    // the session leader's process group. Ignoring HUP before the fork makes the
+    // sleep survive the SIGHUP the kernel sends when the session leader exits,
+    // so only a signal aimed at the process group can take it down.
+    let cmd = format!("sh -c 'trap \"\" HUP; sleep 100 & echo $! > {}; wait'", pid_file.display());
+    let info = service.create(Some("tree".into()), None, None, Some(cmd), false).expect("create session");
+
+    let socket_path = session_socket_path(temp.path(), &info.id);
+    wait_for_socket(&socket_path);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let child_pid = loop {
+        if let Some(pid) = std::fs::read_to_string(&pid_file).ok().and_then(|contents| contents.trim().parse::<i32>().ok()) {
+            break pid;
+        }
+        assert!(Instant::now() < deadline, "timed out waiting for background child pid file");
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    // SAFETY: signal 0 performs existence and permission checks only.
+    assert_eq!(unsafe { libc::kill(child_pid, 0) }, 0, "background child should be alive before kill");
+
+    service.kill(&info.id).expect("kill session");
+
+    wait_until("background child to die after cleat kill", || {
+        // SAFETY: signal 0 performs existence and permission checks only.
+        let rc = unsafe { libc::kill(child_pid, 0) };
+        rc == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+    });
+}
+
+#[test]
 fn short_lived_session_reaps_its_directory_after_child_exit() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Fixes #137

## Problem

`SignalTarget::Tree` returned "tree signal target is not yet implemented" on Unix, and `SessionDelete` (the path behind `cleat kill`) only SIGTERMed the session leader. A child that survives the leader's exit — e.g. one ignoring SIGHUP — outlived the session while the CLI reported success.

## Changes

- `crates/cleat/src/platform/unix.rs`: implement `SignalTarget::Tree` by signalling the leader's process group with `killpg` (the forkpty child is the session leader, so its pid doubles as its pgid; children stay in that group unless they `setsid`). Additionally signals the foreground process group from `tcgetpgrp` when it differs from the leader's group, so a group is never signalled twice. `ESRCH` (already-dead group) is treated as success.
- `crates/cleat/src/session.rs`: `SessionDelete` now dispatches SIGTERM to `SignalTarget::Tree` instead of `Leader`.
- `crates/cleat/src/cli.rs`: `cleat signal --target tree` now parses instead of erroring, and the `--target` help text mentions it.
- `crates/cleat/tests/lifecycle.rs`: regression test launching `sh -c 'trap "" HUP; sleep 100 & echo $! > pidfile; wait'`, killing the session, and polling `kill(pid, 0)` for `ESRCH`. The `trap "" HUP` makes the background child survive the kernel's SIGHUP-on-leader-exit, so the test is red without the tree kill (verified) and green with it.

## Out of scope / follow-up

- Windows tree-kill: `dispatch_signal` on Windows ignores the target and terminates via `TerminateProcess` / `GenerateConsoleCtrlEvent` on the leader. A proper tree story there (job objects / ConPTY close) is left as a follow-up; this change does not alter Windows behavior.
- Full descendant-walking (children that `setsid` into their own session) and TERM-wait-KILL escalation are intentionally not attempted here.

## Verification

- `cargo build --locked`
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (all suites pass; new regression test verified red on main, green with the fix)