### PR TITLE
perf: bulk-read Ghostty render cells

### DIFF
--- a/crates/cleat/src/vt/ghostty.rs
+++ b/crates/cleat/src/vt/ghostty.rs
@@ -1,12 +1,12 @@
 use super::{
     ghostty_ffi::{
-        self, GhosttyCellContentTag, GhosttyCellSemanticContent, GhosttyCellWide, GhosttyFormatterFormat, GhosttyFormatterTerminalOptions,
-        GhosttyMods, GhosttyMouseAction, GhosttyMouseButton, GhosttyRenderStateCursorVisualStyle, GhosttyRenderStateDirty, GhosttyRowData,
-        GhosttyRowSemanticPrompt, GhosttyStyle, GhosttyStyleColor, GhosttyStyleColorTag, GhosttyTerminalScreen,
-        GhosttyTerminalScrollViewport, MouseEncodeEvent, MouseEncoder, RenderStateHandle, RowCellsHandle, RowIteratorHandle,
-        TerminalHandle, GHOSTTY_MODE_ALT_SCROLL, GHOSTTY_MODE_BRACKETED_PASTE, GHOSTTY_MODE_DECCKM, GHOSTTY_MODE_MOUSE_ANY,
-        GHOSTTY_MODE_MOUSE_BUTTON, GHOSTTY_MODE_MOUSE_NORMAL, GHOSTTY_MODE_MOUSE_X10, GHOSTTY_MODE_SGR_MOUSE,
-        GHOSTTY_MODE_SGR_PIXELS_MOUSE, GHOSTTY_MODS_ALT, GHOSTTY_MODS_CTRL, GHOSTTY_MODS_SHIFT,
+        self, GhosttyCellContentTag, GhosttyCellSemanticContent, GhosttyCellSnapshot, GhosttyCellWide, GhosttyFormatterFormat,
+        GhosttyFormatterTerminalOptions, GhosttyMods, GhosttyMouseAction, GhosttyMouseButton, GhosttyRenderStateColors,
+        GhosttyRenderStateCursorVisualStyle, GhosttyRenderStateDirty, GhosttyRowData, GhosttyRowSemanticPrompt, GhosttyStyle,
+        GhosttyStyleColor, GhosttyStyleColorTag, GhosttyTerminalScreen, GhosttyTerminalScrollViewport, MouseEncodeEvent, MouseEncoder,
+        RenderStateHandle, RowCellsHandle, RowIteratorHandle, TerminalHandle, GHOSTTY_MODE_ALT_SCROLL, GHOSTTY_MODE_BRACKETED_PASTE,
+        GHOSTTY_MODE_DECCKM, GHOSTTY_MODE_MOUSE_ANY, GHOSTTY_MODE_MOUSE_BUTTON, GHOSTTY_MODE_MOUSE_NORMAL, GHOSTTY_MODE_MOUSE_X10,
+        GHOSTTY_MODE_SGR_MOUSE, GHOSTTY_MODE_SGR_PIXELS_MOUSE, GHOSTTY_MODS_ALT, GHOSTTY_MODS_CTRL, GHOSTTY_MODS_SHIFT,
     },
     CellFlags, CellWidth, ClientCapabilities, ColorLevel, CursorState, CursorStyle, MouseAction, MouseButton, MouseModifiers,
     MouseReportFormat, MouseTrackingMode, ResolvedCell, Rgb, ScreenGrid, TerminalColors, TerminalModeState, VtEngine,
@@ -126,95 +126,66 @@ impl GhosttyVtEngine {
         row: u16,
         cols: u16,
         raw_row: ghostty_ffi::GhosttyRow,
-        default_fg: Rgb,
-        default_bg: Rgb,
+        colors: &GhosttyRenderStateColors,
         dirty: bool,
-    ) -> Result<(TerminalRenderRow, Vec<ResolvedCell>), String> {
+        cached_cells: &mut [ResolvedCell],
+    ) -> Result<TerminalRenderRow, String> {
         self.row_iter.populate_cells(&mut self.row_cells)?;
 
         let mut render_cells = Vec::with_capacity(cols as usize);
-        let mut resolved_cells = Vec::with_capacity(cols as usize);
+        let mut col_idx = 0;
         while self.row_cells.next() {
-            let graphemes_len = self.row_cells.get_graphemes_len()?;
-            let graphemes = if graphemes_len > 0 {
-                let mut buf = vec![0u32; graphemes_len as usize];
-                self.row_cells.get_graphemes_buf(&mut buf)?;
-                buf
-            } else {
-                Vec::new()
-            };
-
-            let resolved_fg = self.row_cells.get_fg_color()?.map(rgb_from_ghostty).unwrap_or(default_fg);
-            let resolved_bg = self.row_cells.get_bg_color()?.map(rgb_from_ghostty).unwrap_or(default_bg);
-            let style = self.row_cells.get_style()?;
-            let flags = flags_from_ghostty_style(&style);
-            let underline_style = u32::try_from(style.underline).unwrap_or(0);
-            let underline_color = rgb_from_ghostty_style_color(style.underline_color);
-            let protected = self.row_cells.get_protected()?;
-            let has_hyperlink = self.row_cells.get_has_hyperlink()?;
-            let semantic = semantic_from_ghostty(self.row_cells.get_semantic_content()?);
-            let width = cell_width_from_ghostty(self.row_cells.get_wide()?);
-
-            resolved_cells.push(ResolvedCell {
-                graphemes: graphemes.clone(),
-                fg: resolved_fg,
-                bg: resolved_bg,
-                underline_color,
-                flags,
-                underline_style,
-                width,
-                protected,
-                semantic,
-                has_hyperlink,
-            });
+            let resolved_cell =
+                cached_cells.get_mut(col_idx).ok_or_else(|| format!("ghostty returned more than {cols} cells for render row {row}"))?;
+            let cell = self.row_cells.read_cell_into(&mut resolved_cell.graphemes)?;
+            apply_ghostty_cell_snapshot(resolved_cell, &cell, colors);
+            let style = cell.style;
 
             render_cells.push(TerminalRenderCell {
-                graphemes,
+                graphemes: resolved_cell.graphemes.clone(),
                 style: TerminalRenderStyle {
-                    flags: terminal_cell_flags_from_vt(flags),
-                    width: terminal_cell_width_from_vt(width),
-                    resolved_fg: terminal_rgb_from_rgb(resolved_fg),
-                    resolved_bg: terminal_rgb_from_rgb(resolved_bg),
+                    flags: terminal_cell_flags_from_vt(resolved_cell.flags),
+                    width: terminal_cell_width_from_vt(resolved_cell.width),
+                    resolved_fg: terminal_rgb_from_rgb(resolved_cell.fg),
+                    resolved_bg: terminal_rgb_from_rgb(resolved_cell.bg),
                     fg_color: terminal_style_color_from_ghostty(style.fg_color),
                     bg_color: terminal_style_color_from_ghostty(style.bg_color),
-                    underline_style,
+                    underline_style: resolved_cell.underline_style,
                     underline_color: terminal_style_color_from_ghostty(style.underline_color),
-                    protected,
-                    semantic,
-                    has_hyperlink,
+                    protected: cell.protected,
+                    semantic: resolved_cell.semantic,
+                    has_hyperlink: cell.has_hyperlink,
                     hyperlink_id: 0,
-                    content_tag: content_tag_from_ghostty(self.row_cells.get_content_tag()?),
-                    has_text: self.row_cells.get_has_text()?,
-                    has_styling: self.row_cells.get_has_styling()?,
-                    style_id: self.row_cells.get_style_id()?,
+                    content_tag: content_tag_from_ghostty(cell.content_tag),
+                    has_text: cell.has_text,
+                    has_styling: cell.has_styling,
+                    style_id: cell.style_id,
                 },
             });
+            col_idx += 1;
         }
 
-        Ok((
-            TerminalRenderRow {
-                row,
-                col_count: cols,
-                cells: render_cells,
-                wrap: ghostty_ffi::row_get_bool(raw_row, GhosttyRowData::Wrap, "ghostty_row_get(Wrap)")?,
-                wrap_continuation: ghostty_ffi::row_get_bool(
-                    raw_row,
-                    GhosttyRowData::WrapContinuation,
-                    "ghostty_row_get(WrapContinuation)",
-                )?,
-                has_graphemes: ghostty_ffi::row_get_bool(raw_row, GhosttyRowData::Grapheme, "ghostty_row_get(Grapheme)")?,
-                has_styling: ghostty_ffi::row_get_bool(raw_row, GhosttyRowData::Styled, "ghostty_row_get(Styled)")?,
-                has_hyperlink: ghostty_ffi::row_get_bool(raw_row, GhosttyRowData::Hyperlink, "ghostty_row_get(Hyperlink)")?,
-                semantic_prompt: row_semantic_prompt_from_ghostty(ghostty_ffi::row_get_semantic_prompt(raw_row)?),
-                has_kitty_virtual_placeholder: ghostty_ffi::row_get_bool(
-                    raw_row,
-                    GhosttyRowData::KittyVirtualPlaceholder,
-                    "ghostty_row_get(KittyVirtualPlaceholder)",
-                )?,
-                dirty,
-            },
-            resolved_cells,
-        ))
+        if col_idx != cached_cells.len() {
+            return Err(format!("ghostty returned {col_idx} cells for {cols}-column render row {row}"));
+        }
+
+        Ok(TerminalRenderRow {
+            row,
+            col_count: cols,
+            cells: render_cells,
+            wrap: ghostty_ffi::row_get_bool(raw_row, GhosttyRowData::Wrap, "ghostty_row_get(Wrap)")?,
+            wrap_continuation: ghostty_ffi::row_get_bool(raw_row, GhosttyRowData::WrapContinuation, "ghostty_row_get(WrapContinuation)")?,
+            has_graphemes: ghostty_ffi::row_get_bool(raw_row, GhosttyRowData::Grapheme, "ghostty_row_get(Grapheme)")?,
+            has_styling: ghostty_ffi::row_get_bool(raw_row, GhosttyRowData::Styled, "ghostty_row_get(Styled)")?,
+            has_hyperlink: ghostty_ffi::row_get_bool(raw_row, GhosttyRowData::Hyperlink, "ghostty_row_get(Hyperlink)")?,
+            semantic_prompt: row_semantic_prompt_from_ghostty(ghostty_ffi::row_get_semantic_prompt(raw_row)?),
+            has_kitty_virtual_placeholder: ghostty_ffi::row_get_bool(
+                raw_row,
+                GhosttyRowData::KittyVirtualPlaceholder,
+                "ghostty_row_get(KittyVirtualPlaceholder)",
+            )?,
+            dirty,
+        })
     }
 }
 
@@ -330,11 +301,10 @@ impl VtEngine for GhosttyVtEngine {
 
         let dirty = self.render_state.get_dirty()?;
         if dirty == GhosttyRenderStateDirty::False {
-            if let Some(ref cached) = self.cached_grid {
-                let mut grid = cached.clone();
-                grid.cursor = self.read_cursor_state()?;
-                self.cached_grid = Some(grid.clone());
-                return Ok(grid);
+            let cursor = self.read_cursor_state()?;
+            if let Some(cached) = self.cached_grid.as_mut() {
+                cached.cursor = cursor;
+                return Ok(cached.clone());
             }
         }
 
@@ -342,19 +312,17 @@ impl VtEngine for GhosttyVtEngine {
         let rows = self.render_state.get_rows()?;
         let colors = self.render_state.get_colors()?;
 
-        let default_fg = Rgb { r: colors.foreground.r, g: colors.foreground.g, b: colors.foreground.b };
-        let default_bg = Rgb { r: colors.background.r, g: colors.background.g, b: colors.background.b };
-
         let mut partial = dirty == GhosttyRenderStateDirty::Partial;
         let row_stride = cols as usize;
+        let expected_cell_count = row_stride * rows as usize;
 
-        // Reuse the cached cell vec when doing a partial update.
-        let mut cells = if partial { self.cached_grid.take().map(|g| g.cells).unwrap_or_default() } else { Vec::new() };
-        if cells.len() != row_stride * (rows as usize) {
+        // Reuse per-cell grapheme allocations on both partial and full redraws.
+        let mut cells = self.cached_grid.take().map(|g| g.cells).unwrap_or_default();
+        if cells.len() != expected_cell_count {
             // Dimensions changed or no cache — force a full rebuild.
             partial = false;
             cells.clear();
-            cells.reserve(row_stride * (rows as usize));
+            cells.resize_with(expected_cell_count, ResolvedCell::default);
         }
 
         self.render_state.populate_row_iterator(&mut self.row_iter)?;
@@ -375,52 +343,15 @@ impl VtEngine for GhosttyVtEngine {
             let row_start = row_idx * row_stride;
             let mut col_idx: usize = 0;
             while self.row_cells.next() {
-                let graphemes_len = self.row_cells.get_graphemes_len()?;
-                let graphemes = if graphemes_len > 0 {
-                    let mut buf = vec![0u32; graphemes_len as usize];
-                    self.row_cells.get_graphemes_buf(&mut buf)?;
-                    buf
-                } else {
-                    Vec::new()
-                };
-
-                let fg = match self.row_cells.get_fg_color()? {
-                    Some(c) => Rgb { r: c.r, g: c.g, b: c.b },
-                    None => default_fg,
-                };
-                let bg = match self.row_cells.get_bg_color()? {
-                    Some(c) => Rgb { r: c.r, g: c.g, b: c.b },
-                    None => default_bg,
-                };
-
-                let style = self.row_cells.get_style()?;
-                let flags = flags_from_ghostty_style(&style);
-                let underline_style = u32::try_from(style.underline).unwrap_or(0);
-                let underline_color = rgb_from_ghostty_style_color(style.underline_color);
-                let protected = self.row_cells.get_protected()?;
-                let has_hyperlink = self.row_cells.get_has_hyperlink()?;
-                let semantic = match self.row_cells.get_semantic_content()? {
-                    GhosttyCellSemanticContent::Output => 0,
-                    GhosttyCellSemanticContent::Input => 1,
-                    GhosttyCellSemanticContent::Prompt => 2,
-                };
-
-                let width = match self.row_cells.get_wide()? {
-                    GhosttyCellWide::Narrow => CellWidth::Narrow,
-                    GhosttyCellWide::Wide => CellWidth::Wide,
-                    GhosttyCellWide::SpacerTail => CellWidth::SpacerTail,
-                    GhosttyCellWide::SpacerHead => CellWidth::SpacerHead,
-                };
-
-                let cell =
-                    ResolvedCell { graphemes, fg, bg, underline_color, flags, underline_style, width, protected, semantic, has_hyperlink };
                 let idx = row_start + col_idx;
-                if idx < cells.len() {
-                    cells[idx] = cell;
-                } else {
-                    cells.push(cell);
-                }
+                let resolved_cell =
+                    cells.get_mut(idx).ok_or_else(|| format!("ghostty returned too many cells for {cols}x{rows} screen grid"))?;
+                let cell = self.row_cells.read_cell_into(&mut resolved_cell.graphemes)?;
+                apply_ghostty_cell_snapshot(resolved_cell, &cell, &colors);
                 col_idx += 1;
+            }
+            if col_idx != row_stride {
+                return Err(format!("ghostty returned {col_idx} cells for {cols}-column screen-grid row {row_idx}"));
             }
             self.row_iter.set_dirty(false)?;
             row_idx += 1;
@@ -442,8 +373,6 @@ impl VtEngine for GhosttyVtEngine {
         let cols = self.render_state.get_cols()?;
         let rows = self.render_state.get_rows()?;
         let colors = self.render_state.get_colors()?;
-        let default_fg = rgb_from_ghostty(colors.foreground);
-        let default_bg = rgb_from_ghostty(colors.background);
         let had_cache = self.cached_grid.is_some();
         let effective_dirty = effective_render_dirty(dirty, render_dirty, had_cache);
         let row_stride = cols as usize;
@@ -469,14 +398,12 @@ impl VtEngine for GhosttyVtEngine {
                 if include_row {
                     let row = u16::try_from(row_idx).unwrap_or(u16::MAX);
                     let raw_row = self.row_iter.get_raw_row()?;
-                    let (render_row, resolved_cells) = self.read_render_row(row, cols, raw_row, default_fg, default_bg, row_dirty)?;
                     let row_start = row_idx * row_stride;
-                    for (offset, cell) in resolved_cells.into_iter().enumerate() {
-                        let idx = row_start + offset;
-                        if idx < cached_cells.len() {
-                            cached_cells[idx] = cell;
-                        }
-                    }
+                    let row_end = row_start + row_stride;
+                    let cached_row = cached_cells
+                        .get_mut(row_start..row_end)
+                        .ok_or_else(|| format!("render row {row} was outside the {cols}x{rows} cell cache"))?;
+                    let render_row = self.read_render_row(row, cols, raw_row, &colors, row_dirty, cached_row)?;
                     if effective_dirty == DirtyState::Partial {
                         dirty_rows.push(row);
                     }
@@ -711,6 +638,41 @@ fn effective_render_dirty(requested: DirtyState, render_dirty: GhosttyRenderStat
 
 fn rgb_from_ghostty(rgb: ghostty_ffi::GhosttyColorRgb) -> Rgb {
     Rgb { r: rgb.r, g: rgb.g, b: rgb.b }
+}
+
+fn resolved_style_color(
+    color: GhosttyStyleColor,
+    default: ghostty_ffi::GhosttyColorRgb,
+    palette: &[ghostty_ffi::GhosttyColorRgb; 256],
+) -> Rgb {
+    match color.tag {
+        GhosttyStyleColorTag::None => rgb_from_ghostty(default),
+        GhosttyStyleColorTag::Palette => rgb_from_ghostty(palette[usize::from(unsafe { color.value.palette })]),
+        GhosttyStyleColorTag::Rgb => rgb_from_ghostty(unsafe { color.value.rgb }),
+    }
+}
+
+fn resolved_cell_background(cell: &GhosttyCellSnapshot, colors: &GhosttyRenderStateColors) -> Rgb {
+    match cell.content_tag {
+        GhosttyCellContentTag::BgColorPalette => rgb_from_ghostty(colors.palette[usize::from(cell.color_palette)]),
+        GhosttyCellContentTag::BgColorRgb => rgb_from_ghostty(cell.color_rgb),
+        GhosttyCellContentTag::Codepoint | GhosttyCellContentTag::CodepointGrapheme => {
+            resolved_style_color(cell.style.bg_color, colors.background, &colors.palette)
+        }
+    }
+}
+
+fn apply_ghostty_cell_snapshot(target: &mut ResolvedCell, source: &GhosttyCellSnapshot, colors: &GhosttyRenderStateColors) {
+    let style = source.style;
+    target.fg = resolved_style_color(style.fg_color, colors.foreground, &colors.palette);
+    target.bg = resolved_cell_background(source, colors);
+    target.underline_color = rgb_from_ghostty_style_color(style.underline_color);
+    target.flags = flags_from_ghostty_style(&style);
+    target.underline_style = u32::try_from(style.underline).unwrap_or(0);
+    target.width = cell_width_from_ghostty(source.wide);
+    target.protected = source.protected;
+    target.semantic = semantic_from_ghostty(source.semantic_content);
+    target.has_hyperlink = source.has_hyperlink;
 }
 
 fn terminal_rgb_from_rgb(rgb: Rgb) -> TerminalRgb {

--- a/crates/cleat/src/vt/ghostty_ffi.rs
+++ b/crates/cleat/src/vt/ghostty_ffi.rs
@@ -335,6 +335,9 @@ pub enum GhosttyRenderStateRowCellsData {
     GraphemesBuf = 4,
     BgColor = 5,
     FgColor = 6,
+    Selected = 7,
+    HasStyling = 8,
+    GraphemesUtf8 = 9,
 }
 
 pub type GhosttyCell = u64;
@@ -417,6 +420,14 @@ pub struct GhosttyColorRgb {
     pub r: u8,
     pub g: u8,
     pub b: u8,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct GhosttyBuffer {
+    pub ptr: *mut u8,
+    pub cap: usize,
+    pub len: usize,
 }
 
 #[allow(dead_code)]
@@ -583,6 +594,7 @@ const _: () = assert!(std::mem::size_of::<GhosttyDeviceAttributes>() == 160);
 const _: () = assert!(std::mem::size_of::<GhosttyStyleColor>() == 16);
 const _: () = assert!(std::mem::size_of::<GhosttyStyle>() == 72);
 const _: () = assert!(std::mem::size_of::<GhosttyColorRgb>() == 3);
+const _: () = assert!(std::mem::size_of::<GhosttyBuffer>() == 24);
 const _: () = assert!(std::mem::size_of::<GhosttyRenderStateColors>() == 792);
 const _: () = assert!(std::mem::size_of::<GhosttyTerminalScrollViewport>() == 24);
 const _: () = assert!(std::mem::size_of::<GhosttyTerminalScrollbar>() == 24);
@@ -864,14 +876,22 @@ unsafe extern "C" {
     fn ghostty_render_state_row_cells_next(cells: GhosttyRenderStateRowCells) -> bool;
     #[allow(dead_code)]
     fn ghostty_render_state_row_cells_select(cells: GhosttyRenderStateRowCells, x: u16) -> GhosttyResult;
-    fn ghostty_render_state_row_cells_get(
+    fn ghostty_render_state_row_cells_get_multi(
         cells: GhosttyRenderStateRowCells,
-        data: GhosttyRenderStateRowCellsData,
-        out: *mut c_void,
+        count: usize,
+        keys: *const GhosttyRenderStateRowCellsData,
+        values: *mut *mut c_void,
+        out_written: *mut usize,
     ) -> GhosttyResult;
 
     // --- Cell data ---
-    fn ghostty_cell_get(cell: GhosttyCell, data: GhosttyCellData, out: *mut c_void) -> GhosttyResult;
+    fn ghostty_cell_get_multi(
+        cell: GhosttyCell,
+        count: usize,
+        keys: *const GhosttyCellData,
+        values: *mut *mut c_void,
+        out_written: *mut usize,
+    ) -> GhosttyResult;
     fn ghostty_row_get(row: GhosttyRow, data: GhosttyRowData, out: *mut c_void) -> GhosttyResult;
 }
 
@@ -1938,8 +1958,26 @@ impl Drop for RowIteratorHandle {
     }
 }
 
+const INLINE_GRAPHEME_UTF8_CAPACITY: usize = 64;
+
+pub struct GhosttyCellSnapshot {
+    pub style: GhosttyStyle,
+    pub content_tag: GhosttyCellContentTag,
+    pub wide: GhosttyCellWide,
+    pub has_text: bool,
+    pub has_styling: bool,
+    pub style_id: u16,
+    pub has_hyperlink: bool,
+    pub protected: bool,
+    pub semantic_content: GhosttyCellSemanticContent,
+    pub color_palette: u8,
+    pub color_rgb: GhosttyColorRgb,
+}
+
 pub struct RowCellsHandle {
     raw: GhosttyRenderStateRowCells,
+    inline_grapheme_utf8: [u8; INLINE_GRAPHEME_UTF8_CAPACITY],
+    overflow_grapheme_utf8: Vec<u8>,
 }
 
 impl RowCellsHandle {
@@ -1947,147 +1985,122 @@ impl RowCellsHandle {
         let mut raw = ptr::null_mut();
         let result = unsafe { ghostty_render_state_row_cells_new(ptr::null(), &mut raw) };
         check_result(result, "ghostty_render_state_row_cells_new")?;
-        Ok(Self { raw })
+        Ok(Self { raw, inline_grapheme_utf8: [0; INLINE_GRAPHEME_UTF8_CAPACITY], overflow_grapheme_utf8: Vec::new() })
     }
 
     pub fn next(&mut self) -> bool {
         unsafe { ghostty_render_state_row_cells_next(self.raw) }
     }
 
-    pub fn get_graphemes_len(&self) -> Result<u32, String> {
-        let mut len: u32 = 0;
-        let result = unsafe {
-            ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::GraphemesLen, &mut len as *mut u32 as *mut c_void)
-        };
-        check_result(result, "ghostty_render_state_row_cells_get(GraphemesLen)")?;
-        Ok(len)
-    }
-
-    pub fn get_graphemes_buf(&self, buf: &mut [u32]) -> Result<(), String> {
-        let result = unsafe {
-            ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::GraphemesBuf, buf.as_mut_ptr() as *mut c_void)
-        };
-        check_result(result, "ghostty_render_state_row_cells_get(GraphemesBuf)")
-    }
-
-    pub fn get_style(&self) -> Result<GhosttyStyle, String> {
-        let mut style = GhosttyStyle::init();
-        let result = unsafe {
-            ghostty_render_state_row_cells_get(
-                self.raw,
-                GhosttyRenderStateRowCellsData::Style,
-                &mut style as *mut GhosttyStyle as *mut c_void,
-            )
-        };
-        check_result(result, "ghostty_render_state_row_cells_get(Style)")?;
-        Ok(style)
-    }
-
-    pub fn get_bg_color(&self) -> Result<Option<GhosttyColorRgb>, String> {
-        let mut color = GhosttyColorRgb::default();
-        let result = unsafe {
-            ghostty_render_state_row_cells_get(
-                self.raw,
-                GhosttyRenderStateRowCellsData::BgColor,
-                &mut color as *mut GhosttyColorRgb as *mut c_void,
-            )
-        };
-        match result {
-            GhosttyResult::Success => Ok(Some(color)),
-            GhosttyResult::InvalidValue => Ok(None),
-            other => check_result(other, "ghostty_render_state_row_cells_get(BgColor)").map(|_| None),
-        }
-    }
-
-    pub fn get_fg_color(&self) -> Result<Option<GhosttyColorRgb>, String> {
-        let mut color = GhosttyColorRgb::default();
-        let result = unsafe {
-            ghostty_render_state_row_cells_get(
-                self.raw,
-                GhosttyRenderStateRowCellsData::FgColor,
-                &mut color as *mut GhosttyColorRgb as *mut c_void,
-            )
-        };
-        match result {
-            GhosttyResult::Success => Ok(Some(color)),
-            GhosttyResult::InvalidValue => Ok(None),
-            other => check_result(other, "ghostty_render_state_row_cells_get(FgColor)").map(|_| None),
-        }
-    }
-
-    pub fn get_raw_cell(&self) -> Result<GhosttyCell, String> {
+    pub fn read_cell_into(&mut self, graphemes: &mut Vec<u32>) -> Result<GhosttyCellSnapshot, String> {
         let mut cell: GhosttyCell = 0;
-        let result = unsafe {
-            ghostty_render_state_row_cells_get(self.raw, GhosttyRenderStateRowCellsData::Raw, &mut cell as *mut GhosttyCell as *mut c_void)
+        let mut style = GhosttyStyle::init();
+        let raw = self.raw;
+        let grapheme_len = match fetch_row_cell(raw, &mut self.inline_grapheme_utf8, &mut cell, &mut style) {
+            Ok(len) => len,
+            Err((GhosttyResult::OutOfSpace, 2, required)) => {
+                self.overflow_grapheme_utf8.resize(required, 0);
+                fetch_row_cell(raw, &mut self.overflow_grapheme_utf8, &mut cell, &mut style).map_err(|(result, written, _)| {
+                    format!("ghostty_render_state_row_cells_get_multi failed after {written} values: {result:?}")
+                })?
+            }
+            Err((result, written, _)) => {
+                return Err(format!("ghostty_render_state_row_cells_get_multi failed after {written} values: {result:?}"));
+            }
         };
-        check_result(result, "ghostty_render_state_row_cells_get(Raw)")?;
-        Ok(cell)
-    }
 
-    pub fn get_wide(&self) -> Result<GhosttyCellWide, String> {
-        let cell = self.get_raw_cell()?;
+        let grapheme_bytes = if grapheme_len <= self.inline_grapheme_utf8.len() {
+            &self.inline_grapheme_utf8[..grapheme_len]
+        } else {
+            &self.overflow_grapheme_utf8[..grapheme_len]
+        };
+        let grapheme_text =
+            std::str::from_utf8(grapheme_bytes).map_err(|err| format!("ghostty render-state grapheme was not valid utf-8: {err}"))?;
+        graphemes.clear();
+        graphemes.extend(grapheme_text.chars().map(u32::from));
+
+        let mut content_tag = GhosttyCellContentTag::Codepoint;
         let mut wide = GhosttyCellWide::Narrow;
-        let result = unsafe { ghostty_cell_get(cell, GhosttyCellData::Wide, &mut wide as *mut GhosttyCellWide as *mut c_void) };
-        check_result(result, "ghostty_cell_get(Wide)")?;
-        Ok(wide)
-    }
-
-    pub fn get_content_tag(&self) -> Result<GhosttyCellContentTag, String> {
-        let cell = self.get_raw_cell()?;
-        let mut tag = GhosttyCellContentTag::Codepoint;
-        let result = unsafe { ghostty_cell_get(cell, GhosttyCellData::ContentTag, &mut tag as *mut GhosttyCellContentTag as *mut c_void) };
-        check_result(result, "ghostty_cell_get(ContentTag)")?;
-        Ok(tag)
-    }
-
-    pub fn get_has_text(&self) -> Result<bool, String> {
-        let cell = self.get_raw_cell()?;
         let mut has_text = false;
-        let result = unsafe { ghostty_cell_get(cell, GhosttyCellData::HasText, &mut has_text as *mut bool as *mut c_void) };
-        check_result(result, "ghostty_cell_get(HasText)")?;
-        Ok(has_text)
-    }
-
-    pub fn get_has_styling(&self) -> Result<bool, String> {
-        let cell = self.get_raw_cell()?;
         let mut has_styling = false;
-        let result = unsafe { ghostty_cell_get(cell, GhosttyCellData::HasStyling, &mut has_styling as *mut bool as *mut c_void) };
-        check_result(result, "ghostty_cell_get(HasStyling)")?;
-        Ok(has_styling)
-    }
-
-    pub fn get_style_id(&self) -> Result<u16, String> {
-        let cell = self.get_raw_cell()?;
-        let mut style_id = 0;
-        let result = unsafe { ghostty_cell_get(cell, GhosttyCellData::StyleId, &mut style_id as *mut u16 as *mut c_void) };
-        check_result(result, "ghostty_cell_get(StyleId)")?;
-        Ok(style_id)
-    }
-
-    pub fn get_protected(&self) -> Result<bool, String> {
-        let cell = self.get_raw_cell()?;
-        let mut protected = false;
-        let result = unsafe { ghostty_cell_get(cell, GhosttyCellData::Protected, &mut protected as *mut bool as *mut c_void) };
-        check_result(result, "ghostty_cell_get(Protected)")?;
-        Ok(protected)
-    }
-
-    pub fn get_has_hyperlink(&self) -> Result<bool, String> {
-        let cell = self.get_raw_cell()?;
+        let mut style_id: u16 = 0;
         let mut has_hyperlink = false;
-        let result = unsafe { ghostty_cell_get(cell, GhosttyCellData::HasHyperlink, &mut has_hyperlink as *mut bool as *mut c_void) };
-        check_result(result, "ghostty_cell_get(HasHyperlink)")?;
-        Ok(has_hyperlink)
-    }
+        let mut protected = false;
+        let mut semantic_content = GhosttyCellSemanticContent::Output;
+        let mut color_palette: u8 = 0;
+        let mut color_rgb = GhosttyColorRgb::default();
+        let keys = [
+            GhosttyCellData::ContentTag,
+            GhosttyCellData::Wide,
+            GhosttyCellData::HasText,
+            GhosttyCellData::HasStyling,
+            GhosttyCellData::StyleId,
+            GhosttyCellData::HasHyperlink,
+            GhosttyCellData::Protected,
+            GhosttyCellData::SemanticContent,
+            GhosttyCellData::ColorPalette,
+            GhosttyCellData::ColorRgb,
+        ];
+        let mut values = [
+            (&mut content_tag as *mut GhosttyCellContentTag).cast::<c_void>(),
+            (&mut wide as *mut GhosttyCellWide).cast::<c_void>(),
+            (&mut has_text as *mut bool).cast::<c_void>(),
+            (&mut has_styling as *mut bool).cast::<c_void>(),
+            (&mut style_id as *mut u16).cast::<c_void>(),
+            (&mut has_hyperlink as *mut bool).cast::<c_void>(),
+            (&mut protected as *mut bool).cast::<c_void>(),
+            (&mut semantic_content as *mut GhosttyCellSemanticContent).cast::<c_void>(),
+            (&mut color_palette as *mut u8).cast::<c_void>(),
+            (&mut color_rgb as *mut GhosttyColorRgb).cast::<c_void>(),
+        ];
+        let mut written = 0;
+        let result = unsafe { ghostty_cell_get_multi(cell, keys.len(), keys.as_ptr(), values.as_mut_ptr(), &mut written) };
+        check_multi_result(result, written, keys.len(), "ghostty_cell_get_multi")?;
 
-    pub fn get_semantic_content(&self) -> Result<GhosttyCellSemanticContent, String> {
-        let cell = self.get_raw_cell()?;
-        let mut semantic = GhosttyCellSemanticContent::Output;
-        let result = unsafe {
-            ghostty_cell_get(cell, GhosttyCellData::SemanticContent, &mut semantic as *mut GhosttyCellSemanticContent as *mut c_void)
-        };
-        check_result(result, "ghostty_cell_get(SemanticContent)")?;
-        Ok(semantic)
+        Ok(GhosttyCellSnapshot {
+            style,
+            content_tag,
+            wide,
+            has_text,
+            has_styling,
+            style_id,
+            has_hyperlink,
+            protected,
+            semantic_content,
+            color_palette,
+            color_rgb,
+        })
+    }
+}
+
+fn fetch_row_cell(
+    cells: GhosttyRenderStateRowCells,
+    storage: &mut [u8],
+    cell: &mut GhosttyCell,
+    style: &mut GhosttyStyle,
+) -> Result<usize, (GhosttyResult, usize, usize)> {
+    let mut graphemes = GhosttyBuffer { ptr: storage.as_mut_ptr(), cap: storage.len(), len: 0 };
+    let keys = [GhosttyRenderStateRowCellsData::Raw, GhosttyRenderStateRowCellsData::Style, GhosttyRenderStateRowCellsData::GraphemesUtf8];
+    let mut values = [
+        (cell as *mut GhosttyCell).cast::<c_void>(),
+        (style as *mut GhosttyStyle).cast::<c_void>(),
+        (&mut graphemes as *mut GhosttyBuffer).cast::<c_void>(),
+    ];
+    let mut written = 0;
+    let result = unsafe { ghostty_render_state_row_cells_get_multi(cells, keys.len(), keys.as_ptr(), values.as_mut_ptr(), &mut written) };
+    if result == GhosttyResult::Success && written == keys.len() {
+        Ok(graphemes.len)
+    } else {
+        Err((result, written, graphemes.len))
+    }
+}
+
+fn check_multi_result(result: GhosttyResult, written: usize, expected: usize, label: &'static str) -> Result<(), String> {
+    check_result(result, label)?;
+    if written == expected {
+        Ok(())
+    } else {
+        Err(format!("{label} wrote {written} of {expected} values"))
     }
 }
 

--- a/crates/cleat/tests/vt.rs
+++ b/crates/cleat/tests/vt.rs
@@ -612,21 +612,25 @@ fn vt_ghostty_screen_grid_resolves_explicit_fg_and_bg_colors() {
 fn vt_ghostty_snapshot_and_render_update_resolve_background_only_cells() {
     use cleat::vt::Rgb;
 
-    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(4, 2);
-    engine.feed(b"\x1b[48;5;42m\x1b[2K").expect("erase row with palette background");
+    fn assert_background_only_cell(input: &[u8], expected: Rgb) {
+        let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(4, 2);
+        engine.feed(input).expect("erase row with configured background");
 
-    let expected = Rgb { r: 0, g: 215, b: 135 };
-    let grid = engine.screen_grid().expect("screen grid");
-    let grid_cell = grid.cell(0, 0).expect("background-only grid cell");
-    assert!(grid_cell.graphemes.is_empty());
-    assert_eq!(grid_cell.bg, expected);
+        let grid = engine.screen_grid().expect("screen grid");
+        let grid_cell = grid.cell(0, 0).expect("background-only grid cell");
+        assert!(grid_cell.graphemes.is_empty());
+        assert_eq!(grid_cell.bg, expected);
 
-    let update = engine.render_update(DirtyState::Full).expect("full render update");
-    let render_cell = &update.ops[0].rows[0].cells[0];
-    assert!(render_cell.graphemes.is_empty());
-    assert_eq!(render_cell.style.resolved_bg.r, expected.r);
-    assert_eq!(render_cell.style.resolved_bg.g, expected.g);
-    assert_eq!(render_cell.style.resolved_bg.b, expected.b);
+        let update = engine.render_update(DirtyState::Full).expect("full render update");
+        let render_cell = &update.ops[0].rows[0].cells[0];
+        assert!(render_cell.graphemes.is_empty());
+        assert_eq!(render_cell.style.resolved_bg.r, expected.r);
+        assert_eq!(render_cell.style.resolved_bg.g, expected.g);
+        assert_eq!(render_cell.style.resolved_bg.b, expected.b);
+    }
+
+    assert_background_only_cell(b"\x1b[48;5;42m\x1b[2K", Rgb { r: 0, g: 215, b: 135 });
+    assert_background_only_cell(b"\x1b[48;2;17;34;51m\x1b[2K", Rgb { r: 17, g: 34, b: 51 });
 }
 
 #[cfg(feature = "ghostty-vt")]

--- a/crates/cleat/tests/vt.rs
+++ b/crates/cleat/tests/vt.rs
@@ -609,6 +609,28 @@ fn vt_ghostty_screen_grid_resolves_explicit_fg_and_bg_colors() {
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
+fn vt_ghostty_snapshot_and_render_update_resolve_background_only_cells() {
+    use cleat::vt::Rgb;
+
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(4, 2);
+    engine.feed(b"\x1b[48;5;42m\x1b[2K").expect("erase row with palette background");
+
+    let expected = Rgb { r: 0, g: 215, b: 135 };
+    let grid = engine.screen_grid().expect("screen grid");
+    let grid_cell = grid.cell(0, 0).expect("background-only grid cell");
+    assert!(grid_cell.graphemes.is_empty());
+    assert_eq!(grid_cell.bg, expected);
+
+    let update = engine.render_update(DirtyState::Full).expect("full render update");
+    let render_cell = &update.ops[0].rows[0].cells[0];
+    assert!(render_cell.graphemes.is_empty());
+    assert_eq!(render_cell.style.resolved_bg.r, expected.r);
+    assert_eq!(render_cell.style.resolved_bg.g, expected.g);
+    assert_eq!(render_cell.style.resolved_bg.b, expected.b);
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
 fn vt_ghostty_screen_grid_uses_configured_default_colors() {
     use cleat::vt::{Rgb, TerminalColors};
 
@@ -647,6 +669,22 @@ fn vt_ghostty_screen_grid_multi_codepoint_grapheme() {
     // row_text should reconstruct the full grapheme cluster
     let text = grid.row_text(0);
     assert!(text.starts_with("e\u{0301}AB"), "row_text should contain the full grapheme cluster, got: {text:?}");
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn vt_ghostty_snapshot_and_render_update_preserve_large_grapheme_clusters() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(40, 5);
+    let grapheme = format!("e{}", "\u{0301}".repeat(40));
+    let expected: Vec<u32> = grapheme.chars().map(u32::from).collect();
+
+    engine.feed(grapheme.as_bytes()).expect("feed large grapheme cluster");
+
+    let grid = engine.screen_grid().expect("screen grid");
+    assert_eq!(grid.cell(0, 0).expect("large grapheme cell").graphemes, expected);
+
+    let update = engine.render_update(DirtyState::Full).expect("full render update");
+    assert_eq!(update.ops[0].rows[0].cells[0].graphemes, expected);
 }
 
 #[cfg(feature = "ghostty-vt")]


### PR DESCRIPTION
## Summary

- bind Ghostty's bulk render-row-cell and raw-cell getters
- reduce the normal grid/render path to two FFI data-fetch crossings per cell
- decode graphemes through reusable inline/overflow UTF-8 scratch storage
- reuse cached grapheme vector capacity on full and partial redraws
- cover large grapheme clusters and background-only cells through both snapshot and render-update APIs

## Why

The remaining work in #136 rebuilt each cell through many individual FFI getters and allocated fresh grapheme buffers during redraws. The pinned Ghostty library already exposes the bulk APIs needed to collapse those calls, so this is a Cleat-only binding and read-path change with no Ghostty pin or public cell-type change.

Owned output cells still retain their existing `Vec<u32>` representation; eliminating those inherent output allocations would require a separate public representation or upstream API change.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `CLEAT_GHOSTTY_PREFIX=/Users/robert/dev/cleat/.tools/ghostty-install cargo build -p cleat --locked --features ghostty-vt`
- `CLEAT_GHOSTTY_PREFIX=/Users/robert/dev/cleat/.tools/ghostty-install cargo clippy -p cleat --locked --all-targets --features ghostty-vt -- -D warnings`
- `CLEAT_GHOSTTY_PREFIX=/Users/robert/dev/cleat/.tools/ghostty-install cargo test -p cleat --locked --features ghostty-vt`

Closes #136.