### PR TITLE
Keep daemon state out of purgeable temporary storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,18 @@ find .tools/ghostty-install -maxdepth 3 | sort
 
 **Tags.** Sessions may carry flat, opaque tags. Add them at launch with repeated `--tag TAG`, mutate them with `cleat tag <id> +TAG -TAG`, and filter directory reads with repeated `--selector TAG`. Selectors are exact whole-tag matches and are ANDed when repeated. `key=value` is only a client convention; cleat does not interpret tag keys, values, hierarchy, or globs.
 
-**Runtime directory.** Discovered in priority order:
+**State directory.** The daemon registration, control socket, session state, and recordings share one root, discovered in priority order:
 
 1. `$CLEAT_RUNTIME_DIR` (if set)
-2. `$XDG_RUNTIME_DIR/cleat` (if `XDG_RUNTIME_DIR` is set)
-3. `$TMPDIR/cleat-<uid>`
-4. `/tmp/cleat-<uid>`
+2. `$XDG_STATE_HOME/cleat` (if `XDG_STATE_HOME` is an absolute path)
+3. `$HOME/.local/state/cleat` on Unix, or `%LOCALAPPDATA%\cleat` on Windows
+
+Discovery fails with an actionable error when no persistent state directory is available; cleat never implicitly stores daemon state or recordings in a temporary directory. `CLEAT_RUNTIME_DIR` retains its historical name as the explicit whole-layout override. Use a short persistent path for this override if the discovered Unix socket path exceeds the platform limit; cleat rejects an unusable socket path before starting a daemon.
 
 Runtime layout v2 is daemon-scoped:
 
 ```text
-<runtime-root>/
+<state-root>/
   <daemon-name>/
     socket
     daemon.pid
@@ -89,7 +90,7 @@ Runtime layout v2 is daemon-scoped:
 
 `socket` and `daemon.pid` belong to the daemon, not to an individual session. Session directories live under `sessions/`. `session.cast` is the asciicast v3 recording when recording is active. `foreground` is a transient attachment marker.
 
-**Liveness and discovery.** Session liveness is daemon state, not a per-session socket stat. `cleat list` queries the selected daemon. `cleat list --all` enumerates every daemon directory under the runtime root and queries or sweeps each daemon independently. If a daemon is definitively stale, cleat performs a daemon-scoped sweep: sessions with a non-empty recording are preserved as recreatable, and sessions without a recording are removed.
+**Liveness and discovery.** Session liveness is daemon state, not a per-session socket stat. `cleat list` queries the selected daemon. `cleat list --all` enumerates every daemon directory under the state root and queries or sweeps each daemon independently. If a daemon is definitively stale, cleat performs a daemon-scoped sweep: sessions with a non-empty recording are preserved as recreatable, and sessions without a recording are removed.
 
 **Linger and cleanup.** A daemon starts on first use of its name. When it has no live sessions, it lingers for 120 seconds before exiting so a burst of commands does not repeatedly bounce the daemon. When a child process exits, its session is removed unless it has a recording that makes it recreatable.
 
@@ -116,7 +117,7 @@ Four surfaces cooperate during a session. Knowing which surface is authoritative
 | `attach` / `detach` | host terminal + daemon | While attached, host terminal is authoritative for query replies |
 | `watch` | host terminal + daemon | Read-only live view; does not take foreground control |
 | `list [--selector TAG]...` | daemon directory state | One-shot read of the selected daemon's directory |
-| `list --all` | daemon directory state | Enumerates every daemon directory under the runtime root |
+| `list --all` | daemon directory state | Enumerates every daemon directory under the state root |
 | `list --watch [--selector TAG]...` | packet directory subscription | Prints a snapshot, then one line per directory delta |
 | `packets` | packet protocol | Opens the structured multiplexed probe surface |
 | `inspect`, `kill`, `signal` | daemon state | No VT / recording involvement |

--- a/crates/cleat/src/main.rs
+++ b/crates/cleat/src/main.rs
@@ -3,9 +3,16 @@ use cleat::{cli, server::SessionService};
 fn main() {
     let cli = cli::parse();
     let service = if let Some(root) = cli.runtime_root.clone() {
-        SessionService::new(cleat::runtime::RuntimeLayout::new(root))
+        Ok(SessionService::new(cleat::runtime::RuntimeLayout::new(root)))
     } else {
         SessionService::discover()
+    };
+    let service = match service {
+        Ok(service) => service,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
     };
     match cli::execute(cli, &service) {
         cli::ExecResult::Ok(Some(output)) => println!("{output}"),

--- a/crates/cleat/src/platform/ipc/unix.rs
+++ b/crates/cleat/src/platform/ipc/unix.rs
@@ -3,6 +3,15 @@ use std::{io, net::Shutdown, path::Path, time::Duration};
 pub type SessionStream = std::os::unix::net::UnixStream;
 pub type SessionListener = std::os::unix::net::UnixListener;
 
+pub fn validate_session_socket_path(socket_path: &Path) -> Result<(), String> {
+    std::os::unix::net::SocketAddr::from_pathname(socket_path).map(|_| ()).map_err(|err| {
+        format!(
+            "Unix socket path {} is too long or otherwise unusable: {err}; set CLEAT_RUNTIME_DIR to a shorter persistent path",
+            socket_path.display()
+        )
+    })
+}
+
 pub fn connect_session_stream(socket_path: &Path) -> Result<SessionStream, String> {
     try_connect_session_stream(socket_path).map_err(|err| format!("connect {}: {err}", socket_path.display()))
 }

--- a/crates/cleat/src/platform/ipc/unsupported.rs
+++ b/crates/cleat/src/platform/ipc/unsupported.rs
@@ -36,6 +36,10 @@ pub fn connect_session_stream(_socket_path: &Path) -> Result<SessionStream, Stri
     Err("session IPC is only supported on Unix".to_string())
 }
 
+pub fn validate_session_socket_path(_socket_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
 pub fn try_connect_session_stream(_socket_path: &Path) -> io::Result<SessionStream> {
     Err(unsupported_io())
 }

--- a/crates/cleat/src/platform/ipc/windows.rs
+++ b/crates/cleat/src/platform/ipc/windows.rs
@@ -110,6 +110,10 @@ pub fn connect_session_stream(socket_path: &Path) -> Result<SessionStream, Strin
     try_connect_session_stream(socket_path).map_err(|err| format!("connect {}: {err}", socket_path.display()))
 }
 
+pub fn validate_session_socket_path(_socket_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
 pub fn try_connect_session_stream(socket_path: &Path) -> io::Result<SessionStream> {
     let pipe_name = pipe_name_from_marker_file(socket_path)?;
     let handle = open_pipe(&pipe_name)?;

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -1029,7 +1029,10 @@ pub unsafe extern "C" fn cleat_provider_open(desc: *const CleatProviderDesc) -> 
     };
     let runtime_root = match read_optional_utf8(requested.runtime_root, requested.runtime_root_len) {
         Ok(Some(path)) => PathBuf::from(path),
-        Ok(None) => RuntimeLayout::discover().root().to_path_buf(),
+        Ok(None) => match RuntimeLayout::discover() {
+            Ok(layout) => layout.root().to_path_buf(),
+            Err(_) => return ptr::null_mut(),
+        },
         Err(_) => return ptr::null_mut(),
     };
     let daemon_name = match read_optional_utf8(requested.daemon_name, requested.daemon_name_len) {

--- a/crates/cleat/src/runtime.rs
+++ b/crates/cleat/src/runtime.rs
@@ -51,16 +51,11 @@ pub struct RuntimeLayout {
 }
 
 impl RuntimeLayout {
-    pub fn discover() -> Self {
-        Self {
-            root: discover_runtime_root(
-                env::var_os("CLEAT_RUNTIME_DIR"),
-                env::var_os("XDG_RUNTIME_DIR"),
-                env::var_os("TMPDIR"),
-                env::temp_dir(),
-            ),
+    pub fn discover() -> Result<Self, String> {
+        Ok(Self {
+            root: discover_runtime_root(env::var_os("CLEAT_RUNTIME_DIR"), env::var_os("XDG_STATE_HOME"), platform_state_dir())?,
             daemon_name: DEFAULT_DAEMON_NAME.to_string(),
-        }
+        })
     }
 
     pub fn new(root: PathBuf) -> Self {
@@ -172,30 +167,29 @@ pub fn normalize_tags(tags: &mut Vec<String>) {
 
 fn discover_runtime_root(
     explicit_root: Option<std::ffi::OsString>,
-    xdg_runtime_dir: Option<std::ffi::OsString>,
-    tmpdir: Option<std::ffi::OsString>,
-    default_tmp: PathBuf,
-) -> PathBuf {
+    xdg_state_home: Option<std::ffi::OsString>,
+    platform_state_dir: Option<PathBuf>,
+) -> Result<PathBuf, String> {
     if let Some(explicit_root) = explicit_root {
-        return PathBuf::from(explicit_root);
+        return Ok(PathBuf::from(explicit_root));
     }
-    if let Some(xdg_runtime_dir) = xdg_runtime_dir {
-        return PathBuf::from(xdg_runtime_dir).join(SESSION_ROOT_DIR);
+    if let Some(xdg_state_home) = xdg_state_home.map(PathBuf::from).filter(|path| path.is_absolute()) {
+        return Ok(xdg_state_home.join(SESSION_ROOT_DIR));
     }
-    if let Some(tmpdir) = tmpdir {
-        return PathBuf::from(tmpdir).join(format!("{SESSION_ROOT_DIR}-{}", current_uid()));
+    if let Some(platform_state_dir) = platform_state_dir {
+        return Ok(platform_state_dir.join(SESSION_ROOT_DIR));
     }
-    default_tmp.join(format!("{SESSION_ROOT_DIR}-{}", current_uid()))
+    Err("unable to discover a persistent cleat state directory; set CLEAT_RUNTIME_DIR or an absolute XDG_STATE_HOME".to_string())
 }
 
-#[cfg(unix)]
-fn current_uid() -> u32 {
-    unsafe { libc::geteuid() }
+#[cfg(windows)]
+fn platform_state_dir() -> Option<PathBuf> {
+    env::var_os("LOCALAPPDATA").map(PathBuf::from).filter(|path| path.is_absolute())
 }
 
-#[cfg(not(unix))]
-fn current_uid() -> u32 {
-    0
+#[cfg(not(windows))]
+fn platform_state_dir() -> Option<PathBuf> {
+    env::var_os("HOME").map(PathBuf::from).filter(|path| path.is_absolute()).map(|home| home.join(".local/state"))
 }
 
 #[cfg(test)]
@@ -208,17 +202,38 @@ mod tests {
     fn discover_runtime_root_prefers_explicit_root() {
         let root = discover_runtime_root(
             Some(OsString::from("/custom/root")),
-            Some(OsString::from("/xdg/runtime")),
-            Some(OsString::from("/tmpdir")),
-            PathBuf::from("/tmp"),
-        );
+            Some(OsString::from("/xdg/state")),
+            Some(PathBuf::from("/home/test/.local/state")),
+        )
+        .expect("discover explicit root");
         assert_eq!(root, PathBuf::from("/custom/root"));
     }
 
     #[test]
-    fn discover_runtime_root_prefers_xdg_before_tmpdir() {
+    fn discover_runtime_root_prefers_xdg_state_home() {
+        let root = discover_runtime_root(None, Some(OsString::from("/xdg/state")), Some(PathBuf::from("/home/test/.local/state")))
+            .expect("discover XDG state home");
+        assert_eq!(root, PathBuf::from("/xdg/state/cleat"));
+    }
+
+    #[test]
+    fn discover_runtime_root_uses_platform_state_directory() {
         let root =
-            discover_runtime_root(None, Some(OsString::from("/xdg/runtime")), Some(OsString::from("/tmpdir")), PathBuf::from("/tmp"));
-        assert_eq!(root, PathBuf::from("/xdg/runtime/cleat"));
+            discover_runtime_root(None, None, Some(PathBuf::from("/home/test/.local/state"))).expect("discover platform state directory");
+        assert_eq!(root, PathBuf::from("/home/test/.local/state/cleat"));
+    }
+
+    #[test]
+    fn discover_runtime_root_ignores_relative_xdg_state_home() {
+        let root = discover_runtime_root(None, Some(OsString::from("relative/state")), Some(PathBuf::from("/home/test/.local/state")))
+            .expect("fall back from relative XDG state home");
+        assert_eq!(root, PathBuf::from("/home/test/.local/state/cleat"));
+    }
+
+    #[test]
+    fn discover_runtime_root_requires_a_persistent_state_directory() {
+        let err = discover_runtime_root(None, None, None).expect_err("discovery must not place daemon state in a temporary directory");
+        assert!(err.contains("CLEAT_RUNTIME_DIR"), "{err}");
+        assert!(err.contains("XDG_STATE_HOME"), "{err}");
     }
 }

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -72,8 +72,8 @@ impl SessionService {
         Self { layout }
     }
 
-    pub fn discover() -> Self {
-        Self::new(RuntimeLayout::discover())
+    pub fn discover() -> Result<Self, String> {
+        Ok(Self::new(RuntimeLayout::discover()?))
     }
 
     pub fn with_daemon(&self, daemon_name: String) -> Result<Self, String> {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -29,7 +29,7 @@ use crate::{
         daemon::{is_session_daemon_alive, spawn_daemon_process},
         ipc::{
             bind_session_listener, connect_session_stream, set_listener_nonblocking, set_stream_nonblocking, set_stream_write_timeout,
-            shutdown_stream, try_connect_session_stream, SessionStream,
+            shutdown_stream, try_connect_session_stream, validate_session_socket_path, SessionStream,
         },
         terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
@@ -801,6 +801,7 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
     let layout = RuntimeLayout::new(root.to_path_buf()).with_daemon(daemon_name.to_string())?;
     layout.ensure_daemon_dirs()?;
     let socket_path = layout.socket_path();
+    validate_session_socket_path(&socket_path)?;
     let listener = match bind_session_listener(&socket_path) {
         Ok(listener) => listener,
         Err(first_err) => {
@@ -2797,6 +2798,7 @@ fn wait_for_socket(path: &Path) -> Result<(), String> {
 }
 
 pub(crate) fn ensure_daemon_started(layout: &RuntimeLayout) -> Result<(), String> {
+    validate_session_socket_path(&layout.socket_path())?;
     if try_connect_session_stream(&layout.socket_path()).is_ok() && is_session_daemon_alive(layout.root(), layout.daemon_name()) {
         return Ok(());
     }

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -799,9 +799,9 @@ fn flush_watchers(watchers: &mut Vec<ActiveClient>) {
 #[cfg(any(unix, windows))]
 pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> {
     let layout = RuntimeLayout::new(root.to_path_buf()).with_daemon(daemon_name.to_string())?;
-    layout.ensure_daemon_dirs()?;
     let socket_path = layout.socket_path();
     validate_session_socket_path(&socket_path)?;
+    layout.ensure_daemon_dirs()?;
     let listener = match bind_session_listener(&socket_path) {
         Ok(listener) => listener,
         Err(first_err) => {

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -34,7 +34,7 @@ use cleat::{
     recording::{SessionRecorder, CAST_FILE_NAME},
     runtime::{RuntimeLayout, TerminalSize, DEFAULT_DAEMON_NAME},
     server::{EndBound, SessionService, StartBound},
-    session::{daemon_pid_path, ensure_session_started, session_socket_path, SessionStartOptions},
+    session::{daemon_pid_path, ensure_session_started, run_session_daemon, session_socket_path, SessionStartOptions},
     vt::{self, ClientCapabilities, ColorLevel, VtEngineKind},
 };
 #[cfg(feature = "ghostty-vt")]
@@ -2373,6 +2373,17 @@ fn overlong_daemon_socket_path_is_rejected_before_spawn() {
     assert!(started.elapsed() < Duration::from_secs(1), "socket path validation should fail before spawning a daemon");
     assert!(err.contains("Unix socket path"), "{err}");
     assert!(err.contains("CLEAT_RUNTIME_DIR"), "{err}");
+}
+
+#[test]
+fn direct_daemon_serve_rejects_overlong_socket_path_before_creating_directories() {
+    let temp = tempfile::Builder::new().prefix("cleat-socket-").tempdir_in("/tmp").expect("short-path tempdir");
+    let root = temp.path().join("x".repeat(120));
+
+    let err = run_session_daemon(&root, DEFAULT_DAEMON_NAME).expect_err("overlong daemon socket path should be rejected");
+
+    assert!(err.contains("Unix socket path"), "{err}");
+    assert!(!root.exists(), "socket validation should run before creating daemon directories");
 }
 
 #[cfg(feature = "ghostty-vt")]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -2359,6 +2359,71 @@ fn daemon_exits_when_pid_file_names_another_process() {
     wait_for_daemon_exit(pid, "daemon should exit after losing its pid-file registration");
 }
 
+#[test]
+fn overlong_daemon_socket_path_is_rejected_before_spawn() {
+    let temp = tempfile::Builder::new().prefix("cleat-socket-").tempdir_in("/tmp").expect("short-path tempdir");
+    let root = temp.path().join("x".repeat(120));
+    let service = service_for(&root);
+
+    let started = Instant::now();
+    let err = service
+        .create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("cat".into()), false)
+        .expect_err("overlong daemon socket path should be rejected");
+
+    assert!(started.elapsed() < Duration::from_secs(1), "socket path validation should fail before spawning a daemon");
+    assert!(err.contains("Unix socket path"), "{err}");
+    assert!(err.contains("CLEAT_RUNTIME_DIR"), "{err}");
+}
+
+#[cfg(feature = "ghostty-vt")]
+fn isolated_discovery_command(cleat_bin: &str, home: &std::path::Path, tmpdir: &std::path::Path) -> Command {
+    let mut command = Command::new(cleat_bin);
+    command
+        .env("HOME", home)
+        .env("TMPDIR", tmpdir)
+        .env_remove("CLEAT_RUNTIME_DIR")
+        .env_remove("XDG_RUNTIME_DIR")
+        .env_remove("XDG_STATE_HOME");
+    command
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn discovered_state_root_survives_legacy_tmpdir_registration_purge() {
+    let temp = tempfile::Builder::new().prefix("cleat-154-").tempdir_in("/tmp").expect("short-path tempdir");
+    let home = temp.path().join("home");
+    let tmpdir = temp.path().join("tmp");
+    std::fs::create_dir_all(&home).expect("create isolated home");
+    std::fs::create_dir_all(&tmpdir).expect("create isolated tmpdir");
+
+    let cleat_bin = std::env::var("CARGO_BIN_EXE_cleat").expect("cleat bin");
+    let mut command = isolated_discovery_command(&cleat_bin, &home, &tmpdir);
+    command.args(["--server", "issue154-state-root", "launch", "alpha", "--vt", "ghostty", "--cmd", "cat", "--record", "--json"]);
+    let output = command.output().expect("launch through discovered runtime root");
+    assert!(output.status.success(), "launch failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    let state_daemon_dir = home.join(".local/state/cleat/issue154-state-root");
+    assert!(state_daemon_dir.join("daemon.pid").exists(), "daemon registration should live in persistent state");
+    assert!(state_daemon_dir.join("sessions/alpha/session.cast").exists(), "recording should live in persistent state");
+
+    let legacy_root = tmpdir.join(format!("cleat-{}", unsafe { libc::geteuid() }));
+    if legacy_root.exists() {
+        std::fs::remove_dir_all(&legacy_root).expect("simulate purging the legacy TMPDIR runtime root");
+    }
+
+    std::thread::sleep(Duration::from_millis(2_500));
+
+    let mut inspect = isolated_discovery_command(&cleat_bin, &home, &tmpdir);
+    inspect.args(["--server", "issue154-state-root", "inspect", "alpha", "--json"]);
+    let output = inspect.output().expect("inspect session after legacy TMPDIR purge");
+    assert!(output.status.success(), "session did not survive legacy TMPDIR purge: {}", String::from_utf8_lossy(&output.stderr));
+
+    let mut kill = isolated_discovery_command(&cleat_bin, &home, &tmpdir);
+    kill.args(["--server", "issue154-state-root", "kill", "alpha"]);
+    let output = kill.output().expect("kill surviving test session");
+    assert!(output.status.success(), "kill failed: {}", String::from_utf8_lossy(&output.stderr));
+}
+
 /// The daemon is our direct child, so poll with waitpid rather than
 /// kill(pid, 0): an exited-but-unreaped zombie still answers signals.
 fn wait_for_daemon_exit(pid: i32, message: &str) {


### PR DESCRIPTION
## Summary

- move the discovered daemon root from purgeable runtime/temp storage to persistent user state
- keep daemon registration, recordings, and session state together while rejecting unusable Unix socket paths before spawn
- fail actionably when no persistent state directory is discoverable instead of silently falling back to temp
- add a regression proving a legacy TMPDIR purge does not terminate a state-hosted session

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `CLEAT_GHOSTTY_PREFIX=/Users/robert/dev/cleat/.tools/ghostty-install cargo test -p cleat --locked --features ghostty-vt`

Closes #154
