### PR TITLE
fix: detect client terminal capabilities for attach/watch

### DIFF
--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -394,7 +394,7 @@ fn record_pty_output(engine: &mut dyn VtEngine, bytes: &[u8]) -> Result<(), Stri
 }
 
 fn attach_init_capabilities() -> vt::ClientCapabilities {
-    vt::ClientCapabilities::conservative_fallback()
+    vt::ClientCapabilities::detect()
 }
 
 fn attach_capabilities_to_http(capabilities: vt::ClientCapabilities) -> http_uds::AttachCapabilitiesRequest {
@@ -2798,7 +2798,11 @@ mod tests {
         assert!(request.starts_with("POST /sessions/alpha/attach HTTP/1.1\r\n"), "{request}");
         assert!(request.contains("Connection: Upgrade\r\n"), "{request}");
         assert!(request.contains("Upgrade: cleat-attach/1\r\n"), "{request}");
-        assert!(request.ends_with(r#""capabilities":{"color_level":"sixteen","kitty_keyboard":false}}"#), "{request}");
+        // Capabilities are detected from the ambient environment, so compare
+        // against the serialization of whatever detection currently reports.
+        let expected_capabilities =
+            serde_json::to_string(&super::attach_capabilities_to_http(attach_init_capabilities())).expect("serialize capabilities");
+        assert!(request.ends_with(&format!(r#""capabilities":{expected_capabilities}}}"#)), "{request}");
     }
 
     #[test]
@@ -2950,8 +2954,11 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_attach_init_capabilities_use_conservative_terminal_assumptions() {
-        assert_eq!(attach_init_capabilities(), vt::ClientCapabilities::conservative_fallback());
+    fn lifecycle_attach_init_capabilities_detect_from_environment() {
+        // Detection reads the ambient environment, so assert the wiring rather
+        // than a specific level; the pure detection logic is unit-tested in
+        // `vt::tests`.
+        assert_eq!(attach_init_capabilities(), vt::ClientCapabilities::detect());
     }
 
     fn screen_stable_fingerprint_with_cells(cell_count: usize, changed_prefix: usize) -> ScreenStableFingerprint {

--- a/crates/cleat/src/vt/mod.rs
+++ b/crates/cleat/src/vt/mod.rs
@@ -33,6 +33,55 @@ impl ClientCapabilities {
     pub fn conservative_fallback() -> Self {
         Self::new(ColorLevel::Sixteen, false)
     }
+
+    /// Detect client capabilities from the real process environment.
+    ///
+    /// Environment-based detection is deliberate: the attach handshake happens
+    /// before raw mode, so query-based probing would add latency and failure
+    /// modes for little gain.
+    pub fn detect() -> Self {
+        Self::detect_from_env(
+            std::env::var("TERM").ok().as_deref(),
+            std::env::var("COLORTERM").ok().as_deref(),
+            std::env::var("TERM_PROGRAM").ok().as_deref(),
+            std::env::var_os("ZELLIJ").is_some(),
+        )
+    }
+
+    /// Pure capability detection from environment values.
+    ///
+    /// Color level: `COLORTERM` containing `truecolor`/`24bit` wins, then
+    /// `TERM` containing `256color`, then a small allowlist of terminals known
+    /// to support truecolor via `TERM_PROGRAM`; otherwise the conservative
+    /// sixteen-color fallback.
+    ///
+    /// Kitty keyboard: conservative allowlist (kitty, Ghostty, WezTerm), and
+    /// forced off under multiplexers (`TERM` starting with `screen`/`tmux`, or
+    /// `ZELLIJ` set) which historically mangle the kitty protocol. Multiplexers
+    /// pass SGR through fine, so color detection stands.
+    pub fn detect_from_env(term: Option<&str>, colorterm: Option<&str>, term_program: Option<&str>, zellij: bool) -> Self {
+        let term = term.map(str::to_ascii_lowercase).unwrap_or_default();
+        let colorterm = colorterm.map(str::to_ascii_lowercase).unwrap_or_default();
+        let term_program = term_program.map(str::to_ascii_lowercase).unwrap_or_default();
+
+        let truecolor_program = matches!(term_program.as_str(), "iterm.app" | "ghostty" | "wezterm" | "vscode");
+        let color_level = if colorterm.contains("truecolor") || colorterm.contains("24bit") {
+            ColorLevel::TrueColor
+        } else if term.contains("256color") {
+            ColorLevel::Ansi256
+        } else if truecolor_program {
+            ColorLevel::TrueColor
+        } else {
+            ColorLevel::Sixteen
+        };
+
+        let multiplexed = term.starts_with("screen") || term.starts_with("tmux") || zellij;
+        let kitty_program = matches!(term_program.as_str(), "ghostty" | "wezterm");
+        let kitty_term = matches!(term.as_str(), "xterm-kitty" | "xterm-ghostty");
+        let kitty_keyboard = !multiplexed && (kitty_term || kitty_program);
+
+        Self::new(color_level, kitty_keyboard)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
@@ -375,7 +424,60 @@ fn select_default_vt_engine_kind() -> VtEngineKind {
 
 #[cfg(test)]
 mod tests {
-    use super::{TerminalColors, VtEngineKind};
+    use super::{ClientCapabilities, ColorLevel, TerminalColors, VtEngineKind};
+
+    #[test]
+    fn detect_truecolor_via_colorterm() {
+        let caps = ClientCapabilities::detect_from_env(Some("xterm-256color"), Some("truecolor"), None, false);
+        assert_eq!(caps.color_level, ColorLevel::TrueColor);
+        assert!(!caps.kitty_keyboard);
+
+        let caps = ClientCapabilities::detect_from_env(Some("xterm"), Some("24bit"), None, false);
+        assert_eq!(caps.color_level, ColorLevel::TrueColor);
+    }
+
+    #[test]
+    fn detect_ansi256_via_term() {
+        let caps = ClientCapabilities::detect_from_env(Some("xterm-256color"), None, None, false);
+        assert_eq!(caps.color_level, ColorLevel::Ansi256);
+        assert!(!caps.kitty_keyboard);
+    }
+
+    #[test]
+    fn detect_truecolor_via_term_program_allowlist() {
+        for program in ["iTerm.app", "ghostty", "WezTerm", "vscode"] {
+            let caps = ClientCapabilities::detect_from_env(Some("xterm"), None, Some(program), false);
+            assert_eq!(caps.color_level, ColorLevel::TrueColor, "TERM_PROGRAM={program}");
+        }
+    }
+
+    #[test]
+    fn detect_falls_back_to_sixteen_colors() {
+        let caps = ClientCapabilities::detect_from_env(Some("vt100"), None, None, false);
+        assert_eq!(caps, ClientCapabilities::conservative_fallback());
+
+        let caps = ClientCapabilities::detect_from_env(None, None, None, false);
+        assert_eq!(caps, ClientCapabilities::conservative_fallback());
+    }
+
+    #[test]
+    fn detect_kitty_keyboard_allowlist() {
+        assert!(ClientCapabilities::detect_from_env(Some("xterm-kitty"), None, None, false).kitty_keyboard);
+        assert!(ClientCapabilities::detect_from_env(Some("xterm-ghostty"), None, None, false).kitty_keyboard);
+        assert!(ClientCapabilities::detect_from_env(Some("xterm-256color"), None, Some("ghostty"), false).kitty_keyboard);
+        assert!(ClientCapabilities::detect_from_env(Some("xterm-256color"), None, Some("WezTerm"), false).kitty_keyboard);
+        assert!(!ClientCapabilities::detect_from_env(Some("xterm-256color"), Some("truecolor"), Some("iTerm.app"), false).kitty_keyboard);
+    }
+
+    #[test]
+    fn detect_kitty_keyboard_forced_off_under_multiplexers() {
+        let caps = ClientCapabilities::detect_from_env(Some("tmux-256color"), Some("truecolor"), Some("ghostty"), false);
+        assert!(!caps.kitty_keyboard);
+        assert_eq!(caps.color_level, ColorLevel::TrueColor, "multiplexers pass SGR through, color detection stands");
+
+        assert!(!ClientCapabilities::detect_from_env(Some("screen-256color"), None, Some("WezTerm"), false).kitty_keyboard);
+        assert!(!ClientCapabilities::detect_from_env(Some("xterm-kitty"), None, None, true).kitty_keyboard, "ZELLIJ set");
+    }
 
     #[cfg(feature = "ghostty-vt")]
     #[test]


### PR DESCRIPTION
Fixes #138

## Problem

`attach_init_capabilities()` in `crates/cleat/src/session.rs` returned `ClientCapabilities::conservative_fallback()` (16-color, no kitty keyboard) unconditionally. The protocol already carries capabilities end-to-end (`AttachCapabilitiesRequest` -> `apply_attach_state` -> the Ghostty replay formatter gates palette emission on `Ansi256 | TrueColor`), but the client never detected anything, so every attach from a truecolor terminal repainted degraded and kitty keyboard state was never restored.

## Change

New pure function `ClientCapabilities::detect_from_env(term, colorterm, term_program, zellij)` in `crates/cleat/src/vt/mod.rs`, plus a thin `detect()` wrapper that reads the real environment, wired into `attach_init_capabilities()` (used by both attach and watch).

Detection rules (environment-based only — the attach handshake happens before raw mode, so a query-probe round-trip would add latency and failure modes):

- **Color level**: `COLORTERM` containing `truecolor`/`24bit` -> TrueColor; else `TERM` containing `256color` -> Ansi256; else `TERM_PROGRAM` in a known-truecolor allowlist (iTerm.app, ghostty, WezTerm, vscode) -> TrueColor; else Sixteen. Case-insensitive.
- **Kitty keyboard**: conservative allowlist — `TERM=xterm-kitty`/`xterm-ghostty`, `TERM_PROGRAM=ghostty`/`wezterm`. Forced off when `TERM` starts with `screen`/`tmux` or `ZELLIJ` is set (multiplexers historically mangle the kitty protocol). Color detection stands under multiplexers since SGR passes through.

Also updated two tests that asserted the hardcoded conservative fallback to assert the detection wiring instead.

## Tests

- Unit tests in `vt::tests`: truecolor via COLORTERM, 256color via TERM, TERM_PROGRAM allowlist, Sixteen fallback, kitty allowlist hits, kitty forced off under tmux/screen/zellij (with color preserved).
- `cargo build --locked`, `cargo +nightly-2026-03-12 fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked`: all pass.
- `cargo test -p cleat --locked --features ghostty-vt` (with `CLEAT_GHOSTTY_PREFIX` pointing at the ghostty install): all pass.