### PR TITLE
perf: gate screen-stable wait snapshots on render generation

### DIFF
--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -247,6 +247,10 @@ impl ObservationMirror {
             DirtyState::Clean
         }
     }
+
+    pub(crate) fn render_generation(&self) -> u64 {
+        self.render_generation.load(AtomicOrdering::SeqCst)
+    }
 }
 
 fn dirty_state_to_u8(dirty: DirtyState) -> u8 {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -522,6 +522,9 @@ struct HostedSession {
     had_foreground_client: bool,
     pending_waits: Vec<PendingWait>,
     pending_expects: Vec<PendingExpect>,
+    /// Render generation at the last screen-stable fingerprint snapshot; lets
+    /// the servicing loop skip full-grid snapshots while nothing has rendered.
+    screen_stable_snapshot_generation: Option<u64>,
     should_keep_session_dir: bool,
 }
 
@@ -543,6 +546,7 @@ impl HostedSession {
             had_foreground_client: false,
             pending_waits: Vec::new(),
             pending_expects: Vec::new(),
+            screen_stable_snapshot_generation: None,
             should_keep_session_dir: session.record,
         })
     }
@@ -1019,7 +1023,7 @@ fn service_hosted_session(
         broadcast_directory_upsert(directory_entry_for_session(layout, hosted, packet_clients)?, packet_clients)?;
     }
 
-    service_pending_waits(&hosted.actor, &mut hosted.pending_waits);
+    service_pending_waits(&hosted.actor, &mut hosted.pending_waits, &mut hosted.screen_stable_snapshot_generation);
     service_pending_expects(layout, id, &hosted.actor, &mut hosted.pending_expects)?;
     // Recording flush happens actor-side after each pump slice; no per-tick
     // round-trip here (ADR 0004: the servicing side is never blocked).
@@ -1027,10 +1031,30 @@ fn service_hosted_session(
     Ok(did_work)
 }
 
-fn service_pending_waits(actor: &SessionActor, pending_waits: &mut Vec<PendingWait>) {
+/// Whether a screen-stable wait needs a fresh full-grid fingerprint. An
+/// unchanged render generation means the actor has fed nothing to the engine
+/// since the last fingerprint, so the screen cannot have changed and the
+/// existing stability window simply keeps aging without a snapshot.
+fn screen_stable_needs_snapshot(current_generation: u64, last_snapshot_generation: Option<u64>) -> bool {
+    last_snapshot_generation != Some(current_generation)
+}
+
+fn service_pending_waits(actor: &SessionActor, pending_waits: &mut Vec<PendingWait>, last_snapshot_generation: &mut Option<u64>) {
     let screen_stable_fingerprint = if pending_waits.iter().any(|wait| wait.screen_stable.is_some()) {
-        actor.full_snapshot().ok().map(ScreenStableFingerprint::from_snapshot)
+        // Read the generation before snapshotting: a pump landing in between
+        // costs one redundant snapshot next tick instead of a missed change.
+        let generation = actor.observation().render_generation();
+        if screen_stable_needs_snapshot(generation, *last_snapshot_generation) {
+            let fingerprint = actor.full_snapshot().ok().map(ScreenStableFingerprint::from_snapshot);
+            if fingerprint.is_some() {
+                *last_snapshot_generation = Some(generation);
+            }
+            fingerprint
+        } else {
+            None
+        }
     } else {
+        *last_snapshot_generation = None;
         None
     };
     let now = Instant::now();
@@ -2707,6 +2731,17 @@ mod tests {
         let reset_at = original_stable_since + Duration::from_millis(200);
         state.observe(screen_stable_fingerprint_with_cells(80, SCREEN_STABLE_CHANGED_CELL_TOLERANCE + 1), reset_at);
         assert_eq!(state.stable_since, reset_at);
+    }
+
+    #[test]
+    fn screen_stable_snapshot_gating_tracks_render_generation() {
+        // No fingerprint taken yet: always snapshot.
+        assert!(super::screen_stable_needs_snapshot(0, None));
+        // Nothing rendered since the last fingerprint: the screen cannot have
+        // changed, skip the snapshot and let the stability window age.
+        assert!(!super::screen_stable_needs_snapshot(7, Some(7)));
+        // A pump advanced the generation: re-fingerprint.
+        assert!(super::screen_stable_needs_snapshot(8, Some(7)));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

While any `screen_stable` wait is registered, `service_pending_waits` called `actor.full_snapshot()` every ~10 ms servicing tick, then cloned all cells into a fingerprint and diffed cell-by-cell — even when the session was completely idle. On an idle screen this is pure waste; on a busy one it stacks a full-grid round-trip into the actor on every tick for the wait's lifetime.

## Fix

Track the render generation at the last fingerprint (`HostedSession::screen_stable_snapshot_generation`) and re-snapshot only when the actor's generation — read lock-free from the `ObservationMirror` — has advanced. An unchanged generation means nothing was fed to the engine, so the screen cannot have changed and the stability window keeps aging without a snapshot.

Safety argument, verified against the code:
- every screen-mutating path bumps the generation (pump output, resize, `ApplyAttachState`, viewport scroll on `Moved`),
- each wait is seeded with its own baseline fingerprint at registration, so a wait on a fully quiet screen still completes,
- the generation is read *before* snapshotting, so a concurrent pump costs one redundant snapshot next tick rather than a missed change.

This is the hot-path half of #136. The other half (per-cell grapheme `Vec` allocation in the grid build) needs a `ResolvedCell` type change (inline small-vec) or bulk-row FFI — noted on the issue as follow-up rather than forced into this PR.

## Tests

`screen_stable_snapshot_gating_tracks_render_generation` unit-tests the gating decision; existing screen-stable fingerprint/wait tests unchanged and passing. Full gates run: build, nightly fmt, clippy (default + ghostty-vt, -D warnings), workspace tests, ghostty-vt test suite.

Refs #136