### PR TITLE
Fix control-plane robustness edge cases

### DIFF
--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -353,21 +353,28 @@ pub(crate) fn looks_like_http_prefix(prefix: &[u8]) -> bool {
         || prefix.starts_with(b"OPTIO")
 }
 
+#[cfg(test)]
 pub(crate) fn read_request_with_prefix(reader: &mut impl Read, prefix: &[u8]) -> std::io::Result<HttpRequest> {
     let mut bytes = prefix.to_vec();
-    let header_end = loop {
-        if let Some(header_end) = header_end_index(&bytes) {
-            break header_end;
-        }
-        if bytes.len() >= MAX_HEADER_BYTES {
-            return Err(Error::new(ErrorKind::InvalidData, "HTTP request headers exceeded maximum size"));
+    loop {
+        if let Some(request) = try_parse_request(&bytes)? {
+            return Ok(request);
         }
         let mut buf = [0; 1024];
         let n = reader.read(&mut buf)?;
         if n == 0 {
-            return Err(Error::new(ErrorKind::UnexpectedEof, "connection closed before HTTP headers completed"));
+            return Err(Error::new(ErrorKind::UnexpectedEof, "connection closed before HTTP request completed"));
         }
         bytes.extend_from_slice(&buf[..n]);
+    }
+}
+
+pub(crate) fn try_parse_request(bytes: &[u8]) -> std::io::Result<Option<HttpRequest>> {
+    let Some(header_end) = header_end_index(bytes) else {
+        if bytes.len() >= MAX_HEADER_BYTES {
+            return Err(Error::new(ErrorKind::InvalidData, "HTTP request headers exceeded maximum size"));
+        }
+        return Ok(None);
     };
 
     let mut headers = [httparse::EMPTY_HEADER; 64];
@@ -385,17 +392,10 @@ pub(crate) fn read_request_with_prefix(reader: &mut impl Read, prefix: &[u8]) ->
     }
 
     let body_start = header_end + 4;
-    let mut body = bytes[body_start..].to_vec();
-    while body.len() < content_length {
-        let remaining = content_length - body.len();
-        let mut buf = vec![0; remaining.min(8192)];
-        let n = reader.read(&mut buf)?;
-        if n == 0 {
-            return Err(Error::new(ErrorKind::UnexpectedEof, "connection closed before HTTP body completed"));
-        }
-        body.extend_from_slice(&buf[..n]);
+    if bytes.len().saturating_sub(body_start) < content_length {
+        return Ok(None);
     }
-    body.truncate(content_length);
+    let body = bytes[body_start..body_start + content_length].to_vec();
 
     let mut builder = Request::builder()
         .method(Method::from_bytes(method.as_bytes()).map_err(|err| Error::new(ErrorKind::InvalidData, err))?)
@@ -411,7 +411,7 @@ pub(crate) fn read_request_with_prefix(reader: &mut impl Read, prefix: &[u8]) ->
             HeaderValue::from_bytes(header.value).map_err(|err| Error::new(ErrorKind::InvalidData, err))?,
         );
     }
-    builder.body(body).map_err(Error::other)
+    builder.body(body).map(Some).map_err(Error::other)
 }
 
 pub(crate) fn write_request(writer: &mut impl Write, method: Method, path: &str, body: &[u8]) -> std::io::Result<()> {

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -16,7 +16,7 @@ use std::{
     io::Write,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
+        Arc, Mutex, MutexGuard,
     },
     thread::JoinHandle,
     time::Duration,
@@ -49,6 +49,14 @@ const BACKOFF_POLL_STEP: Duration = Duration::from_millis(10);
 /// Input events queued while the connection is down (they flush after the
 /// session channels are re-opened). Beyond this the send reports failure.
 const MAX_QUEUED_INPUT_FRAMES: usize = 1024;
+
+/// A panic in one client callback must not turn every later provider call into
+/// another panic. The protected values use exception-safe standard collection
+/// operations, so retain their state and let the normal disconnected paths
+/// report transport failures.
+fn recover_lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
 
 /// State the last consumed render packet left behind. Used to answer
 /// scrollbar/extent queries between packets and to synthesize a clean update
@@ -228,7 +236,7 @@ impl DaemonConnection {
             .name(format!("cleat-daemon-io:{}", thread_connection.layout.daemon_name()))
             .spawn(move || thread_connection.reader_loop())
             .expect("spawn daemon connection reader thread");
-        *connection.reader.lock().expect("reader handle lock") = Some(handle);
+        *recover_lock(&connection.reader) = Some(handle);
         connection
     }
 
@@ -241,7 +249,7 @@ impl DaemonConnection {
     }
 
     pub(crate) fn with_directory<R>(&self, read: impl FnOnce(&DirectoryState) -> R) -> R {
-        let state = self.state.lock().expect("connection state lock");
+        let state = recover_lock(&self.state);
         read(&state.directory)
     }
 
@@ -266,7 +274,7 @@ impl DaemonConnection {
             closed: None,
         }));
         let (channel, connected) = {
-            let mut state = self.state.lock().expect("connection state lock");
+            let mut state = recover_lock(&self.state);
             let channel = state.next_channel;
             state.next_channel = state.next_channel.wrapping_add(1).max(1);
             state.channels.insert(channel, Arc::clone(&slot));
@@ -286,9 +294,9 @@ impl DaemonConnection {
     /// packet controller). The grant arrives asynchronously as a RoleState.
     pub(crate) fn request_role(&self, channel: u32, role: ChannelRole, take: bool) -> Result<(), String> {
         {
-            let state = self.state.lock().expect("connection state lock");
+            let state = recover_lock(&self.state);
             if let Some(slot) = state.channels.get(&channel) {
-                slot.lock().expect("channel slot lock").desired_role = role;
+                recover_lock(slot).desired_role = role;
             }
         }
         self.send_frame_result(PacketFrame::new(channel, MSG_SESSION_ROLE, &crate::packet::RoleRequest { role, take }))
@@ -296,7 +304,7 @@ impl DaemonConnection {
 
     pub(crate) fn close_session_channel(&self, channel: u32) {
         let removed = {
-            let mut state = self.state.lock().expect("connection state lock");
+            let mut state = recover_lock(&self.state);
             state.channels.remove(&channel).is_some()
         };
         if removed {
@@ -315,7 +323,7 @@ impl DaemonConnection {
             // Queue while disconnected: the reader flushes the queue right
             // after it re-opens the session channels, so input typed across a
             // brief reconnect is not lost.
-            let mut state = self.state.lock().expect("connection state lock");
+            let mut state = recover_lock(&self.state);
             if !state.connected {
                 if state.queued_input.len() >= MAX_QUEUED_INPUT_FRAMES {
                     return Err("daemon connection is down and the input queue is full".to_string());
@@ -354,7 +362,7 @@ impl DaemonConnection {
 
     fn send_frame_result(&self, frame: std::io::Result<PacketFrame>) -> Result<(), String> {
         let frame = frame.map_err(|err| format!("encode packet frame: {err}"))?;
-        let mut writer = self.writer.lock().expect("connection writer lock");
+        let mut writer = recover_lock(&self.writer);
         let Some(stream) = writer.as_mut() else {
             return Err("daemon connection is down".to_string());
         };
@@ -373,12 +381,10 @@ impl DaemonConnection {
 
     pub(crate) fn shutdown(&self) {
         self.stop.store(true, Ordering::SeqCst);
-        if let Ok(mut writer) = self.writer.lock() {
-            if let Some(stream) = writer.take() {
-                let _ = stream.shutdown(std::net::Shutdown::Both);
-            }
+        if let Some(stream) = recover_lock(&self.writer).take() {
+            let _ = stream.shutdown(std::net::Shutdown::Both);
         }
-        let handle = self.reader.lock().ok().and_then(|mut reader| reader.take());
+        let handle = recover_lock(&self.reader).take();
         if let Some(handle) = handle {
             let _ = handle.join();
         }
@@ -410,18 +416,18 @@ impl DaemonConnection {
             Err(_) => return false,
         };
         {
-            let mut writer = self.writer.lock().expect("connection writer lock");
+            let mut writer = recover_lock(&self.writer);
             *writer = Some(writer_stream);
         }
         let (reopen, queued_input) = {
-            let mut state = self.state.lock().expect("connection state lock");
+            let mut state = recover_lock(&self.state);
             state.connected = true;
             state.directory.replace(snapshot);
             let reopen: Vec<(u32, String, u16, u16, ChannelRole)> = state
                 .channels
                 .iter()
                 .filter_map(|(channel, slot)| {
-                    let mut slot = slot.lock().expect("channel slot lock");
+                    let mut slot = recover_lock(slot);
                     // A closed channel (session gone) stays closed; reopening
                     // it would just re-error on every reconnect until the FFI
                     // caller destroys the session.
@@ -461,7 +467,7 @@ impl DaemonConnection {
         match (frame.channel, frame.msg_type) {
             (CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_SNAPSHOT) => {
                 if let Ok(snapshot) = frame.decode::<DirectorySnapshot>() {
-                    let mut state = self.state.lock().expect("connection state lock");
+                    let mut state = recover_lock(&self.state);
                     state.directory.replace(snapshot);
                     drop(state);
                     (self.wake)();
@@ -469,7 +475,7 @@ impl DaemonConnection {
             }
             (CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_DELTA) => {
                 if let Ok(delta) = frame.decode::<DirectoryDelta>() {
-                    let mut state = self.state.lock().expect("connection state lock");
+                    let mut state = recover_lock(&self.state);
                     state.directory.apply_delta(delta);
                     drop(state);
                     (self.wake)();
@@ -478,11 +484,11 @@ impl DaemonConnection {
             (CHANNEL_CONTROL, MSG_CONTROL_ERROR) => {
                 if let Ok(error) = frame.decode::<ControlError>() {
                     let slot = {
-                        let state = self.state.lock().expect("connection state lock");
+                        let state = recover_lock(&self.state);
                         state.channels.get(&error.channel).cloned()
                     };
                     if let Some(slot) = slot {
-                        slot.lock().expect("channel slot lock").closed = Some(error.message);
+                        recover_lock(&slot).closed = Some(error.message);
                         (self.wake)();
                     }
                 }
@@ -490,11 +496,11 @@ impl DaemonConnection {
             (channel, MSG_SESSION_RENDER) if channel != CHANNEL_CONTROL => {
                 if let Ok(packet) = frame.decode::<RenderPacket>() {
                     let slot = {
-                        let state = self.state.lock().expect("connection state lock");
+                        let state = recover_lock(&self.state);
                         state.channels.get(&channel).cloned()
                     };
                     if let Some(slot) = slot {
-                        let mut slot = slot.lock().expect("channel slot lock");
+                        let mut slot = recover_lock(&slot);
                         slot.pending = Some(packet.update);
                         drop(slot);
                         (self.wake)();
@@ -504,11 +510,11 @@ impl DaemonConnection {
             (channel, MSG_SESSION_ROLE) if channel != CHANNEL_CONTROL => {
                 if let Ok(role_state) = frame.decode::<crate::packet::RoleState>() {
                     let slot = {
-                        let state = self.state.lock().expect("connection state lock");
+                        let state = recover_lock(&self.state);
                         state.channels.get(&channel).cloned()
                     };
                     if let Some(slot) = slot {
-                        slot.lock().expect("channel slot lock").granted_role = Some(role_state.role);
+                        recover_lock(&slot).granted_role = Some(role_state.role);
                         (self.wake)();
                     }
                 }
@@ -519,11 +525,11 @@ impl DaemonConnection {
 
     fn teardown_connection(&self) {
         {
-            let mut writer = self.writer.lock().expect("connection writer lock");
+            let mut writer = recover_lock(&self.writer);
             *writer = None;
         }
         {
-            let mut state = self.state.lock().expect("connection state lock");
+            let mut state = recover_lock(&self.state);
             state.connected = false;
         }
         (self.wake)();
@@ -856,6 +862,33 @@ mod tests {
 
         wait_until(|| connection.with_directory(|directory| !directory.entries.contains_key("alpha")));
         assert_eq!(connection.with_directory(|directory| directory.entries.len()), 1);
+
+        connection.shutdown();
+    }
+
+    #[test]
+    fn poisoned_client_mutexes_do_not_cascade_panics() {
+        let (_temp, layout) = test_layout();
+        let connection = DaemonConnection::open(layout, Vec::new(), Arc::new(|| {}));
+        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 80, 24, ChannelRole::Controller);
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _state = connection.state.lock().expect("state lock");
+            panic!("poison state lock");
+        }));
+        assert_eq!(connection.with_directory(|directory| directory.entries.len()), 0);
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _slot = slot.lock().expect("slot lock");
+            panic!("poison channel slot lock");
+        }));
+        assert!(connection.request_role(channel, ChannelRole::Watcher, false).is_err());
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _writer = connection.writer.lock().expect("writer lock");
+            panic!("poison writer lock");
+        }));
+        assert!(connection.send_resize(channel, 100, 40).is_err());
 
         connection.shutdown();
     }

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1382,7 +1382,6 @@ fn handle_http_request(
             maybe_fail_after_http_upgrade("attach")?;
             let _ = fs::write(state.layout.foreground_path(&id), b"1");
             hosted.active_client = Some(client);
-            hosted.had_foreground_client = true;
             let activation = (|| {
                 hosted.actor.set_client_presence(true)?;
                 hosted.actor.record_attach()?;
@@ -1394,6 +1393,7 @@ fn handle_http_request(
                 let _ = fs::remove_file(state.layout.foreground_path(&id));
                 return Err(err);
             }
+            hosted.had_foreground_client = true;
             Ok(())
         }
         http_uds::Route::SessionWatch { id } => {
@@ -1544,21 +1544,23 @@ fn handle_http_request(
                 .map_err(|err| format!("write HTTP paste-with-mark response: {err}"))
         }
         http_uds::Route::SessionRecord { id } => {
-            let Some(hosted) = state.sessions.get(&id) else {
+            let Some(hosted) = state.sessions.get_mut(&id) else {
                 return write_http_not_found(stream);
             };
             let body: http_uds::RecordRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP record request: {err}"))?;
             hosted.actor.set_recording(body.enable)?;
+            hosted.metadata.record = body.enable;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP record response: {err}"))
         }
         http_uds::Route::SessionTags { id } => {
-            let Some(hosted) = state.sessions.get(&id) else {
+            let Some(hosted) = state.sessions.get_mut(&id) else {
                 return write_http_not_found(stream);
             };
             let body: http_uds::TagRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP tag request: {err}"))?;
             let tags = hosted.actor.update_tags(body.add, body.remove)?;
+            hosted.metadata.tags.clone_from(&tags);
             broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
             http_uds::write_json(stream, StatusCode::OK, &http_uds::TagResponse { tags })
                 .map_err(|err| format!("write HTTP tag response: {err}"))

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -718,8 +718,12 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
                         packet_clients: &mut packet_clients,
                         next_packet_client_id: &mut next_packet_client_id,
                     };
-                    if let Err(err) = handle_http_request(root, daemon_name, &mut stream, request, &mut http_state) {
-                        let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &err);
+                    let mut response_committed = false;
+                    if let Err(err) = handle_http_request(root, daemon_name, &mut stream, request, &mut http_state, &mut response_committed)
+                    {
+                        if !response_committed {
+                            let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &err);
+                        }
                     }
                     if !sessions.is_empty() {
                         idle_since = None;
@@ -945,6 +949,19 @@ fn maybe_panic_for_containment_test(session_id: &str) {
     if std::env::var("CLEAT_TEST_PANIC_SESSION_TICK").as_deref() == Ok(session_id) {
         panic!("test-requested panic for session {session_id}");
     }
+}
+
+#[cfg(not(debug_assertions))]
+fn maybe_fail_after_http_upgrade(_route: &str) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(debug_assertions)]
+fn maybe_fail_after_http_upgrade(route: &str) -> Result<(), String> {
+    if std::env::var("CLEAT_TEST_FAIL_AFTER_HTTP_UPGRADE").as_deref() == Ok(route) {
+        return Err(format!("test-requested failure after {route} upgrade"));
+    }
+    Ok(())
 }
 
 fn cleanup_exited_session(layout: &RuntimeLayout, id: &str, should_keep_session_dir: bool) {
@@ -1195,6 +1212,7 @@ fn handle_http_request(
     stream: &mut SessionStream,
     request: http_uds::HttpRequest,
     state: &mut HttpRequestState<'_>,
+    response_committed: &mut bool,
 ) -> Result<(), String> {
     match http_uds::route(&request) {
         http_uds::Route::Root | http_uds::Route::Health => http_uds::write_json(
@@ -1257,15 +1275,17 @@ fn handle_http_request(
             let mut selectors = subscribe.selectors;
             crate::runtime::normalize_tags(&mut selectors);
             let directory = directory_snapshot_for_sessions(state.layout, state.sessions, state.packet_clients, &selectors)?;
-            http_uds::write_packet_switching_protocols(stream).map_err(|err| format!("write HTTP packet upgrade response: {err}"))?;
             let packet_stream = stream.try_clone().map_err(|err| format!("clone HTTP packet stream: {err}"))?;
             #[cfg(unix)]
             set_stream_nonblocking(&packet_stream, true).map_err(|err| format!("set HTTP packet stream nonblocking: {err}"))?;
             let client_id = *state.next_packet_client_id;
-            *state.next_packet_client_id += 1;
             let mut client = PacketClient::new(client_id, packet_stream, selectors, &directory)?;
             client.enqueue_control(MSG_CONTROL_HELLO, &ControlHello::current())?;
             client.enqueue_control(MSG_CONTROL_DIRECTORY_SNAPSHOT, &directory)?;
+            *response_committed = true;
+            http_uds::write_packet_switching_protocols(stream).map_err(|err| format!("write HTTP packet upgrade response: {err}"))?;
+            maybe_fail_after_http_upgrade("packet")?;
+            *state.next_packet_client_id += 1;
             state.packet_clients.push(client);
             Ok(())
         }
@@ -1298,7 +1318,6 @@ fn handle_http_request(
 
             let capabilities = attach_capabilities_from_http(body.capabilities);
             let replay = hosted.actor.apply_attach_state(body.cols, body.rows, capabilities)?;
-            http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP attach upgrade response: {err}"))?;
             let attach_stream = stream.try_clone().map_err(|err| format!("clone HTTP attach stream: {err}"))?;
             #[cfg(unix)]
             set_stream_nonblocking(&attach_stream, true).map_err(|err| format!("set HTTP attach stream nonblocking: {err}"))?;
@@ -1311,12 +1330,23 @@ fn handle_http_request(
                     client.enqueue_frame(&Frame::Output(payload))?;
                 }
             }
+            *response_committed = true;
+            http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP attach upgrade response: {err}"))?;
+            maybe_fail_after_http_upgrade("attach")?;
             let _ = fs::write(state.layout.foreground_path(&id), b"1");
             hosted.active_client = Some(client);
             hosted.had_foreground_client = true;
-            hosted.actor.set_client_presence(true)?;
-            hosted.actor.record_attach()?;
-            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
+            let activation = (|| {
+                hosted.actor.set_client_presence(true)?;
+                hosted.actor.record_attach()?;
+                broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)
+            })();
+            if let Err(err) = activation {
+                hosted.active_client = None;
+                let _ = hosted.actor.set_client_presence(false);
+                let _ = fs::remove_file(state.layout.foreground_path(&id));
+                return Err(err);
+            }
             Ok(())
         }
         http_uds::Route::SessionWatch { id } => {
@@ -1327,7 +1357,6 @@ fn handle_http_request(
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP watch request: {err}"))?;
             let capabilities = attach_capabilities_from_http(body.capabilities);
             let replay = hosted.actor.replay_payload(capabilities)?;
-            http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP watch upgrade response: {err}"))?;
             let watch_stream = stream.try_clone().map_err(|err| format!("clone HTTP watch stream: {err}"))?;
             #[cfg(unix)]
             set_stream_nonblocking(&watch_stream, true).map_err(|err| format!("set HTTP watch stream nonblocking: {err}"))?;
@@ -1337,8 +1366,17 @@ fn handle_http_request(
                     watcher.enqueue_frame(&Frame::Output(payload))?;
                 }
             }
+            *response_committed = true;
+            http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP watch upgrade response: {err}"))?;
+            maybe_fail_after_http_upgrade("watch")?;
             hosted.watchers.push(watcher);
-            broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
+            let activation = (|| {
+                broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)
+            })();
+            if let Err(err) = activation {
+                hosted.watchers.pop();
+                return Err(err);
+            }
             Ok(())
         }
         http_uds::Route::SessionDetach { id } => {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -28,8 +28,8 @@ use crate::{
     platform::{
         daemon::{is_session_daemon_alive, spawn_daemon_process},
         ipc::{
-            bind_session_listener, connect_session_stream, set_listener_nonblocking, set_stream_nonblocking, set_stream_read_timeout,
-            set_stream_write_timeout, shutdown_stream, try_connect_session_stream, SessionStream,
+            bind_session_listener, connect_session_stream, set_listener_nonblocking, set_stream_nonblocking, set_stream_write_timeout,
+            shutdown_stream, try_connect_session_stream, SessionStream,
         },
         terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
@@ -636,6 +636,7 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
 
     let mut sessions: HashMap<String, HostedSession> = HashMap::new();
     let mut packet_clients: Vec<PacketClient> = Vec::new();
+    let mut pending_http_handshakes: Vec<PendingHttpHandshake> = Vec::new();
     let mut next_packet_client_id: u64 = 1;
     let mut exited_session: Option<(String, bool)> = None;
     let mut faulted_session: Option<String> = None;
@@ -676,42 +677,31 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
 
         loop {
             match listener.accept() {
-                Ok((mut stream, _)) => {
+                Ok((stream, _)) => {
                     did_work = true;
-                    // Accepted sockets inherit nonblocking mode from the listener on macOS/BSD.
-                    // Reset to blocking so the initial frame read works correctly.
-                    #[cfg(unix)]
-                    {
-                        set_stream_nonblocking(&stream, false).map_err(|err| format!("set accepted stream blocking: {err}"))?;
+                    if let Ok(pending) = PendingHttpHandshake::new(stream) {
+                        pending_http_handshakes.push(pending);
                     }
-                    #[cfg(windows)]
-                    {
-                        set_stream_nonblocking(&stream, true).map_err(|err| format!("set accepted stream nonblocking: {err}"))?;
-                    }
-                    let _ = set_stream_write_timeout(&stream, Some(SESSION_HTTP_RESPONSE_WRITE_DEADLINE));
-                    let request = {
-                        let mut reader = HttpHandshakeReader::new(&mut stream, SESSION_HTTP_HANDSHAKE_DEADLINE);
-                        let mut prefix = [0; 5];
-                        if let Err(err) = reader.read_exact(&mut prefix) {
-                            let _ = err;
-                            continue;
-                        }
-                        if !http_uds::looks_like_http_prefix(&prefix) {
-                            continue;
-                        }
-                        match http_uds::read_request_with_prefix(&mut reader, &prefix) {
-                            Ok(request) => request,
-                            Err(err) => {
-                                let _ = http_uds::write_error(
-                                    &mut stream,
-                                    StatusCode::INTERNAL_SERVER_ERROR,
-                                    &format!("read HTTP request: {err}"),
-                                );
-                                continue;
-                            }
-                        }
-                    };
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(err) => return Err(format!("accept client: {err}")),
+            }
+        }
 
+        let mut handshake_index = 0;
+        while handshake_index < pending_http_handshakes.len() {
+            match pending_http_handshakes[handshake_index].poll() {
+                Ok(HttpHandshakePoll::Pending(handshake_did_work)) => {
+                    did_work |= handshake_did_work;
+                    handshake_index += 1;
+                }
+                Ok(HttpHandshakePoll::Ready(request)) => {
+                    did_work = true;
+                    let pending = pending_http_handshakes.swap_remove(handshake_index);
+                    let mut stream = pending.into_stream();
+                    if set_stream_nonblocking(&stream, false).is_err() {
+                        continue;
+                    }
                     let mut http_state = HttpRequestState {
                         layout: &layout,
                         sessions: &mut sessions,
@@ -719,7 +709,8 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
                         next_packet_client_id: &mut next_packet_client_id,
                     };
                     let mut response_committed = false;
-                    if let Err(err) = handle_http_request(root, daemon_name, &mut stream, request, &mut http_state, &mut response_committed)
+                    if let Err(err) =
+                        handle_http_request(root, daemon_name, &mut stream, *request, &mut http_state, &mut response_committed)
                     {
                         if !response_committed {
                             let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &err);
@@ -729,8 +720,15 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
                         idle_since = None;
                     }
                 }
-                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
-                Err(err) => return Err(format!("accept client: {err}")),
+                Err(err) => {
+                    did_work = true;
+                    let pending = pending_http_handshakes.swap_remove(handshake_index);
+                    if err.kind() == io::ErrorKind::InvalidData {
+                        let mut stream = pending.into_stream();
+                        let _ = set_stream_nonblocking(&stream, false);
+                        let _ = http_uds::write_error(&mut stream, StatusCode::INTERNAL_SERVER_ERROR, &format!("read HTTP request: {err}"));
+                    }
+                }
             }
         }
 
@@ -1177,32 +1175,81 @@ struct HttpRequestState<'a> {
     next_packet_client_id: &'a mut u64,
 }
 
-struct HttpHandshakeReader<'a> {
-    stream: &'a mut SessionStream,
+#[cfg(any(unix, windows))]
+struct PendingHttpHandshake {
+    stream: SessionStream,
+    buffer: Vec<u8>,
     deadline: Instant,
+    #[cfg(windows)]
+    reader: crate::platform::ipc::OverlappedRead,
 }
 
-impl<'a> HttpHandshakeReader<'a> {
-    fn new(stream: &'a mut SessionStream, budget: Duration) -> Self {
-        Self { stream, deadline: Instant::now() + budget }
+enum HttpHandshakePoll {
+    Pending(bool),
+    Ready(Box<http_uds::HttpRequest>),
+}
+
+#[cfg(any(unix, windows))]
+impl PendingHttpHandshake {
+    fn new(stream: SessionStream) -> Result<Self, String> {
+        set_stream_nonblocking(&stream, true)?;
+        set_stream_write_timeout(&stream, Some(SESSION_HTTP_RESPONSE_WRITE_DEADLINE))?;
+        #[cfg(windows)]
+        let reader = stream.overlapped_reader(8192).map_err(|err| format!("create HTTP handshake reader: {err}"))?;
+        Ok(Self {
+            stream,
+            buffer: Vec::new(),
+            deadline: Instant::now() + SESSION_HTTP_HANDSHAKE_DEADLINE,
+            #[cfg(windows)]
+            reader,
+        })
     }
 
-    fn remaining_budget(&self) -> io::Result<Duration> {
-        let Some(remaining) = self.deadline.checked_duration_since(Instant::now()) else {
-            return Err(io::Error::new(io::ErrorKind::TimedOut, "HTTP request handshake deadline exceeded"));
-        };
-        if remaining.is_zero() {
+    fn poll(&mut self) -> io::Result<HttpHandshakePoll> {
+        if Instant::now() >= self.deadline {
             return Err(io::Error::new(io::ErrorKind::TimedOut, "HTTP request handshake deadline exceeded"));
         }
-        Ok(remaining)
-    }
-}
 
-impl Read for HttpHandshakeReader<'_> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let remaining = self.remaining_budget()?;
-        set_stream_read_timeout(self.stream, Some(remaining)).map_err(io::Error::other)?;
-        self.stream.read(buf)
+        let mut did_work = false;
+        loop {
+            if self.buffer.len() >= 5 && !http_uds::looks_like_http_prefix(&self.buffer[..5]) {
+                return Err(io::Error::new(io::ErrorKind::ConnectionAborted, "connection did not start with HTTP"));
+            }
+            if let Some(request) = http_uds::try_parse_request(&self.buffer)? {
+                return Ok(HttpHandshakePoll::Ready(Box::new(request)));
+            }
+
+            let Some(chunk) = self.read_available()? else {
+                return Ok(HttpHandshakePoll::Pending(did_work));
+            };
+            if chunk.is_empty() {
+                return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "connection closed before HTTP request completed"));
+            }
+            self.buffer.extend_from_slice(&chunk);
+            did_work = true;
+        }
+    }
+
+    #[cfg(unix)]
+    fn read_available(&mut self) -> io::Result<Option<Vec<u8>>> {
+        let mut chunk = vec![0; 8192];
+        match self.stream.read(&mut chunk) {
+            Ok(read) => {
+                chunk.truncate(read);
+                Ok(Some(chunk))
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    #[cfg(windows)]
+    fn read_available(&mut self) -> io::Result<Option<Vec<u8>>> {
+        self.reader.poll()
+    }
+
+    fn into_stream(self) -> SessionStream {
+        self.stream
     }
 }
 

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -511,6 +511,7 @@ struct PacketChannelRef {
 }
 
 struct HostedSession {
+    metadata: SessionMetadata,
     actor: SessionActor,
     raw_output_tap: RawOutputTap,
     active_client: Option<ActiveClient>,
@@ -527,6 +528,7 @@ struct HostedSession {
 
 impl HostedSession {
     fn spawn(session_dir: PathBuf, session: SessionMetadata) -> Result<Self, String> {
+        let should_keep_session_dir = session.record;
         let actor_session_dir = session_dir;
         let actor_session = session.clone();
         let actor = SessionActor::spawn(session.initial_size.rows, Arc::new(|| {}), move || {
@@ -534,6 +536,7 @@ impl HostedSession {
         })?;
         let raw_output_tap = actor.subscribe_raw_output()?;
         Ok(Self {
+            metadata: session,
             actor,
             raw_output_tap,
             active_client: None,
@@ -543,7 +546,7 @@ impl HostedSession {
             had_foreground_client: false,
             pending_waits: Vec::new(),
             pending_expects: Vec::new(),
-            should_keep_session_dir: session.record,
+            should_keep_session_dir,
         })
     }
 }
@@ -1234,6 +1237,8 @@ fn handle_http_request(
                     )?;
                 }
             }
+            let session =
+                state.sessions.get(&session.id).ok_or_else(|| "created session disappeared before response".to_string())?.metadata.clone();
             http_uds::write_json(stream, StatusCode::OK, &http_uds::CreateSessionResponse { session })
                 .map_err(|err| format!("write HTTP session create response: {err}"))
         }

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -475,6 +475,32 @@ fn create_existing_session_returns_its_running_metadata() {
     service.kill("alpha").expect("kill session");
 }
 
+#[test]
+fn failures_after_protocol_upgrade_close_without_an_http_error() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    for route in ["attach", "watch", "packet"] {
+        let _failure = EnvVarGuard::set("CLEAT_TEST_FAIL_AFTER_HTTP_UPGRADE", route);
+        let temp = tempfile::tempdir().expect("tempdir");
+        let service = service_for(temp.path());
+        service
+            .create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+            .expect("create session");
+
+        let mut stream = match route {
+            "attach" => http_attach_stream(temp.path(), "alpha", 80, 24, ClientCapabilities::conservative_fallback()),
+            "watch" => http_watch_stream(temp.path(), "alpha", 80, 24, ClientCapabilities::conservative_fallback()),
+            "packet" => http_packet_stream(temp.path(), "alpha"),
+            _ => unreachable!(),
+        };
+        let mut post_upgrade = Vec::new();
+        stream.read_to_end(&mut post_upgrade).expect("read upgraded stream to close");
+
+        assert!(post_upgrade.is_empty(), "HTTP bytes followed the {route} 101 response: {}", String::from_utf8_lossy(&post_upgrade));
+
+        service.kill("alpha").expect("kill session");
+    }
+}
+
 #[cfg(feature = "ghostty-vt")]
 #[test]
 fn create_json_returns_structured_metadata() {

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -34,7 +34,7 @@ use cleat::{
     recording::{SessionRecorder, CAST_FILE_NAME},
     runtime::{RuntimeLayout, TerminalSize, DEFAULT_DAEMON_NAME},
     server::{EndBound, SessionService, StartBound},
-    session::{daemon_pid_path, session_socket_path},
+    session::{daemon_pid_path, ensure_session_started, session_socket_path, SessionStartOptions},
     vt::{self, ClientCapabilities, ColorLevel, VtEngineKind},
 };
 #[cfg(feature = "ghostty-vt")]
@@ -438,6 +438,41 @@ fn create_makes_session_directory_and_returns_metadata() {
     let output = cli::execute(cli, &service).expect("execute create").expect("create output");
     assert_eq!(output, "alpha");
     assert!(service.session_dir("alpha").exists());
+}
+
+#[test]
+fn create_existing_session_returns_its_running_metadata() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let layout = RuntimeLayout::new(temp.path().to_path_buf());
+    let service = SessionService::new(layout.clone());
+    let first_cwd = temp.path().join("first");
+    let second_cwd = temp.path().join("second");
+    std::fs::create_dir_all(&first_cwd).expect("create first cwd");
+    std::fs::create_dir_all(&second_cwd).expect("create second cwd");
+
+    let first = ensure_session_started(
+        &layout,
+        Some("alpha".into()),
+        Some(VtEngineKind::Passthrough),
+        Some(first_cwd),
+        Some("sleep 30".into()),
+        SessionStartOptions::default(),
+    )
+    .expect("create first session");
+    let second = ensure_session_started(
+        &layout,
+        Some("alpha".into()),
+        Some(VtEngineKind::Passthrough),
+        Some(second_cwd),
+        Some("printf replacement".into()),
+        SessionStartOptions::default(),
+    )
+    .expect("ensure existing session");
+
+    assert_eq!(second, first);
+
+    service.kill("alpha").expect("kill session");
 }
 
 #[cfg(feature = "ghostty-vt")]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -501,6 +501,35 @@ fn failures_after_protocol_upgrade_close_without_an_http_error() {
     }
 }
 
+#[test]
+fn partial_handshakes_do_not_block_ready_control_requests() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false).expect("create session");
+
+    let socket_path = session_socket_path(temp.path(), "alpha");
+    let mut partials = Vec::new();
+    for _ in 0..4 {
+        let mut stream = UnixStream::connect(&socket_path).expect("connect partial request");
+        stream.write_all(b"GET /").expect("write partial request");
+        partials.push(stream);
+    }
+    std::thread::sleep(Duration::from_millis(50));
+
+    let start = Instant::now();
+    let mut ready = UnixStream::connect(&socket_path).expect("connect ready request");
+    ready.set_read_timeout(Some(Duration::from_secs(2))).expect("set ready response timeout");
+    ready.write_all(b"GET /healthz HTTP/1.1\r\nHost: cleat\r\n\r\n").expect("write ready request");
+    let response = read_http_response_head(&mut ready);
+
+    assert!(response.starts_with("HTTP/1.1 200 OK\r\n"), "{response}");
+    assert!(start.elapsed() < Duration::from_millis(700), "ready request waited behind partial handshakes: {:?}", start.elapsed());
+
+    drop(partials);
+    service.kill("alpha").expect("kill session");
+}
+
 #[cfg(feature = "ghostty-vt")]
 #[test]
 fn create_json_returns_structured_metadata() {

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -460,6 +460,8 @@ fn create_existing_session_returns_its_running_metadata() {
         SessionStartOptions::default(),
     )
     .expect("create first session");
+    let tags = service.update_tags("alpha", vec!["project=cleat".into()], Vec::new()).expect("tag running session");
+    assert_eq!(tags, ["project=cleat"]);
     let second = ensure_session_started(
         &layout,
         Some("alpha".into()),
@@ -470,7 +472,9 @@ fn create_existing_session_returns_its_running_metadata() {
     )
     .expect("ensure existing session");
 
-    assert_eq!(second, first);
+    let mut expected = first;
+    expected.tags = tags;
+    assert_eq!(second, expected);
 
     service.kill("alpha").expect("kill session");
 }


### PR DESCRIPTION
Closes #139.

## What changed

- service accepted HTTP handshakes incrementally so partial clients cannot block session output or other control requests
- stop writing HTTP errors after a protocol upgrade has committed
- return the running session's authoritative metadata when a create request reuses an existing ID
- recover poisoned provider-daemon client locks instead of cascading panics through later calls

## Root cause

The daemon read each accepted handshake inline on its main servicing loop, upgrade routes could still propagate errors after writing `101 Switching Protocols`, create responses reused request metadata even when no session was created, and provider client state used poisoning `expect` calls throughout.

## Impact

Slow local clients no longer stall unrelated sessions, upgraded clients receive a clean close instead of HTTP bytes in the frame stream, repeated creates describe the actual running session, and a poisoned client mutex no longer turns subsequent provider calls into panics.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`