### PR TITLE
Fix raw output snapshot synchronization

### DIFF
--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -50,13 +50,35 @@ pub(crate) type WakeCallback = Arc<dyn Fn() + Send + Sync + 'static>;
 pub(crate) type ImageResourceDataCallback = Box<dyn FnMut(&[u8]) -> bool + Send>;
 
 pub(crate) struct RawOutputTap {
-    rx: Receiver<Vec<u8>>,
+    rx: Receiver<RawOutputChunk>,
 }
 
 impl RawOutputTap {
-    pub(crate) fn try_recv(&self) -> Result<Vec<u8>, mpsc::TryRecvError> {
+    pub(crate) fn try_recv(&self) -> Result<RawOutputChunk, mpsc::TryRecvError> {
         self.rx.try_recv()
     }
+
+    #[cfg(test)]
+    pub(crate) fn test_channel(capacity: usize) -> (SyncSender<RawOutputChunk>, Self) {
+        let (tx, rx) = mpsc::sync_channel(capacity);
+        (tx, Self { rx })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RawOutputChunk {
+    pub(crate) sequence: u64,
+    pub(crate) bytes: Vec<u8>,
+}
+
+pub(crate) struct RawOutputReplay {
+    pub(crate) payload: Option<Vec<u8>>,
+    pub(crate) through_sequence: u64,
+}
+
+pub(crate) struct RawOutputRecovery {
+    pub(crate) tap: RawOutputTap,
+    pub(crate) payloads: Vec<Option<Vec<u8>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -303,8 +325,8 @@ pub(crate) enum SessionCommand {
     FullSnapshot { reply: mpsc::Sender<Result<TerminalSnapshot, String>> },
     ImageResourceData { image_id: u32, generation: u64, callback: ImageResourceDataCallback, reply: mpsc::Sender<Result<bool, String>> },
     Inspect { has_controller: bool, watcher_count: usize, reply: mpsc::Sender<Result<InspectResult, String>> },
-    ApplyAttachState { cols: u16, rows: u16, capabilities: vt::ClientCapabilities, reply: mpsc::Sender<Result<Option<Vec<u8>>, String>> },
-    ReplayPayload { capabilities: vt::ClientCapabilities, reply: mpsc::Sender<Result<Option<Vec<u8>>, String>> },
+    ApplyAttachState { cols: u16, rows: u16, capabilities: vt::ClientCapabilities, reply: mpsc::Sender<Result<RawOutputReplay, String>> },
+    ReplayPayload { capabilities: vt::ClientCapabilities, reply: mpsc::Sender<Result<RawOutputReplay, String>> },
     CaptureText { reply: mpsc::Sender<Result<String, String>> },
     ValidateTextMatching { reply: mpsc::Sender<Result<(), String>> },
     ScreenContains { text: String, reply: mpsc::Sender<Result<bool, String>> },
@@ -327,6 +349,7 @@ pub(crate) enum SessionCommand {
     ScrollbarState { reply: mpsc::Sender<TerminalScrollbarState> },
     SetClientPresence { active: bool, reply: mpsc::Sender<Result<(), String>> },
     SubscribeRawOutput { reply: mpsc::Sender<RawOutputTap> },
+    RecoverRawOutput { capabilities: Vec<vt::ClientCapabilities>, reply: mpsc::Sender<Result<RawOutputRecovery, String>> },
     Stop { terminate: bool },
 }
 
@@ -662,11 +685,15 @@ impl SessionActor {
         recv.recv().map_err(|_| "session actor did not reply".to_string())
     }
 
+    pub(crate) fn recover_raw_output(&self, capabilities: Vec<vt::ClientCapabilities>) -> Result<RawOutputRecovery, String> {
+        self.request_result(|reply| SessionCommand::RecoverRawOutput { capabilities, reply })
+    }
+
     pub(crate) fn inspect(&self, has_controller: bool, watcher_count: usize) -> Result<InspectResult, String> {
         self.request_result(|reply| SessionCommand::Inspect { has_controller, watcher_count, reply })
     }
 
-    pub(crate) fn apply_attach_state(&self, cols: u16, rows: u16, capabilities: vt::ClientCapabilities) -> Result<Option<Vec<u8>>, String> {
+    pub(crate) fn apply_attach_state(&self, cols: u16, rows: u16, capabilities: vt::ClientCapabilities) -> Result<RawOutputReplay, String> {
         self.request_result(|reply| SessionCommand::ApplyAttachState { cols, rows, capabilities, reply })
     }
 
@@ -694,7 +721,7 @@ impl SessionActor {
         self.request_result(|reply| SessionCommand::Paste { text, reply })
     }
 
-    pub(crate) fn replay_payload(&self, capabilities: vt::ClientCapabilities) -> Result<Option<Vec<u8>>, String> {
+    pub(crate) fn replay_payload(&self, capabilities: vt::ClientCapabilities) -> Result<RawOutputReplay, String> {
         self.request_result(|reply| SessionCommand::ReplayPayload { capabilities, reply })
     }
 
@@ -831,7 +858,8 @@ struct SessionActorLoopState {
     exited: bool,
     exit_code: Option<i32>,
     has_active_client: bool,
-    raw_output_taps: Vec<SyncSender<Vec<u8>>>,
+    raw_output_taps: Vec<SyncSender<RawOutputChunk>>,
+    last_raw_output_sequence: u64,
 }
 
 fn pump_session_runtime(
@@ -901,6 +929,7 @@ fn session_actor_loop(
         exit_code: None,
         has_active_client: false,
         raw_output_taps: Vec::new(),
+        last_raw_output_sequence: 0,
     };
     let _ = ready.send(Ok(()));
     #[cfg(unix)]
@@ -1048,13 +1077,19 @@ fn session_actor_handle_command(
         SessionCommand::ApplyAttachState { cols, rows, capabilities, reply } => {
             let cols = cols.max(1);
             let rows = rows.max(1);
-            let result = runtime.apply_attach_state(cols, rows, &capabilities).inspect(|_| {
-                mark_full_and_wake(&mut state.observation, rows, wake);
-            });
+            let result = runtime
+                .apply_attach_state(cols, rows, &capabilities)
+                .inspect(|_| {
+                    mark_full_and_wake(&mut state.observation, rows, wake);
+                })
+                .map(|payload| RawOutputReplay { payload, through_sequence: state.last_raw_output_sequence });
             let _ = reply.send(result);
         }
         SessionCommand::ReplayPayload { capabilities, reply } => {
-            let _ = reply.send(runtime.replay_payload(&capabilities));
+            let result = runtime
+                .replay_payload(&capabilities)
+                .map(|payload| RawOutputReplay { payload, through_sequence: state.last_raw_output_sequence });
+            let _ = reply.send(result);
         }
         SessionCommand::CaptureText { reply } => {
             let _ = reply.send(runtime.capture_text());
@@ -1137,6 +1172,16 @@ fn session_actor_handle_command(
             state.raw_output_taps.push(tx);
             let _ = reply.send(RawOutputTap { rx });
         }
+        SessionCommand::RecoverRawOutput { capabilities, reply } => {
+            let result = capabilities.iter().map(|capabilities| runtime.replay_payload(capabilities)).collect::<Result<Vec<_>, _>>().map(
+                |payloads| {
+                    let (tx, rx) = mpsc::sync_channel(RAW_OUTPUT_TAP_CHUNKS);
+                    state.raw_output_taps.push(tx);
+                    RawOutputRecovery { tap: RawOutputTap { rx }, payloads }
+                },
+            );
+            let _ = reply.send(result);
+        }
         SessionCommand::Stop { terminate } => {
             if terminate && !state.exited {
                 let _ = runtime.dispatch_signal(POSIX_SIGTERM, SignalTarget::Leader);
@@ -1171,7 +1216,7 @@ fn session_actor_pump(runtime: &mut SessionRuntime, state: &mut SessionActorLoop
             if !result.chunks.is_empty() {
                 maybe_panic_actor_for_test(runtime.session_id());
             }
-            publish_raw_output(&mut state.raw_output_taps, &result.chunks);
+            publish_raw_output(&mut state.raw_output_taps, &mut state.last_raw_output_sequence, &result.chunks);
             // Flush actor-side after each pump slice: the servicing loop no
             // longer round-trips into the actor for it, and recording only
             // grows when the pump runs.
@@ -1200,18 +1245,12 @@ fn session_actor_pump(runtime: &mut SessionRuntime, state: &mut SessionActorLoop
     sync_terminal_modes_and_wake(runtime, &mut state.observation, wake);
 }
 
-fn publish_raw_output(taps: &mut Vec<SyncSender<Vec<u8>>>, chunks: &[Vec<u8>]) {
-    if chunks.is_empty() || taps.is_empty() {
-        return;
+fn publish_raw_output(taps: &mut Vec<SyncSender<RawOutputChunk>>, last_sequence: &mut u64, chunks: &[Vec<u8>]) {
+    for bytes in chunks {
+        *last_sequence = last_sequence.saturating_add(1);
+        let chunk = RawOutputChunk { sequence: *last_sequence, bytes: bytes.clone() };
+        taps.retain(|tap| tap.try_send(chunk.clone()).is_ok());
     }
-    taps.retain(|tap| {
-        for chunk in chunks {
-            if tap.try_send(chunk.clone()).is_err() {
-                return false;
-            }
-        }
-        true
-    });
 }
 
 fn route_paste_on_actor(runtime: &mut SessionRuntime, text: &[u8]) -> Result<usize, String> {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -17,7 +17,7 @@ use std::{
 use http::StatusCode;
 
 use crate::{
-    host::actor::{RawOutputTap, SessionActor, SessionMouseEvent, SessionWheelEvent},
+    host::actor::{RawOutputRecovery, RawOutputReplay, RawOutputTap, SessionActor, SessionMouseEvent, SessionWheelEvent},
     http_uds,
     packet::{
         Ack, ChannelRole, CloseChannel, ControlError, ControlHello, DirectoryDelta, DirectoryEntry, DirectorySnapshot, Input, OpenChannel,
@@ -585,15 +585,195 @@ fn drain_raw_output_tap(
         match raw_output_tap.try_recv() {
             Ok(chunk) => {
                 drained = true;
-                enqueue_output_chunk(layout, id, actor, active_client, watchers, chunk);
+                enqueue_output_chunk(layout, id, actor, active_client, watchers, chunk.bytes);
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => return Ok(drained),
             Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                *raw_output_tap = actor.subscribe_raw_output()?;
+                recover_raw_output_tap(layout, id, actor, raw_output_tap, active_client, watchers, None)?;
                 return Ok(drained);
             }
         }
     }
+}
+
+fn drain_raw_output_tap_before_client_install(
+    layout: &RuntimeLayout,
+    id: &str,
+    hosted: &mut HostedSession,
+    new_client: &mut ActiveClient,
+    replay: RawOutputReplay,
+    replay_mode: ReplayMode,
+) -> Result<(), String> {
+    let plan = plan_raw_output_client_install(&hosted.raw_output_tap, replay, replay_mode);
+    let existing_chunks = match &plan {
+        RawOutputClientInstallPlan::Complete { existing_chunks, .. } | RawOutputClientInstallPlan::Disconnected { existing_chunks } => {
+            existing_chunks
+        }
+    };
+    for chunk in existing_chunks {
+        enqueue_output_chunk(layout, id, &hosted.actor, &mut hosted.active_client, &mut hosted.watchers, chunk.clone());
+    }
+    match plan {
+        RawOutputClientInstallPlan::Complete { new_client_frames, .. } => {
+            enqueue_frames(new_client, &new_client_frames)?;
+        }
+        RawOutputClientInstallPlan::Disconnected { .. } => {
+            recover_raw_output_tap(
+                layout,
+                id,
+                &hosted.actor,
+                &mut hosted.raw_output_tap,
+                &mut hosted.active_client,
+                &mut hosted.watchers,
+                Some(NewRawOutputClient { client: new_client, replay_mode }),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+enum RawOutputClientInstallPlan {
+    Complete { existing_chunks: Vec<Vec<u8>>, new_client_frames: Vec<Frame> },
+    Disconnected { existing_chunks: Vec<Vec<u8>> },
+}
+
+fn plan_raw_output_client_install(
+    raw_output_tap: &RawOutputTap,
+    replay: RawOutputReplay,
+    replay_mode: ReplayMode,
+) -> RawOutputClientInstallPlan {
+    let mut existing_chunks = Vec::new();
+    let mut live_after_replay = Vec::new();
+    loop {
+        match raw_output_tap.try_recv() {
+            Ok(chunk) => {
+                if chunk.sequence > replay.through_sequence {
+                    live_after_replay.push(chunk.bytes.clone());
+                }
+                existing_chunks.push(chunk.bytes);
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                let mut new_client_frames = replay_frames(replay.payload, replay_mode);
+                new_client_frames.extend(live_after_replay.into_iter().map(Frame::Output));
+                return RawOutputClientInstallPlan::Complete { existing_chunks, new_client_frames };
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                return RawOutputClientInstallPlan::Disconnected { existing_chunks };
+            }
+        }
+    }
+}
+
+trait RawOutputRecoverySource {
+    fn recover_raw_output(&self, capabilities: Vec<vt::ClientCapabilities>) -> Result<RawOutputRecovery, String>;
+}
+
+impl RawOutputRecoverySource for SessionActor {
+    fn recover_raw_output(&self, capabilities: Vec<vt::ClientCapabilities>) -> Result<RawOutputRecovery, String> {
+        SessionActor::recover_raw_output(self, capabilities)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ReplayMode {
+    FreshTerminal,
+    ResetTerminal,
+}
+
+impl ReplayMode {
+    fn resets_terminal(self) -> bool {
+        matches!(self, Self::ResetTerminal)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RawOutputRecoveryRequest {
+    capabilities: vt::ClientCapabilities,
+    replay_mode: ReplayMode,
+}
+
+struct RawOutputRecoveryPlan {
+    tap: RawOutputTap,
+    recipient_frames: Vec<Vec<Frame>>,
+}
+
+fn plan_raw_output_recovery(
+    source: &impl RawOutputRecoverySource,
+    requests: &[RawOutputRecoveryRequest],
+) -> Result<RawOutputRecoveryPlan, String> {
+    let recovery = source.recover_raw_output(requests.iter().map(|request| request.capabilities).collect())?;
+    if recovery.payloads.len() != requests.len() {
+        return Err(format!("raw output recovery returned {} payloads for {} clients", recovery.payloads.len(), requests.len()));
+    }
+    let recipient_frames =
+        recovery.payloads.into_iter().zip(requests).map(|(payload, request)| replay_frames(payload, request.replay_mode)).collect();
+    Ok(RawOutputRecoveryPlan { tap: recovery.tap, recipient_frames })
+}
+
+fn replay_frames(payload: Option<Vec<u8>>, replay_mode: ReplayMode) -> Vec<Frame> {
+    let Some(payload) = payload.filter(|payload| !payload.is_empty()) else {
+        return Vec::new();
+    };
+    let mut frames = Vec::with_capacity(usize::from(replay_mode.resets_terminal()) + 1);
+    if replay_mode.resets_terminal() {
+        frames.push(Frame::Output(REATTACH_CLEAR_SEQUENCE.to_vec()));
+    }
+    frames.push(Frame::Output(payload));
+    frames
+}
+
+fn enqueue_frames(client: &mut ActiveClient, frames: &[Frame]) -> Result<(), String> {
+    for frame in frames {
+        client.enqueue_frame(frame)?;
+    }
+    Ok(())
+}
+
+struct NewRawOutputClient<'a> {
+    client: &'a mut ActiveClient,
+    replay_mode: ReplayMode,
+}
+
+fn recover_raw_output_tap(
+    layout: &RuntimeLayout,
+    id: &str,
+    actor: &SessionActor,
+    raw_output_tap: &mut RawOutputTap,
+    active_client: &mut Option<ActiveClient>,
+    watchers: &mut Vec<ActiveClient>,
+    new_client: Option<NewRawOutputClient<'_>>,
+) -> Result<(), String> {
+    let requests: Vec<_> = active_client
+        .iter()
+        .map(|client| RawOutputRecoveryRequest { capabilities: client.capabilities, replay_mode: ReplayMode::ResetTerminal })
+        .chain(
+            watchers
+                .iter()
+                .map(|watcher| RawOutputRecoveryRequest { capabilities: watcher.capabilities, replay_mode: ReplayMode::ResetTerminal }),
+        )
+        .chain(new_client.as_ref().map(|new_client| RawOutputRecoveryRequest {
+            capabilities: new_client.client.capabilities,
+            replay_mode: new_client.replay_mode,
+        }))
+        .collect();
+    let recovery = plan_raw_output_recovery(actor, &requests)?;
+    *raw_output_tap = recovery.tap;
+    let mut recipient_frames = recovery.recipient_frames.into_iter();
+    if let Some(client) = active_client.as_mut() {
+        if recipient_frames.next().is_some_and(|frames| enqueue_frames(client, &frames).is_err()) {
+            let _ = fs::remove_file(layout.foreground_path(id));
+            let _ = actor.record_detach();
+            let _ = actor.set_client_presence(false);
+            *active_client = None;
+        }
+    }
+    watchers.retain_mut(|watcher| recipient_frames.next().is_none_or(|frames| enqueue_frames(watcher, &frames).is_ok()));
+    if let Some(new_client) = new_client {
+        if let Some(frames) = recipient_frames.next() {
+            enqueue_frames(new_client.client, &frames)?;
+        }
+    }
+    Ok(())
 }
 
 fn drain_watcher_inputs(watchers: &mut Vec<ActiveClient>) {
@@ -1298,14 +1478,9 @@ fn handle_http_request(
             #[cfg(unix)]
             set_stream_nonblocking(&attach_stream, true).map_err(|err| format!("set HTTP attach stream nonblocking: {err}"))?;
             let mut client = ActiveClient::new(attach_stream)?;
-            if let Some(payload) = replay {
-                if !payload.is_empty() {
-                    if hosted.had_foreground_client {
-                        client.enqueue_frame(&Frame::Output(REATTACH_CLEAR_SEQUENCE.to_vec()))?;
-                    }
-                    client.enqueue_frame(&Frame::Output(payload))?;
-                }
-            }
+            client.capabilities = capabilities;
+            let replay_mode = if hosted.had_foreground_client { ReplayMode::ResetTerminal } else { ReplayMode::FreshTerminal };
+            drain_raw_output_tap_before_client_install(state.layout, &id, hosted, &mut client, replay, replay_mode)?;
             let _ = fs::write(state.layout.foreground_path(&id), b"1");
             hosted.active_client = Some(client);
             hosted.had_foreground_client = true;
@@ -1327,11 +1502,8 @@ fn handle_http_request(
             #[cfg(unix)]
             set_stream_nonblocking(&watch_stream, true).map_err(|err| format!("set HTTP watch stream nonblocking: {err}"))?;
             let mut watcher = ActiveClient::new(watch_stream)?;
-            if let Some(payload) = replay {
-                if !payload.is_empty() {
-                    watcher.enqueue_frame(&Frame::Output(payload))?;
-                }
-            }
+            watcher.capabilities = capabilities;
+            drain_raw_output_tap_before_client_install(state.layout, &id, hosted, &mut watcher, replay, ReplayMode::FreshTerminal)?;
             hosted.watchers.push(watcher);
             broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
             Ok(())
@@ -2307,12 +2479,19 @@ struct ActiveClient {
     pending_output: Vec<u8>,
     input_reader: ActiveClientReader,
     input_buffer: Vec<u8>,
+    capabilities: vt::ClientCapabilities,
 }
 
 impl ActiveClient {
     fn new(stream: SessionStream) -> Result<Self, String> {
         let input_reader = ActiveClientReader::new(&stream)?;
-        Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new() })
+        Ok(Self {
+            stream,
+            pending_output: Vec::new(),
+            input_reader,
+            input_buffer: Vec::new(),
+            capabilities: vt::ClientCapabilities::conservative_fallback(),
+        })
     }
 
     fn drain_input_frames(&mut self, pending: &mut VecDeque<Frame>, timeout: Duration) -> Result<bool, std::io::Error> {
@@ -2454,6 +2633,7 @@ fn http_error_message(response: http_uds::HttpResponse) -> String {
 #[cfg(test)]
 mod tests {
     use std::{
+        cell::RefCell,
         sync::{Arc, Mutex},
         time::{Duration, Instant},
     };
@@ -2718,6 +2898,74 @@ mod tests {
 
         assert_eq!(engine.size(), (100, 30));
         assert_eq!(replay, Some(b"Ansi256:true".to_vec()));
+    }
+
+    #[test]
+    fn client_install_plan_sends_snapshot_covered_chunks_only_to_existing_clients() {
+        let (tap_tx, tap) = crate::host::actor::RawOutputTap::test_channel(2);
+        tap_tx.send(crate::host::actor::RawOutputChunk { sequence: 1, bytes: b"line2\n".to_vec() }).expect("queue snapshot-covered output");
+        tap_tx.send(crate::host::actor::RawOutputChunk { sequence: 2, bytes: b"line3\n".to_vec() }).expect("queue post-snapshot output");
+
+        let plan = super::plan_raw_output_client_install(
+            &tap,
+            crate::host::actor::RawOutputReplay { payload: Some(b"line2\n".to_vec()), through_sequence: 1 },
+            super::ReplayMode::FreshTerminal,
+        );
+
+        let super::RawOutputClientInstallPlan::Complete { existing_chunks, new_client_frames } = plan else {
+            panic!("connected tap should produce a complete install plan");
+        };
+        assert_eq!(existing_chunks, vec![b"line2\n".to_vec(), b"line3\n".to_vec()]);
+        assert_eq!(new_client_frames, vec![
+            crate::protocol::Frame::Output(b"line2\n".to_vec()),
+            crate::protocol::Frame::Output(b"line3\n".to_vec())
+        ]);
+    }
+
+    struct FakeRawOutputRecoverySource {
+        seen_capabilities: RefCell<Vec<vt::ClientCapabilities>>,
+        payloads: Vec<Option<Vec<u8>>>,
+    }
+
+    impl super::RawOutputRecoverySource for FakeRawOutputRecoverySource {
+        fn recover_raw_output(&self, capabilities: Vec<vt::ClientCapabilities>) -> Result<crate::host::actor::RawOutputRecovery, String> {
+            self.seen_capabilities.replace(capabilities);
+            let (_tap_tx, tap) = crate::host::actor::RawOutputTap::test_channel(1);
+            Ok(crate::host::actor::RawOutputRecovery { tap, payloads: self.payloads.clone() })
+        }
+    }
+
+    #[test]
+    fn disconnected_tap_recovers_with_terminal_reset_and_fresh_replay() {
+        let (tap_tx, tap) = crate::host::actor::RawOutputTap::test_channel(1);
+        tap_tx.send(crate::host::actor::RawOutputChunk { sequence: 1, bytes: b"queued\n".to_vec() }).expect("queue output before overflow");
+        drop(tap_tx);
+        let install = super::plan_raw_output_client_install(
+            &tap,
+            crate::host::actor::RawOutputReplay { payload: Some(b"stale snapshot".to_vec()), through_sequence: 0 },
+            super::ReplayMode::FreshTerminal,
+        );
+        let super::RawOutputClientInstallPlan::Disconnected { existing_chunks } = install else {
+            panic!("dropped tap sender should require recovery");
+        };
+        assert_eq!(existing_chunks, vec![b"queued\n".to_vec()]);
+
+        let capabilities = vt::ClientCapabilities::new(vt::ColorLevel::Ansi256, true);
+        let source = FakeRawOutputRecoverySource {
+            seen_capabilities: RefCell::new(Vec::new()),
+            payloads: vec![Some(b"fresh snapshot with OVERFLOW_END".to_vec())],
+        };
+        let recovery = super::plan_raw_output_recovery(&source, &[super::RawOutputRecoveryRequest {
+            capabilities,
+            replay_mode: super::ReplayMode::ResetTerminal,
+        }])
+        .expect("plan recovery");
+
+        assert_eq!(*source.seen_capabilities.borrow(), vec![capabilities]);
+        assert_eq!(recovery.recipient_frames, vec![vec![
+            crate::protocol::Frame::Output(super::REATTACH_CLEAR_SEQUENCE.to_vec()),
+            crate::protocol::Frame::Output(b"fresh snapshot with OVERFLOW_END".to_vec())
+        ]]);
     }
 
     #[cfg(not(feature = "ghostty-vt"))]

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1473,14 +1473,13 @@ fn handle_http_request(
 
             let capabilities = attach_capabilities_from_http(body.capabilities);
             let replay = hosted.actor.apply_attach_state(body.cols, body.rows, capabilities)?;
-            http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP attach upgrade response: {err}"))?;
             let attach_stream = stream.try_clone().map_err(|err| format!("clone HTTP attach stream: {err}"))?;
-            #[cfg(unix)]
-            set_stream_nonblocking(&attach_stream, true).map_err(|err| format!("set HTTP attach stream nonblocking: {err}"))?;
-            let mut client = ActiveClient::new(attach_stream)?;
-            client.capabilities = capabilities;
+            let mut client = ActiveClient::new(attach_stream, capabilities)?;
             let replay_mode = if hosted.had_foreground_client { ReplayMode::ResetTerminal } else { ReplayMode::FreshTerminal };
             drain_raw_output_tap_before_client_install(state.layout, &id, hosted, &mut client, replay, replay_mode)?;
+            http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP attach upgrade response: {err}"))?;
+            #[cfg(unix)]
+            set_stream_nonblocking(&client.stream, true).map_err(|err| format!("set HTTP attach stream nonblocking: {err}"))?;
             let _ = fs::write(state.layout.foreground_path(&id), b"1");
             hosted.active_client = Some(client);
             hosted.had_foreground_client = true;
@@ -1497,13 +1496,12 @@ fn handle_http_request(
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP watch request: {err}"))?;
             let capabilities = attach_capabilities_from_http(body.capabilities);
             let replay = hosted.actor.replay_payload(capabilities)?;
-            http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP watch upgrade response: {err}"))?;
             let watch_stream = stream.try_clone().map_err(|err| format!("clone HTTP watch stream: {err}"))?;
-            #[cfg(unix)]
-            set_stream_nonblocking(&watch_stream, true).map_err(|err| format!("set HTTP watch stream nonblocking: {err}"))?;
-            let mut watcher = ActiveClient::new(watch_stream)?;
-            watcher.capabilities = capabilities;
+            let mut watcher = ActiveClient::new(watch_stream, capabilities)?;
             drain_raw_output_tap_before_client_install(state.layout, &id, hosted, &mut watcher, replay, ReplayMode::FreshTerminal)?;
+            http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP watch upgrade response: {err}"))?;
+            #[cfg(unix)]
+            set_stream_nonblocking(&watcher.stream, true).map_err(|err| format!("set HTTP watch stream nonblocking: {err}"))?;
             hosted.watchers.push(watcher);
             broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
             Ok(())
@@ -2483,15 +2481,9 @@ struct ActiveClient {
 }
 
 impl ActiveClient {
-    fn new(stream: SessionStream) -> Result<Self, String> {
+    fn new(stream: SessionStream, capabilities: vt::ClientCapabilities) -> Result<Self, String> {
         let input_reader = ActiveClientReader::new(&stream)?;
-        Ok(Self {
-            stream,
-            pending_output: Vec::new(),
-            input_reader,
-            input_buffer: Vec::new(),
-            capabilities: vt::ClientCapabilities::conservative_fallback(),
-        })
+        Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new(), capabilities })
     }
 
     fn drain_input_frames(&mut self, pending: &mut VecDeque<Frame>, timeout: Duration) -> Result<bool, std::io::Error> {
@@ -2772,7 +2764,8 @@ mod tests {
     #[test]
     fn active_client_rejects_unbounded_output_backlog() {
         let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
-        let mut client = super::ActiveClient::new(stream).expect("create active client");
+        let mut client =
+            super::ActiveClient::new(stream, crate::vt::ClientCapabilities::conservative_fallback()).expect("create active client");
         client.pending_output = vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1];
 
         let err = client.enqueue_frame(&super::Frame::Output(vec![1])).expect_err("backlog should overflow");


### PR DESCRIPTION
## Summary

- sequence raw output chunks and watermark authoritative replay snapshots
- suppress tap chunks already represented by a new attach/watch snapshot while preserving them for existing clients
- recover atomically from tap overflow by installing a replacement tap and repainting every attached client from authoritative engine state
- reset existing terminals before overflow recovery replay and preserve each client's terminal capabilities
- cover snapshot deduplication and overflow recovery through injected collaborators

Fixes #132.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `./tools/prepare-ghostty-vt.sh`
- `cargo build -p cleat --locked --features ghostty-vt`
- `cargo test -p cleat --locked --features ghostty-vt`
