### PR TITLE
perf: single-copy output fan-out and O(1) backlog consumption

### DIFF
--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -68,7 +68,10 @@ impl RawOutputTap {
 #[derive(Clone, Debug)]
 pub(crate) struct RawOutputChunk {
     pub(crate) sequence: u64,
-    pub(crate) bytes: Vec<u8>,
+    /// Shared with every other tap and the actor's pump result: cloning a
+    /// chunk to cross the actor→servicing channel is a refcount bump, not a
+    /// payload copy (issue #135).
+    pub(crate) bytes: Arc<[u8]>,
 }
 
 pub(crate) struct RawOutputReplay {
@@ -854,7 +857,7 @@ enum PumpOutcome {
 
 struct PumpResult {
     outcome: PumpOutcome,
-    chunks: Vec<Vec<u8>>,
+    chunks: Vec<Arc<[u8]>>,
 }
 
 struct SessionActorLoopState {
@@ -1249,10 +1252,10 @@ fn session_actor_pump(runtime: &mut SessionRuntime, state: &mut SessionActorLoop
     sync_terminal_modes_and_wake(runtime, &mut state.observation, wake);
 }
 
-fn publish_raw_output(taps: &mut Vec<SyncSender<RawOutputChunk>>, last_sequence: &mut u64, chunks: &[Vec<u8>]) {
+fn publish_raw_output(taps: &mut Vec<SyncSender<RawOutputChunk>>, last_sequence: &mut u64, chunks: &[Arc<[u8]>]) {
     for bytes in chunks {
         *last_sequence = last_sequence.saturating_add(1);
-        let chunk = RawOutputChunk { sequence: *last_sequence, bytes: bytes.clone() };
+        let chunk = RawOutputChunk { sequence: *last_sequence, bytes: Arc::clone(bytes) };
         taps.retain(|tap| tap.try_send(chunk.clone()).is_ok());
     }
 }

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -167,6 +167,12 @@ impl PacketFrame {
         postcard::from_bytes(&self.payload).map_err(|err| Error::new(ErrorKind::InvalidData, err))
     }
 
+    /// Wire size of this frame (header plus payload), computed without
+    /// encoding anything.
+    pub fn encoded_len(&self) -> usize {
+        HEADER_LEN + self.payload.len()
+    }
+
     pub fn write(&self, writer: &mut impl Write) -> std::io::Result<()> {
         let len =
             u32::try_from(self.payload.len()).map_err(|_| Error::new(ErrorKind::InvalidInput, "packet payload exceeds u32 length"))?;

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -118,12 +118,12 @@ pub enum Frame {
 
 impl Frame {
     pub fn read(reader: &mut impl Read) -> std::io::Result<Self> {
-        let mut header = [0u8; 5];
+        let mut header = [0u8; WIRE_HEADER_LEN];
         reader.read_exact(&mut header)?;
         Self::read_after_header(header, reader)
     }
 
-    pub(crate) fn read_after_header(header: [u8; 5], reader: &mut impl Read) -> std::io::Result<Self> {
+    pub(crate) fn read_after_header(header: [u8; WIRE_HEADER_LEN], reader: &mut impl Read) -> std::io::Result<Self> {
         let tag = header[0];
         let len = u32::from_le_bytes([header[1], header[2], header[3], header[4]]) as usize;
         let mut payload = vec![0u8; len];
@@ -132,16 +132,16 @@ impl Frame {
     }
 
     pub(crate) fn read_from_buffer(buffer: &mut Vec<u8>) -> std::io::Result<Option<Self>> {
-        if buffer.len() < 5 {
+        if buffer.len() < WIRE_HEADER_LEN {
             return Ok(None);
         }
         let tag = buffer[0];
         let len = u32::from_le_bytes([buffer[1], buffer[2], buffer[3], buffer[4]]) as usize;
-        let frame_len = 5usize.checked_add(len).ok_or_else(|| Error::new(ErrorKind::InvalidData, "frame length overflow"))?;
+        let frame_len = WIRE_HEADER_LEN.checked_add(len).ok_or_else(|| Error::new(ErrorKind::InvalidData, "frame length overflow"))?;
         if buffer.len() < frame_len {
             return Ok(None);
         }
-        let payload = buffer[5..frame_len].to_vec();
+        let payload = buffer[WIRE_HEADER_LEN..frame_len].to_vec();
         buffer.drain(..frame_len);
         Self::decode(tag, payload).map(Some)
     }

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -87,6 +87,8 @@ pub enum SignalTarget {
     Tree = 2,
 }
 
+pub(crate) const WIRE_HEADER_LEN: usize = 5;
+
 const TAG_INPUT: u8 = 2;
 const TAG_OUTPUT: u8 = 3;
 const TAG_RESIZE: u8 = 4;
@@ -145,26 +147,40 @@ impl Frame {
     }
 
     pub fn write(&self, writer: &mut impl Write) -> std::io::Result<()> {
-        let (tag, payload) = self.encode();
-        let mut header = [0u8; 5];
-        header[0] = tag;
-        header[1..].copy_from_slice(&(payload.len() as u32).to_le_bytes());
-        writer.write_all(&header)?;
-        writer.write_all(&payload)
-    }
-
-    fn encode(&self) -> (u8, Vec<u8>) {
         match self {
             Frame::Resize { cols, rows } => {
-                let mut payload = Vec::with_capacity(4);
-                payload.extend_from_slice(&cols.to_le_bytes());
-                payload.extend_from_slice(&rows.to_le_bytes());
-                (TAG_RESIZE, payload)
+                let mut payload = [0u8; 4];
+                payload[..2].copy_from_slice(&cols.to_le_bytes());
+                payload[2..].copy_from_slice(&rows.to_le_bytes());
+                write_tagged(writer, TAG_RESIZE, &payload)
             }
-            Frame::Input(bytes) => (TAG_INPUT, bytes.clone()),
-            Frame::Output(bytes) => (TAG_OUTPUT, bytes.clone()),
-            Frame::Error(message) => (TAG_ERROR, message.clone().into_bytes()),
+            Frame::Input(bytes) => write_tagged(writer, TAG_INPUT, bytes),
+            Frame::Output(bytes) => write_tagged(writer, TAG_OUTPUT, bytes),
+            Frame::Error(message) => write_tagged(writer, TAG_ERROR, message.as_bytes()),
         }
+    }
+
+    /// Wire size of this frame (header plus payload), computed without
+    /// encoding anything.
+    pub(crate) fn encoded_len(&self) -> usize {
+        let payload_len = match self {
+            Frame::Resize { .. } => 4,
+            Frame::Input(bytes) | Frame::Output(bytes) => bytes.len(),
+            Frame::Error(message) => message.len(),
+        };
+        WIRE_HEADER_LEN + payload_len
+    }
+
+    /// Wire size of an `Output` frame carrying `payload_len` bytes.
+    pub(crate) fn output_encoded_len(payload_len: usize) -> usize {
+        WIRE_HEADER_LEN + payload_len
+    }
+
+    /// Frames `payload` as an `Output` frame without constructing a `Frame`,
+    /// so the fan-out hot path never copies the chunk into an owned payload
+    /// first. Byte-identical to `Frame::Output(payload.to_vec()).write(..)`.
+    pub(crate) fn write_output(writer: &mut impl Write, payload: &[u8]) -> std::io::Result<()> {
+        write_tagged(writer, TAG_OUTPUT, payload)
     }
 
     fn decode(tag: u8, payload: Vec<u8>) -> std::io::Result<Self> {
@@ -178,6 +194,14 @@ impl Frame {
             _ => Err(Error::new(ErrorKind::InvalidData, format!("unknown frame tag {tag}"))),
         }
     }
+}
+
+fn write_tagged(writer: &mut impl Write, tag: u8, payload: &[u8]) -> std::io::Result<()> {
+    let mut header = [0u8; WIRE_HEADER_LEN];
+    header[0] = tag;
+    header[1..].copy_from_slice(&(payload.len() as u32).to_le_bytes());
+    writer.write_all(&header)?;
+    writer.write_all(payload)
 }
 
 fn decode_size_frame(payload: Vec<u8>) -> std::io::Result<(u16, u16)> {
@@ -227,6 +251,36 @@ mod tests {
         frame.write(&mut bytes).expect("write frame");
         let decoded = Frame::read(&mut bytes.as_slice()).expect("read frame");
         assert_eq!(decoded, frame);
+    }
+
+    /// Pins the wire format byte-for-byte: tag, u32 LE payload length,
+    /// payload. Guards the allocation-free `write` restructuring (issue
+    /// #135) against any framing drift.
+    #[test]
+    fn wire_format_is_tag_then_le_length_then_payload() {
+        let cases: Vec<(Frame, Vec<u8>)> = vec![
+            (Frame::Input(vec![0xDE, 0xAD]), vec![2, 2, 0, 0, 0, 0xDE, 0xAD]),
+            (Frame::Output(vec![1, 2, 3]), vec![3, 3, 0, 0, 0, 1, 2, 3]),
+            (Frame::Resize { cols: 0x0102, rows: 0x0304 }, vec![4, 4, 0, 0, 0, 0x02, 0x01, 0x04, 0x03]),
+            (Frame::Error("no".to_string()), vec![9, 2, 0, 0, 0, b'n', b'o']),
+        ];
+        for (frame, expected) in cases {
+            let mut bytes = Vec::new();
+            frame.write(&mut bytes).expect("write frame");
+            assert_eq!(bytes, expected, "wire bytes for {frame:?}");
+            assert_eq!(frame.encoded_len(), expected.len(), "encoded_len for {frame:?}");
+        }
+    }
+
+    #[test]
+    fn write_output_matches_output_frame_encoding() {
+        let payload = [0u8, 1, 2, 250, 255];
+        let mut direct = Vec::new();
+        Frame::write_output(&mut direct, &payload).expect("write output payload");
+        let mut via_frame = Vec::new();
+        Frame::Output(payload.to_vec()).write(&mut via_frame).expect("write output frame");
+        assert_eq!(direct, via_frame);
+        assert_eq!(Frame::output_encoded_len(payload.len()), direct.len());
     }
 
     #[test]

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -565,18 +565,17 @@ fn enqueue_output_chunk(
     actor: &SessionActor,
     active_client: &mut Option<ActiveClient>,
     watchers: &mut Vec<ActiveClient>,
-    chunk: Vec<u8>,
+    chunk: &[u8],
 ) {
-    let frame = Frame::Output(chunk);
     if let Some(client) = active_client.as_mut() {
-        if client.enqueue_frame(&frame).is_err() {
+        if client.enqueue_output(chunk).is_err() {
             let _ = fs::remove_file(layout.foreground_path(id));
             let _ = actor.record_detach();
             let _ = actor.set_client_presence(false);
             *active_client = None;
         }
     }
-    watchers.retain_mut(|watcher| watcher.enqueue_frame(&frame).is_ok());
+    watchers.retain_mut(|watcher| watcher.enqueue_output(chunk).is_ok());
 }
 
 fn drain_raw_output_tap(
@@ -592,7 +591,7 @@ fn drain_raw_output_tap(
         match raw_output_tap.try_recv() {
             Ok(chunk) => {
                 drained = true;
-                enqueue_output_chunk(layout, id, actor, active_client, watchers, chunk.bytes);
+                enqueue_output_chunk(layout, id, actor, active_client, watchers, &chunk.bytes);
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => return Ok(drained),
             Err(std::sync::mpsc::TryRecvError::Disconnected) => {
@@ -618,7 +617,7 @@ fn drain_raw_output_tap_before_client_install(
         }
     };
     for chunk in existing_chunks {
-        enqueue_output_chunk(layout, id, &hosted.actor, &mut hosted.active_client, &mut hosted.watchers, chunk.clone());
+        enqueue_output_chunk(layout, id, &hosted.actor, &mut hosted.active_client, &mut hosted.watchers, chunk);
     }
     match plan {
         RawOutputClientInstallPlan::Complete { new_client_frames, .. } => {
@@ -640,8 +639,8 @@ fn drain_raw_output_tap_before_client_install(
 }
 
 enum RawOutputClientInstallPlan {
-    Complete { existing_chunks: Vec<Vec<u8>>, new_client_frames: Vec<Frame> },
-    Disconnected { existing_chunks: Vec<Vec<u8>> },
+    Complete { existing_chunks: Vec<Arc<[u8]>>, new_client_frames: Vec<Frame> },
+    Disconnected { existing_chunks: Vec<Arc<[u8]>> },
 }
 
 fn plan_raw_output_client_install(
@@ -655,13 +654,15 @@ fn plan_raw_output_client_install(
         match raw_output_tap.try_recv() {
             Ok(chunk) => {
                 if chunk.sequence > replay.through_sequence {
-                    live_after_replay.push(chunk.bytes.clone());
+                    live_after_replay.push(Arc::clone(&chunk.bytes));
                 }
                 existing_chunks.push(chunk.bytes);
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
                 let mut new_client_frames = replay_frames(replay.payload, replay_mode);
-                new_client_frames.extend(live_after_replay.into_iter().map(Frame::Output));
+                // Install-time only (never the per-byte path), so copying the
+                // few live chunks into owned `Frame` payloads is fine.
+                new_client_frames.extend(live_after_replay.into_iter().map(|bytes| Frame::Output(bytes.to_vec())));
                 return RawOutputClientInstallPlan::Complete { existing_chunks, new_client_frames };
             }
             Err(std::sync::mpsc::TryRecvError::Disconnected) => {
@@ -1975,7 +1976,7 @@ fn http_input_key_bytes(key: http_uds::KeyRequest) -> Vec<u8> {
 struct PacketClient {
     id: u64,
     stream: SessionStream,
-    pending_output: Vec<u8>,
+    pending_output: PendingOutput,
     input_reader: ActiveClientReader,
     input_buffer: Vec<u8>,
     channels: HashMap<u32, PacketSessionChannel>,
@@ -2019,7 +2020,7 @@ impl PacketClient {
         Ok(Self {
             id,
             stream,
-            pending_output: Vec::new(),
+            pending_output: PendingOutput::new(),
             input_reader,
             input_buffer: Vec::new(),
             channels: HashMap::new(),
@@ -2042,15 +2043,12 @@ impl PacketClient {
         if self.dead {
             return Ok(());
         }
-        let mut encoded = Vec::new();
-        frame.write(&mut encoded).map_err(|err| format!("buffer packet frame: {err}"))?;
-        if self.pending_output.len().saturating_add(encoded.len()) > MAX_PENDING_CLIENT_OUTPUT_BYTES {
+        if self.pending_output.len().saturating_add(frame.encoded_len()) > MAX_PENDING_CLIENT_OUTPUT_BYTES {
             self.dead = true;
-            self.pending_output = Vec::new();
+            self.pending_output = PendingOutput::new();
             return Ok(());
         }
-        self.pending_output.extend_from_slice(&encoded);
-        Ok(())
+        frame.write(&mut self.pending_output).map_err(|err| format!("buffer packet frame: {err}"))
     }
 
     fn drain_input_frames(&mut self, pending: &mut VecDeque<PacketFrame>, timeout: Duration) -> Result<bool, std::io::Error> {
@@ -2077,10 +2075,10 @@ impl PacketClient {
 
     fn flush_pending_output(&mut self) -> Result<bool, String> {
         while !self.pending_output.is_empty() {
-            match self.stream.write(&self.pending_output) {
+            match self.stream.write(self.pending_output.as_slice()) {
                 Ok(0) => return Ok(false),
                 Ok(n) => {
-                    self.pending_output.drain(..n);
+                    self.pending_output.consume(n);
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
                 Err(err) if is_graceful_socket_shutdown(&err) => return Ok(false),
@@ -2599,9 +2597,78 @@ fn flush_packet_clients(packet_clients: &mut [PacketClient]) {
     }
 }
 
+/// Bytes queued for a client socket, consumed from the front on partial
+/// writes. A start cursor makes consumption O(1) instead of `Vec::drain`'s
+/// per-write memmove of the whole backlog (issue #135). The consumed prefix
+/// is compacted away once it outgrows the live remainder, so total memmove
+/// work is bounded by total bytes queued (amortized O(1) per byte).
+struct PendingOutput {
+    buf: Vec<u8>,
+    start: usize,
+}
+
+impl PendingOutput {
+    fn new() -> Self {
+        Self { buf: Vec::new(), start: 0 }
+    }
+
+    /// Bytes not yet written to the socket — the quantity capped by
+    /// `MAX_PENDING_CLIENT_OUTPUT_BYTES`, exactly what `Vec::len` measured
+    /// before the cursor existed.
+    fn len(&self) -> usize {
+        self.buf.len() - self.start
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.buf[self.start..]
+    }
+
+    fn consume(&mut self, n: usize) {
+        self.start += n;
+        debug_assert!(self.start <= self.buf.len());
+        if self.start >= self.buf.len() {
+            self.buf.clear();
+            self.start = 0;
+        } else if self.start > self.len() {
+            // The dead prefix outgrew the live remainder: one memmove that
+            // touches fewer bytes than were consumed since the last
+            // compaction keeps append targets (and memory) bounded.
+            self.buf.copy_within(self.start.., 0);
+            let remaining = self.buf.len() - self.start;
+            self.buf.truncate(remaining);
+            self.start = 0;
+        }
+    }
+}
+
+/// Frames append their wire encoding straight into the backlog through
+/// `io::Write`, so enqueueing copies each payload exactly once — no
+/// intermediate encode buffer.
+impl Write for PendingOutput {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl From<Vec<u8>> for PendingOutput {
+    fn from(buf: Vec<u8>) -> Self {
+        Self { buf, start: 0 }
+    }
+}
+
 struct ActiveClient {
     stream: SessionStream,
-    pending_output: Vec<u8>,
+    pending_output: PendingOutput,
     input_reader: ActiveClientReader,
     input_buffer: Vec<u8>,
     capabilities: vt::ClientCapabilities,
@@ -2610,7 +2677,7 @@ struct ActiveClient {
 impl ActiveClient {
     fn new(stream: SessionStream, capabilities: vt::ClientCapabilities) -> Result<Self, String> {
         let input_reader = ActiveClientReader::new(&stream)?;
-        Ok(Self { stream, pending_output: Vec::new(), input_reader, input_buffer: Vec::new(), capabilities })
+        Ok(Self { stream, pending_output: PendingOutput::new(), input_reader, input_buffer: Vec::new(), capabilities })
     }
 
     fn drain_input_frames(&mut self, pending: &mut VecDeque<Frame>, timeout: Duration) -> Result<bool, std::io::Error> {
@@ -2636,21 +2703,28 @@ impl ActiveClient {
     }
 
     fn enqueue_frame(&mut self, frame: &Frame) -> Result<(), String> {
-        let mut encoded = Vec::new();
-        frame.write(&mut encoded).map_err(|err| format!("buffer client frame: {err}"))?;
-        if self.pending_output.len().saturating_add(encoded.len()) > MAX_PENDING_CLIENT_OUTPUT_BYTES {
+        if self.pending_output.len().saturating_add(frame.encoded_len()) > MAX_PENDING_CLIENT_OUTPUT_BYTES {
             return Err(format!("client output backlog exceeded {} bytes", MAX_PENDING_CLIENT_OUTPUT_BYTES));
         }
-        self.pending_output.extend_from_slice(&encoded);
-        Ok(())
+        frame.write(&mut self.pending_output).map_err(|err| format!("buffer client frame: {err}"))
+    }
+
+    /// Frames a raw PTY output chunk straight into the backlog — header plus
+    /// one payload copy, with no intermediate `Frame` allocation. This is the
+    /// per-byte fan-out hot path (issue #135).
+    fn enqueue_output(&mut self, payload: &[u8]) -> Result<(), String> {
+        if self.pending_output.len().saturating_add(Frame::output_encoded_len(payload.len())) > MAX_PENDING_CLIENT_OUTPUT_BYTES {
+            return Err(format!("client output backlog exceeded {} bytes", MAX_PENDING_CLIENT_OUTPUT_BYTES));
+        }
+        Frame::write_output(&mut self.pending_output, payload).map_err(|err| format!("buffer client frame: {err}"))
     }
 
     fn flush_pending_output(&mut self) -> Result<bool, String> {
         while !self.pending_output.is_empty() {
-            match self.stream.write(&self.pending_output) {
+            match self.stream.write(self.pending_output.as_slice()) {
                 Ok(0) => return Ok(false),
                 Ok(n) => {
-                    self.pending_output.drain(..n);
+                    self.pending_output.consume(n);
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
                 Err(err) if is_graceful_socket_shutdown(&err) => return Ok(false),
@@ -2753,6 +2827,7 @@ fn http_error_message(response: http_uds::HttpResponse) -> String {
 mod tests {
     use std::{
         cell::RefCell,
+        io::Write,
         sync::{Arc, Mutex},
         time::{Duration, Instant},
     };
@@ -2851,7 +2926,7 @@ mod tests {
         let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
         let mut client = super::PacketClient::new(1, stream, Vec::new(), &crate::packet::DirectorySnapshot { sessions: Vec::new() })
             .expect("create packet client");
-        client.pending_output = vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1];
+        client.pending_output = super::PendingOutput::from(vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1]);
 
         let frame = crate::packet::PacketFrame { channel: 1, msg_type: 0, payload: vec![0; 64] };
         client.enqueue_frame(&frame).expect("overflow must not surface as a daemon-level error");
@@ -2887,16 +2962,60 @@ mod tests {
         assert_eq!(ok, Some(7));
     }
 
+    #[test]
+    fn pending_output_partial_consumes_preserve_byte_order_without_upfront_memmove() {
+        let mut pending = super::PendingOutput::new();
+        pending.write_all(b"abcdefgh").expect("queue bytes");
+
+        pending.consume(3);
+        assert_eq!(pending.as_slice(), b"defgh");
+        assert_eq!(pending.len(), 5);
+        // Consumed less than remains: the cursor advances, nothing moves yet.
+        assert_eq!(pending.start, 3);
+
+        pending.write_all(b"ij").expect("queue more bytes");
+        assert_eq!(pending.as_slice(), b"defghij");
+
+        // Dead prefix (7) now exceeds the remainder (3): compaction fires.
+        pending.consume(4);
+        assert_eq!(pending.as_slice(), b"hij");
+        assert_eq!(pending.start, 0);
+
+        pending.consume(3);
+        assert!(pending.is_empty());
+        assert_eq!(pending.start, 0);
+    }
+
+    /// The zero-copy output path must produce byte-identical backlogs to the
+    /// generic `Frame` path it replaces (issue #135).
+    #[cfg(unix)]
+    #[test]
+    fn enqueue_output_frames_bytes_identically_to_enqueue_frame() {
+        let (stream_a, _peer_a) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
+        let (stream_b, _peer_b) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
+        let capabilities = crate::vt::ClientCapabilities::conservative_fallback();
+        let mut via_output = super::ActiveClient::new(stream_a, capabilities).expect("create active client");
+        let mut via_frame = super::ActiveClient::new(stream_b, capabilities).expect("create active client");
+
+        let payload = b"\x1b[1mchunk\x00\xff";
+        via_output.enqueue_output(payload).expect("enqueue output payload");
+        via_frame.enqueue_frame(&super::Frame::Output(payload.to_vec())).expect("enqueue output frame");
+
+        assert_eq!(via_output.pending_output.as_slice(), via_frame.pending_output.as_slice());
+    }
+
     #[cfg(unix)]
     #[test]
     fn active_client_rejects_unbounded_output_backlog() {
         let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
         let mut client =
             super::ActiveClient::new(stream, crate::vt::ClientCapabilities::conservative_fallback()).expect("create active client");
-        client.pending_output = vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1];
+        client.pending_output = super::PendingOutput::from(vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1]);
 
         let err = client.enqueue_frame(&super::Frame::Output(vec![1])).expect_err("backlog should overflow");
+        assert!(err.contains("client output backlog exceeded"));
 
+        let err = client.enqueue_output(&[1]).expect_err("zero-copy path enforces the same backlog cap");
         assert!(err.contains("client output backlog exceeded"));
     }
 
@@ -3034,8 +3153,12 @@ mod tests {
     #[test]
     fn client_install_plan_sends_snapshot_covered_chunks_only_to_existing_clients() {
         let (tap_tx, tap) = crate::host::actor::RawOutputTap::test_channel(2);
-        tap_tx.send(crate::host::actor::RawOutputChunk { sequence: 1, bytes: b"line2\n".to_vec() }).expect("queue snapshot-covered output");
-        tap_tx.send(crate::host::actor::RawOutputChunk { sequence: 2, bytes: b"line3\n".to_vec() }).expect("queue post-snapshot output");
+        tap_tx
+            .send(crate::host::actor::RawOutputChunk { sequence: 1, bytes: b"line2\n".to_vec().into() })
+            .expect("queue snapshot-covered output");
+        tap_tx
+            .send(crate::host::actor::RawOutputChunk { sequence: 2, bytes: b"line3\n".to_vec().into() })
+            .expect("queue post-snapshot output");
 
         let plan = super::plan_raw_output_client_install(
             &tap,
@@ -3046,7 +3169,7 @@ mod tests {
         let super::RawOutputClientInstallPlan::Complete { existing_chunks, new_client_frames } = plan else {
             panic!("connected tap should produce a complete install plan");
         };
-        assert_eq!(existing_chunks, vec![b"line2\n".to_vec(), b"line3\n".to_vec()]);
+        assert_eq!(existing_chunks, vec![Arc::from(&b"line2\n"[..]), Arc::from(&b"line3\n"[..])]);
         assert_eq!(new_client_frames, vec![
             crate::protocol::Frame::Output(b"line2\n".to_vec()),
             crate::protocol::Frame::Output(b"line3\n".to_vec())
@@ -3069,7 +3192,9 @@ mod tests {
     #[test]
     fn disconnected_tap_recovers_with_terminal_reset_and_fresh_replay() {
         let (tap_tx, tap) = crate::host::actor::RawOutputTap::test_channel(1);
-        tap_tx.send(crate::host::actor::RawOutputChunk { sequence: 1, bytes: b"queued\n".to_vec() }).expect("queue output before overflow");
+        tap_tx
+            .send(crate::host::actor::RawOutputChunk { sequence: 1, bytes: b"queued\n".to_vec().into() })
+            .expect("queue output before overflow");
         drop(tap_tx);
         let install = super::plan_raw_output_client_install(
             &tap,
@@ -3079,7 +3204,7 @@ mod tests {
         let super::RawOutputClientInstallPlan::Disconnected { existing_chunks } = install else {
             panic!("dropped tap sender should require recovery");
         };
-        assert_eq!(existing_chunks, vec![b"queued\n".to_vec()]);
+        assert_eq!(existing_chunks, vec![Arc::from(&b"queued\n"[..])]);
 
         let capabilities = vt::ClientCapabilities::new(vt::ColorLevel::Ansi256, true);
         let source = FakeRawOutputRecoverySource {

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::HashMap,
     path::PathBuf,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -49,7 +50,9 @@ pub(crate) struct SessionRuntime {
 }
 
 pub(crate) struct PtyOutput {
-    pub chunks: Vec<Vec<u8>>,
+    /// Shared so publishing a chunk to each raw-output tap is a refcount
+    /// bump, not a payload copy (issue #135).
+    pub chunks: Vec<Arc<[u8]>>,
 }
 
 impl SessionRuntime {
@@ -433,7 +436,7 @@ impl SessionRuntime {
                     if !has_active_client {
                         self.write_detached_replies(bytes, &engine_reply)?;
                     }
-                    chunks.push(bytes.to_vec());
+                    chunks.push(Arc::from(bytes));
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::WouldBlock || (after_exit && is_pty_eof_after_exit(&err)) => break,
                 Err(err) if after_exit => return Err(format!("read pty output after exit: {err}")),


### PR DESCRIPTION
Fixes #135

The daemon's busiest per-byte path — PTY output fan-out to attached clients — did several avoidable full-payload copies. This PR removes them without touching the wire format or the backlog-cap semantics.

## What changed

**1. Frame encoding no longer clones or double-buffers (`protocol.rs`, `session.rs`)**

`Frame::encode()` cloned every `Output`/`Input` payload, `frame.write` copied it again into a temp `Vec`, and `extend_from_slice` copied it a third time into `pending_output`. `Frame::write` now streams the 5-byte header (tag + u32 LE length) and the payload slice directly to the writer, `encode()` is gone, and both `ActiveClient` and `PacketClient` enqueue by writing straight into the backlog buffer (`PendingOutput: io::Write`). The hot path additionally uses `Frame::write_output(&[u8])`, which frames a raw chunk without constructing a `Frame` at all — so per client the payload is copied exactly once, with zero temp allocations.

**2. Tap publication is a refcount bump (`session_runtime.rs`, `host/actor.rs`)**

Chunks were copied out of the PTY read buffer with `to_vec()` and then cloned again per tap in `publish_raw_output`. They now travel as `Arc<[u8]>` from `read_available_output` through `RawOutputChunk` to the servicing loop; `try_send` clones only bump a refcount. The servicing side frames each chunk per client from the shared slice. (Attach-time install/replay still makes owned copies of the handful of live chunks — that path is not per-byte.)

**3. Partial socket writes stop memmoving the backlog (`session.rs`)**

`pending_output.drain(..n)` moved the entire remaining backlog down on every partial write — O(n²) churn for a slow client near the 4 MB cap. `PendingOutput` keeps a start cursor and compacts only when the consumed prefix outgrows the live remainder, so total memmove work is bounded by total bytes queued (amortized O(1) per byte).

## Savings

For a 100 MB `cat` to one attached client (issue estimate): framing drops from ~300 MB of memcpy + ~1,600 allocations to ~100 MB / 0 temp allocations; the tap crossing drops another ~100 MB per tap; slow-reader flushes go from quadratic to linear. Watchers multiply the framing savings per client.

## Guardrails held

- Wire format byte-identical: new `wire_format_is_tag_then_le_length_then_payload` pins tag/LE-length/payload for all four variants; existing round-trip tests unchanged and passing.
- `MAX_PENDING_CLIENT_OUTPUT_BYTES` still caps post-framing unflushed bytes (`PendingOutput::len()` measures exactly what `Vec::len` did), checked before appending, with the same overflow behavior (ActiveClient error / PacketClient marked dead and backlog released).
- New tests: `write_output_matches_output_frame_encoding`, `enqueue_output_frames_bytes_identically_to_enqueue_frame`, `pending_output_partial_consumes_preserve_byte_order_without_upfront_memmove`, plus a zero-copy-path case in `active_client_rejects_unbounded_output_backlog`.

## Verification

- `cargo build --locked` ✓
- `cargo +nightly-2026-03-12 fmt --check` ✓
- `cargo clippy --workspace --all-targets --locked -- -D warnings` ✓
- `cargo test --workspace --locked` ✓ (all suites, 0 failures)
- `cargo test -p cleat --locked --features ghostty-vt` ✓ (160 unit + 79 lifecycle tests, 0 failures; known-flaky `packet_lagging_channel_receives_cached_generation_after_session_goes_clean` passed)