### PR TITLE
Subscribe to screen activity transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Four surfaces cooperate during a session. Knowing which surface is authoritative
 - **Host terminal** — your real terminal emulator (kitty, ghostty, iTerm, Terminal.app, etc). In play *only while a client is attached*. Renders output to you, supplies keyboard input, and answers the child's capability queries (DA, DSR, kitty/sixel protocol queries) with whatever the host terminal actually supports.
 - **VT engine** — cleat's internal terminal emulator (libghostty with `--features ghostty-vt`; the `passthrough` engine is a placeholder for testing). Always active. Parses child PTY output into a structured screen grid, tracks modes/cursor/styles, and — when *detached* — synthesizes replies to capability queries so the child's detection logic doesn't stall.
 - **Recording** — default-on raw PTY output tee, stored as asciicast v3 in `session.cast`. Authoritative source for `transcript` and `expect`.
-- **Packet surface** — structured multiplexed control/render/directory protocol. `cleat packets` exposes the raw probe surface, and `cleat list --watch` uses the directory subscription to print a snapshot followed by lifecycle deltas.
+- **Packet surface** — structured multiplexed control/render/directory protocol. `cleat packets` exposes the raw probe surface, and `cleat list --watch` uses the directory subscription to print a snapshot followed by lifecycle deltas. Rust clients can use `SessionService::connect_activity` to subscribe once for every session matching a tag selector: the stream starts with an activity snapshot, then emits threshold-based `active`/`stable` transitions and membership changes with session IDs, tags, and Unix-millisecond timestamps.
 
 ### Command Map
 

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -220,6 +220,8 @@ pub(crate) struct SessionListResponse {
 pub(crate) struct DirectorySubscribeRequest {
     #[serde(default)]
     pub selectors: Vec<String>,
+    #[serde(default)]
+    pub screen_activity_stable_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -217,7 +217,7 @@ pub(crate) struct SessionListResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub(crate) struct DirectorySubscribeRequest {
+pub(crate) struct PacketSubscribeRequest {
     #[serde(default)]
     pub selectors: Vec<String>,
     #[serde(default)]

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -80,6 +80,7 @@ pub enum ScreenActivity {
     Stable,
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ActivitySession {
     pub session_id: String,
@@ -100,6 +101,7 @@ pub struct ActivitySnapshot {
     pub sessions: Vec<ActivitySession>,
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ActivityEvent {
     ActivityChanged { session: ActivitySession, changed_at_unix_ms: u64 },

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -87,8 +87,8 @@ pub struct ActivitySession {
     pub tags: Vec<String>,
     pub activity: ScreenActivity,
     /// Unix timestamp in milliseconds for the beginning of the current quiet
-    /// window. It remains populated while activity is `Active`; the threshold
-    /// determines when that window becomes `Stable`.
+    /// window. While activity is `Active`, this is the quiet window that will
+    /// become `Stable` once the configured threshold elapses.
     pub stable_since_unix_ms: u64,
     /// Unix timestamp in milliseconds for the most recently observed render
     /// generation change, or `None` before the session has rendered.
@@ -440,5 +440,34 @@ mod tests {
         let err = client.read_render(7).expect_err("control error should surface");
         assert_eq!(err.kind(), ErrorKind::InvalidData);
         assert_eq!(err.to_string(), "bad channel");
+    }
+
+    #[test]
+    fn packet_client_reads_activity_events() {
+        let event = ActivityEvent::MembershipAdded {
+            session: ActivitySession {
+                session_id: "alpha".to_string(),
+                tags: vec!["role=impl".to_string()],
+                activity: ScreenActivity::Active,
+                stable_since_unix_ms: 1_000,
+                last_output_at_unix_ms: Some(1_000),
+            },
+            changed_at_unix_ms: 1_000,
+        };
+        let mut bytes = Vec::new();
+        PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_DELTA, &DirectoryDelta {
+            upserted: Vec::new(),
+            removed_session_ids: Vec::new(),
+        })
+        .expect("encode unrelated delta")
+        .write(&mut bytes)
+        .expect("write unrelated delta");
+        PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_ACTIVITY_EVENT, &event)
+            .expect("encode activity event")
+            .write(&mut bytes)
+            .expect("write activity event");
+        let mut client = PacketClient::new(std::io::Cursor::new(bytes));
+
+        assert_eq!(client.read_activity_event().expect("read activity event"), event);
     }
 }

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::provider::{TerminalInputEvent, TerminalRenderUpdate};
 
-pub const PROTOCOL_VERSION: u16 = 2;
+pub const PROTOCOL_VERSION: u16 = 3;
 pub const CHANNEL_CONTROL: u32 = 0;
 
 pub const MSG_CONTROL_HELLO: u8 = 1;
@@ -13,6 +13,8 @@ pub const MSG_CONTROL_DIRECTORY_DELTA: u8 = 3;
 pub const MSG_CONTROL_OPEN_CHANNEL: u8 = 4;
 pub const MSG_CONTROL_CLOSE_CHANNEL: u8 = 5;
 pub const MSG_CONTROL_ERROR: u8 = 6;
+pub const MSG_CONTROL_ACTIVITY_SNAPSHOT: u8 = 7;
+pub const MSG_CONTROL_ACTIVITY_EVENT: u8 = 8;
 
 pub const MSG_SESSION_RENDER: u8 = 16;
 pub const MSG_SESSION_ACK: u8 = 17;
@@ -69,6 +71,40 @@ pub struct DirectoryEntry {
     pub recreatable: bool,
     pub cols: u16,
     pub rows: u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScreenActivity {
+    Active,
+    Stable,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivitySession {
+    pub session_id: String,
+    pub tags: Vec<String>,
+    pub activity: ScreenActivity,
+    /// Unix timestamp in milliseconds for the beginning of the current quiet
+    /// window. It remains populated while activity is `Active`; the threshold
+    /// determines when that window becomes `Stable`.
+    pub stable_since_unix_ms: u64,
+    /// Unix timestamp in milliseconds for the most recently observed render
+    /// generation change, or `None` before the session has rendered.
+    pub last_output_at_unix_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivitySnapshot {
+    pub stable_threshold_ms: u64,
+    pub sessions: Vec<ActivitySession>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActivityEvent {
+    ActivityChanged { session: ActivitySession, changed_at_unix_ms: u64 },
+    MembershipAdded { session: ActivitySession, changed_at_unix_ms: u64 },
+    MembershipRemoved { session_id: String, tags: Vec<String>, changed_at_unix_ms: u64 },
 }
 
 /// Attachment role of a session channel. One controller per session across
@@ -284,6 +320,15 @@ impl<S: Read + Write> PacketClient<S> {
         loop {
             let frame = self.read_frame()?;
             if frame.channel == CHANNEL_CONTROL && frame.msg_type == MSG_CONTROL_DIRECTORY_DELTA {
+                return frame.decode();
+            }
+        }
+    }
+
+    pub fn read_activity_event(&mut self) -> std::io::Result<ActivityEvent> {
+        loop {
+            let frame = self.read_frame()?;
+            if frame.channel == CHANNEL_CONTROL && frame.msg_type == MSG_CONTROL_ACTIVITY_EVENT {
                 return frame.decode();
             }
         }

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -559,7 +559,7 @@ impl Drop for DaemonConnection {
 pub(crate) fn connect_packet_stream(layout: &RuntimeLayout, selectors: &[String]) -> Result<(SessionStream, DirectorySnapshot), String> {
     let socket_path = layout.socket_path();
     let mut stream = try_connect_session_stream(&socket_path).map_err(|err| format!("connect {}: {err}", socket_path.display()))?;
-    let body = serde_json::to_vec(&http_uds::DirectorySubscribeRequest { selectors: selectors.to_vec() })
+    let body = serde_json::to_vec(&http_uds::DirectorySubscribeRequest { selectors: selectors.to_vec(), screen_activity_stable_ms: None })
         .map_err(|err| format!("serialize packet subscribe request: {err}"))?;
     let head = format!(
         "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n",

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -559,7 +559,7 @@ impl Drop for DaemonConnection {
 pub(crate) fn connect_packet_stream(layout: &RuntimeLayout, selectors: &[String]) -> Result<(SessionStream, DirectorySnapshot), String> {
     let socket_path = layout.socket_path();
     let mut stream = try_connect_session_stream(&socket_path).map_err(|err| format!("connect {}: {err}", socket_path.display()))?;
-    let body = serde_json::to_vec(&http_uds::DirectorySubscribeRequest { selectors: selectors.to_vec(), screen_activity_stable_ms: None })
+    let body = serde_json::to_vec(&http_uds::PacketSubscribeRequest { selectors: selectors.to_vec(), screen_activity_stable_ms: None })
         .map_err(|err| format!("serialize packet subscribe request: {err}"))?;
     let head = format!(
         "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n",

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -496,11 +496,35 @@ impl SessionService {
         &self,
         selectors: &[String],
     ) -> Result<(crate::packet::PacketClient<SessionStream>, crate::packet::DirectorySnapshot), String> {
+        let (client, directory, _) = self.connect_subscription(selectors, None)?;
+        Ok((client, directory))
+    }
+
+    pub fn connect_activity(
+        &self,
+        selectors: &[String],
+        stable_threshold: Duration,
+    ) -> Result<(crate::packet::PacketClient<SessionStream>, crate::packet::ActivitySnapshot), String> {
+        let stable_threshold_ms = u64::try_from(stable_threshold.as_millis())
+            .map_err(|_| "screen activity stability threshold exceeds u64 milliseconds".to_string())?;
+        let (client, _, activity) = self.connect_subscription(selectors, Some(stable_threshold_ms))?;
+        let activity = activity.ok_or_else(|| "packet stream did not send an activity snapshot".to_string())?;
+        Ok((client, activity))
+    }
+
+    fn connect_subscription(
+        &self,
+        selectors: &[String],
+        screen_activity_stable_ms: Option<u64>,
+    ) -> Result<
+        (crate::packet::PacketClient<SessionStream>, crate::packet::DirectorySnapshot, Option<crate::packet::ActivitySnapshot>),
+        String,
+    > {
         crate::session::ensure_daemon_started(&self.layout)?;
 
         let socket_path = self.layout.socket_path();
         let mut stream = connect_session_socket(&socket_path)?;
-        let body = serde_json::to_vec(&http_uds::DirectorySubscribeRequest { selectors: selectors.to_vec() })
+        let body = serde_json::to_vec(&http_uds::DirectorySubscribeRequest { selectors: selectors.to_vec(), screen_activity_stable_ms })
             .map_err(|err| format!("serialize directory subscribe request: {err}"))?;
         write!(
             stream,
@@ -529,7 +553,16 @@ impl SessionService {
             return Err("packet stream did not send a directory snapshot after hello".to_string());
         }
         let directory = directory.decode::<crate::packet::DirectorySnapshot>().map_err(|err| format!("decode packet directory: {err}"))?;
-        Ok((client, directory))
+        let activity = if screen_activity_stable_ms.is_some() {
+            let frame = client.read_frame().map_err(|err| format!("read packet activity snapshot: {err}"))?;
+            if frame.channel != crate::packet::CHANNEL_CONTROL || frame.msg_type != crate::packet::MSG_CONTROL_ACTIVITY_SNAPSHOT {
+                return Err("packet stream did not send an activity snapshot after the directory".to_string());
+            }
+            Some(frame.decode::<crate::packet::ActivitySnapshot>().map_err(|err| format!("decode packet activity snapshot: {err}"))?)
+        } else {
+            None
+        };
+        Ok((client, directory, activity))
     }
 
     pub fn inspect(&self, id: &str) -> Result<crate::protocol::InspectResult, String> {

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -531,14 +531,14 @@ impl SessionService {
         let socket_path = self.layout.socket_path();
         let mut stream = connect_session_socket(&socket_path)?;
         let body = serde_json::to_vec(&http_uds::PacketSubscribeRequest { selectors: selectors.to_vec(), screen_activity_stable_ms })
-            .map_err(|err| format!("serialize directory subscribe request: {err}"))?;
+            .map_err(|err| format!("serialize packet subscription request: {err}"))?;
         write!(
             stream,
             "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n",
             body.len()
         )
         .map_err(|err| format!("write packet upgrade request: {err}"))?;
-        stream.write_all(&body).map_err(|err| format!("write directory subscribe request: {err}"))?;
+        stream.write_all(&body).map_err(|err| format!("write packet subscription request: {err}"))?;
         let response = http_uds::read_response_head(&mut stream).map_err(|err| format!("read packet upgrade response: {err}"))?;
         if response.status != StatusCode::SWITCHING_PROTOCOLS {
             return Err(format!("unexpected packet response: {}", response.status));

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -505,8 +505,14 @@ impl SessionService {
         selectors: &[String],
         stable_threshold: Duration,
     ) -> Result<(crate::packet::PacketClient<SessionStream>, crate::packet::ActivitySnapshot), String> {
+        if stable_threshold.is_zero() {
+            return Err("screen activity stability threshold must be greater than zero".to_string());
+        }
         let stable_threshold_ms = u64::try_from(stable_threshold.as_millis())
             .map_err(|_| "screen activity stability threshold exceeds u64 milliseconds".to_string())?;
+        if stable_threshold_ms == 0 {
+            return Err("screen activity stability threshold must be at least one millisecond".to_string());
+        }
         let (client, _, activity) = self.connect_subscription(selectors, Some(stable_threshold_ms))?;
         let activity = activity.ok_or_else(|| "packet stream did not send an activity snapshot".to_string())?;
         Ok((client, activity))
@@ -524,7 +530,7 @@ impl SessionService {
 
         let socket_path = self.layout.socket_path();
         let mut stream = connect_session_socket(&socket_path)?;
-        let body = serde_json::to_vec(&http_uds::DirectorySubscribeRequest { selectors: selectors.to_vec(), screen_activity_stable_ms })
+        let body = serde_json::to_vec(&http_uds::PacketSubscribeRequest { selectors: selectors.to_vec(), screen_activity_stable_ms })
             .map_err(|err| format!("serialize directory subscribe request: {err}"))?;
         write!(
             stream,

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -499,28 +499,77 @@ struct ScreenActivityTracker {
     render_generation: u64,
     stable_since: Instant,
     stable_since_unix_ms: u64,
+    last_output_at: Option<Instant>,
     last_output_at_unix_ms: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ActivityTime {
+    instant: Instant,
+    unix_ms: u64,
+}
+
+impl ActivityTime {
+    fn now() -> Self {
+        Self { instant: Instant::now(), unix_ms: unix_time_ms() }
+    }
+
+    fn unix_ms_for(self, earlier: Instant) -> u64 {
+        let elapsed_ms = self.instant.checked_duration_since(earlier).map(|elapsed| elapsed.as_millis()).unwrap_or(0);
+        self.unix_ms.saturating_sub(u64::try_from(elapsed_ms).unwrap_or(u64::MAX))
+    }
 }
 
 impl ScreenActivityTracker {
     fn new(render_generation: u64) -> Self {
-        let now = Instant::now();
-        Self { render_generation, stable_since: now, stable_since_unix_ms: unix_time_ms(), last_output_at_unix_ms: None }
+        Self::new_at(render_generation, ActivityTime::now())
     }
 
-    fn observe(&mut self, render_generation: u64) {
+    fn new_at(render_generation: u64, now: ActivityTime) -> Self {
+        Self {
+            render_generation,
+            stable_since: now.instant,
+            stable_since_unix_ms: now.unix_ms,
+            last_output_at: None,
+            last_output_at_unix_ms: None,
+        }
+    }
+
+    fn needs_observation(&self, render_generation: u64) -> bool {
+        render_generation != self.render_generation
+    }
+
+    fn observe(&mut self, render_generation: u64, last_output_at: Option<Instant>) {
+        self.observe_at(render_generation, last_output_at, ActivityTime::now());
+    }
+
+    fn observe_at(&mut self, render_generation: u64, last_output_at: Option<Instant>, observed_at: ActivityTime) {
         if render_generation == self.render_generation {
             return;
         }
-        let now_unix_ms = unix_time_ms();
         self.render_generation = render_generation;
-        self.stable_since = Instant::now();
-        self.stable_since_unix_ms = now_unix_ms;
-        self.last_output_at_unix_ms = Some(now_unix_ms);
+        if last_output_at == self.last_output_at {
+            return;
+        }
+        let Some(last_output_at) = last_output_at else {
+            return;
+        };
+        let last_output_at_unix_ms = observed_at.unix_ms_for(last_output_at);
+        self.stable_since = last_output_at;
+        self.stable_since_unix_ms = last_output_at_unix_ms;
+        self.last_output_at = Some(last_output_at);
+        self.last_output_at_unix_ms = Some(last_output_at_unix_ms);
     }
 
     fn session(&self, session_id: String, tags: Vec<String>, stable_threshold_ms: u64) -> ActivitySession {
-        let stable_for_ms = u64::try_from(self.stable_since.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.session_at(session_id, tags, stable_threshold_ms, Instant::now())
+    }
+
+    fn session_at(&self, session_id: String, tags: Vec<String>, stable_threshold_ms: u64, observed_at: Instant) -> ActivitySession {
+        let stable_for_ms = observed_at
+            .checked_duration_since(self.stable_since)
+            .map(|elapsed| u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
+            .unwrap_or(0);
         let activity = if stable_for_ms >= stable_threshold_ms { ScreenActivity::Stable } else { ScreenActivity::Active };
         ActivitySession {
             session_id,
@@ -601,6 +650,18 @@ impl HostedSession {
             screen_activity,
             should_keep_session_dir,
         })
+    }
+
+    fn observe_screen_activity(&mut self) -> Result<(), String> {
+        let render_generation = self.actor.observation().render_generation();
+        if self.screen_activity.needs_observation(render_generation) {
+            self.screen_activity.observe(render_generation, self.actor.last_pty_output_at()?);
+        }
+        Ok(())
+    }
+
+    fn activity_session(&self, stable_threshold_ms: u64) -> ActivitySession {
+        self.screen_activity.session(self.metadata.id.clone(), self.metadata.tags.clone(), stable_threshold_ms)
     }
 }
 
@@ -1148,20 +1209,25 @@ fn activity_snapshot_for_sessions(
     sessions: &mut HashMap<String, HostedSession>,
     selectors: &[String],
     stable_threshold_ms: u64,
-) -> ActivitySnapshot {
-    let mut activity_sessions = Vec::new();
+) -> Result<ActivitySnapshot, String> {
     for hosted in sessions.values_mut() {
-        hosted.screen_activity.observe(hosted.actor.observation().render_generation());
-        if selectors.iter().all(|selector| hosted.metadata.tags.contains(selector)) {
-            activity_sessions.push(hosted.screen_activity.session(
-                hosted.metadata.id.clone(),
-                hosted.metadata.tags.clone(),
-                stable_threshold_ms,
-            ));
-        }
+        hosted.observe_screen_activity()?;
     }
+    Ok(ActivitySnapshot { stable_threshold_ms, sessions: matching_activity_sessions(sessions, selectors, stable_threshold_ms) })
+}
+
+fn matching_activity_sessions(
+    sessions: &HashMap<String, HostedSession>,
+    selectors: &[String],
+    stable_threshold_ms: u64,
+) -> Vec<ActivitySession> {
+    let mut activity_sessions = sessions
+        .values()
+        .filter(|hosted| selectors.iter().all(|selector| hosted.metadata.tags.contains(selector)))
+        .map(|hosted| hosted.activity_session(stable_threshold_ms))
+        .collect::<Vec<_>>();
     activity_sessions.sort_by(|left, right| left.session_id.cmp(&right.session_id));
-    ActivitySnapshot { stable_threshold_ms, sessions: activity_sessions }
+    activity_sessions
 }
 
 fn service_activity_subscriptions(sessions: &HashMap<String, HostedSession>, packet_clients: &mut Vec<PacketClient>) -> Result<(), String> {
@@ -1169,12 +1235,7 @@ fn service_activity_subscriptions(sessions: &HashMap<String, HostedSession>, pac
         let Some(stable_threshold_ms) = client.screen_activity_stable_ms else {
             continue;
         };
-        let mut current = sessions
-            .values()
-            .filter(|hosted| client.selectors.iter().all(|selector| hosted.metadata.tags.contains(selector)))
-            .map(|hosted| hosted.screen_activity.session(hosted.metadata.id.clone(), hosted.metadata.tags.clone(), stable_threshold_ms))
-            .collect::<Vec<_>>();
-        current.sort_by(|left, right| left.session_id.cmp(&right.session_id));
+        let current = matching_activity_sessions(sessions, &client.selectors, stable_threshold_ms);
 
         let current_ids = current.iter().map(|session| session.session_id.clone()).collect::<HashSet<_>>();
         for session in current {
@@ -1182,10 +1243,16 @@ fn service_activity_subscriptions(sessions: &HashMap<String, HostedSession>, pac
             let added = prior.is_none();
             let changed = prior.is_some_and(|known| known.activity != session.activity);
             client.known_activity_sessions.insert(session.session_id.clone(), session.clone());
-            let changed_at_unix_ms = unix_time_ms();
             if added {
-                client.enqueue_control(MSG_CONTROL_ACTIVITY_EVENT, &ActivityEvent::MembershipAdded { session, changed_at_unix_ms })?;
+                client.enqueue_control(MSG_CONTROL_ACTIVITY_EVENT, &ActivityEvent::MembershipAdded {
+                    session,
+                    changed_at_unix_ms: unix_time_ms(),
+                })?;
             } else if changed {
+                let changed_at_unix_ms = match session.activity {
+                    ScreenActivity::Active => session.last_output_at_unix_ms.unwrap_or(session.stable_since_unix_ms),
+                    ScreenActivity::Stable => session.stable_since_unix_ms.saturating_add(stable_threshold_ms),
+                };
                 client.enqueue_control(MSG_CONTROL_ACTIVITY_EVENT, &ActivityEvent::ActivityChanged { session, changed_at_unix_ms })?;
             }
         }
@@ -1334,7 +1401,7 @@ fn service_hosted_session(
     }
     flush_watchers(&mut hosted.watchers);
     push_due_packet_renders(id, &hosted.actor, packet_clients, &mut hosted.packet_render_cache)?;
-    hosted.screen_activity.observe(hosted.actor.observation().render_generation());
+    hosted.observe_screen_activity()?;
 
     if resized || previous_controller_count != hosted.active_client.is_some() || previous_watcher_count != hosted.watchers.len() {
         broadcast_directory_upsert(directory_entry_for_session(layout, hosted, packet_clients)?, packet_clients)?;
@@ -1638,16 +1705,22 @@ fn handle_http_request(
             }
 
             let subscribe = if request.body().is_empty() {
-                http_uds::DirectorySubscribeRequest::default()
+                http_uds::PacketSubscribeRequest::default()
             } else {
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP directory subscribe request: {err}"))?
             };
+            if subscribe.screen_activity_stable_ms == Some(0) {
+                http_uds::write_error(stream, StatusCode::BAD_REQUEST, "screen activity stability threshold must be greater than zero")
+                    .map_err(|err| format!("write HTTP activity subscribe error: {err}"))?;
+                return Ok(());
+            }
             let mut selectors = subscribe.selectors;
             crate::runtime::normalize_tags(&mut selectors);
             let directory = directory_snapshot_for_sessions(state.layout, state.sessions, state.packet_clients, &selectors)?;
             let activity = subscribe
                 .screen_activity_stable_ms
-                .map(|stable_threshold_ms| activity_snapshot_for_sessions(state.sessions, &selectors, stable_threshold_ms));
+                .map(|stable_threshold_ms| activity_snapshot_for_sessions(state.sessions, &selectors, stable_threshold_ms))
+                .transpose()?;
             let packet_stream = stream.try_clone().map_err(|err| format!("clone HTTP packet stream: {err}"))?;
             #[cfg(unix)]
             set_stream_nonblocking(&packet_stream, true).map_err(|err| format!("set HTTP packet stream nonblocking: {err}"))?;
@@ -3284,6 +3357,25 @@ mod tests {
         assert!(!super::screen_stable_needs_snapshot(7, Some(7)));
         // A pump advanced the generation: re-fingerprint.
         assert!(super::screen_stable_needs_snapshot(8, Some(7)));
+    }
+
+    #[test]
+    fn screen_activity_only_resets_for_new_pty_output() {
+        let started_at = Instant::now();
+        let mut tracker = super::ScreenActivityTracker::new_at(1, super::ActivityTime { instant: started_at, unix_ms: 1_000 });
+
+        tracker.observe_at(2, None, super::ActivityTime { instant: started_at + Duration::from_millis(20), unix_ms: 1_020 });
+        let unchanged = tracker.session_at("alpha".to_string(), Vec::new(), 10, started_at + Duration::from_millis(20));
+        assert_eq!(unchanged.activity, crate::packet::ScreenActivity::Stable);
+        assert_eq!(unchanged.stable_since_unix_ms, 1_000);
+        assert_eq!(unchanged.last_output_at_unix_ms, None);
+
+        let output_at = started_at + Duration::from_millis(30);
+        tracker.observe_at(3, Some(output_at), super::ActivityTime { instant: started_at + Duration::from_millis(35), unix_ms: 1_035 });
+        let active = tracker.session_at("alpha".to_string(), Vec::new(), 10, started_at + Duration::from_millis(35));
+        assert_eq!(active.activity, crate::packet::ScreenActivity::Active);
+        assert_eq!(active.stable_since_unix_ms, 1_030);
+        assert_eq!(active.last_output_at_unix_ms, Some(1_030));
     }
 
     #[test]

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1232,6 +1232,9 @@ fn matching_activity_sessions(
 
 fn service_activity_subscriptions(sessions: &HashMap<String, HostedSession>, packet_clients: &mut Vec<PacketClient>) -> Result<(), String> {
     for client in packet_clients {
+        if client.dead {
+            continue;
+        }
         let Some(stable_threshold_ms) = client.screen_activity_stable_ms else {
             continue;
         };

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -11,7 +11,7 @@ use std::{
         Arc, Mutex,
     },
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use http::StatusCode;
@@ -20,8 +20,9 @@ use crate::{
     host::actor::{RawOutputRecovery, RawOutputReplay, RawOutputTap, SessionActor, SessionMouseEvent, SessionWheelEvent},
     http_uds,
     packet::{
-        Ack, ChannelRole, CloseChannel, ControlError, ControlHello, DirectoryDelta, DirectoryEntry, DirectorySnapshot, Input, OpenChannel,
-        PacketFrame, RenderPacket, Resize, RoleRequest, RoleState, CHANNEL_CONTROL, MSG_CONTROL_CLOSE_CHANNEL, MSG_CONTROL_DIRECTORY_DELTA,
+        Ack, ActivityEvent, ActivitySession, ActivitySnapshot, ChannelRole, CloseChannel, ControlError, ControlHello, DirectoryDelta,
+        DirectoryEntry, DirectorySnapshot, Input, OpenChannel, PacketFrame, RenderPacket, Resize, RoleRequest, RoleState, ScreenActivity,
+        CHANNEL_CONTROL, MSG_CONTROL_ACTIVITY_EVENT, MSG_CONTROL_ACTIVITY_SNAPSHOT, MSG_CONTROL_CLOSE_CHANNEL, MSG_CONTROL_DIRECTORY_DELTA,
         MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_ERROR, MSG_CONTROL_HELLO, MSG_CONTROL_OPEN_CHANNEL, MSG_SESSION_ACK, MSG_SESSION_INPUT,
         MSG_SESSION_RENDER, MSG_SESSION_RESIZE, MSG_SESSION_ROLE, MSG_SESSION_VIEWPORT,
     },
@@ -493,6 +494,51 @@ impl ScreenStableState {
     }
 }
 
+#[derive(Clone, Debug)]
+struct ScreenActivityTracker {
+    render_generation: u64,
+    stable_since: Instant,
+    stable_since_unix_ms: u64,
+    last_output_at_unix_ms: Option<u64>,
+}
+
+impl ScreenActivityTracker {
+    fn new(render_generation: u64) -> Self {
+        let now = Instant::now();
+        Self { render_generation, stable_since: now, stable_since_unix_ms: unix_time_ms(), last_output_at_unix_ms: None }
+    }
+
+    fn observe(&mut self, render_generation: u64) {
+        if render_generation == self.render_generation {
+            return;
+        }
+        let now_unix_ms = unix_time_ms();
+        self.render_generation = render_generation;
+        self.stable_since = Instant::now();
+        self.stable_since_unix_ms = now_unix_ms;
+        self.last_output_at_unix_ms = Some(now_unix_ms);
+    }
+
+    fn session(&self, session_id: String, tags: Vec<String>, stable_threshold_ms: u64) -> ActivitySession {
+        let stable_for_ms = u64::try_from(self.stable_since.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let activity = if stable_for_ms >= stable_threshold_ms { ScreenActivity::Stable } else { ScreenActivity::Active };
+        ActivitySession {
+            session_id,
+            tags,
+            activity,
+            stable_since_unix_ms: self.stable_since_unix_ms,
+            last_output_at_unix_ms: self.last_output_at_unix_ms,
+        }
+    }
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
 struct PendingExpect {
     stream: SessionStream,
     text: String,
@@ -526,6 +572,7 @@ struct HostedSession {
     /// Render generation at the last screen-stable fingerprint snapshot; lets
     /// the servicing loop skip full-grid snapshots while nothing has rendered.
     screen_stable_snapshot_generation: Option<u64>,
+    screen_activity: ScreenActivityTracker,
     should_keep_session_dir: bool,
 }
 
@@ -538,6 +585,7 @@ impl HostedSession {
             crate::session_runtime::SessionRuntime::spawn(actor_session_dir, &actor_session, default_vt_engine(&actor_session)?)
         })?;
         let raw_output_tap = actor.subscribe_raw_output()?;
+        let screen_activity = ScreenActivityTracker::new(actor.observation().render_generation());
         Ok(Self {
             metadata: session,
             actor,
@@ -550,6 +598,7 @@ impl HostedSession {
             pending_waits: Vec::new(),
             pending_expects: Vec::new(),
             screen_stable_snapshot_generation: None,
+            screen_activity,
             should_keep_session_dir,
         })
     }
@@ -960,8 +1009,6 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
             }
         }
 
-        flush_packet_clients(&mut packet_clients);
-
         if let Some(session_id) = faulted_session.take() {
             cleanup_exited_session(&layout, &session_id, true);
             broadcast_directory_remove(&session_id, &mut packet_clients)?;
@@ -975,6 +1022,9 @@ pub fn run_session_daemon(root: &Path, daemon_name: &str) -> Result<(), String> 
             sessions.remove(&session_id);
             remove_packet_channels_for_session(&session_id, &mut packet_clients);
         }
+
+        service_activity_subscriptions(&sessions, &mut packet_clients)?;
+        flush_packet_clients(&mut packet_clients);
 
         if sessions.is_empty() {
             let idle_started = idle_since.get_or_insert_with(Instant::now);
@@ -1092,6 +1142,69 @@ fn directory_snapshot_for_sessions(
     }
     entries.sort_by(|a, b| a.session_id.cmp(&b.session_id));
     Ok(DirectorySnapshot { sessions: entries })
+}
+
+fn activity_snapshot_for_sessions(
+    sessions: &mut HashMap<String, HostedSession>,
+    selectors: &[String],
+    stable_threshold_ms: u64,
+) -> ActivitySnapshot {
+    let mut activity_sessions = Vec::new();
+    for hosted in sessions.values_mut() {
+        hosted.screen_activity.observe(hosted.actor.observation().render_generation());
+        if selectors.iter().all(|selector| hosted.metadata.tags.contains(selector)) {
+            activity_sessions.push(hosted.screen_activity.session(
+                hosted.metadata.id.clone(),
+                hosted.metadata.tags.clone(),
+                stable_threshold_ms,
+            ));
+        }
+    }
+    activity_sessions.sort_by(|left, right| left.session_id.cmp(&right.session_id));
+    ActivitySnapshot { stable_threshold_ms, sessions: activity_sessions }
+}
+
+fn service_activity_subscriptions(sessions: &HashMap<String, HostedSession>, packet_clients: &mut Vec<PacketClient>) -> Result<(), String> {
+    for client in packet_clients {
+        let Some(stable_threshold_ms) = client.screen_activity_stable_ms else {
+            continue;
+        };
+        let mut current = sessions
+            .values()
+            .filter(|hosted| client.selectors.iter().all(|selector| hosted.metadata.tags.contains(selector)))
+            .map(|hosted| hosted.screen_activity.session(hosted.metadata.id.clone(), hosted.metadata.tags.clone(), stable_threshold_ms))
+            .collect::<Vec<_>>();
+        current.sort_by(|left, right| left.session_id.cmp(&right.session_id));
+
+        let current_ids = current.iter().map(|session| session.session_id.clone()).collect::<HashSet<_>>();
+        for session in current {
+            let prior = client.known_activity_sessions.get(&session.session_id);
+            let added = prior.is_none();
+            let changed = prior.is_some_and(|known| known.activity != session.activity);
+            client.known_activity_sessions.insert(session.session_id.clone(), session.clone());
+            let changed_at_unix_ms = unix_time_ms();
+            if added {
+                client.enqueue_control(MSG_CONTROL_ACTIVITY_EVENT, &ActivityEvent::MembershipAdded { session, changed_at_unix_ms })?;
+            } else if changed {
+                client.enqueue_control(MSG_CONTROL_ACTIVITY_EVENT, &ActivityEvent::ActivityChanged { session, changed_at_unix_ms })?;
+            }
+        }
+
+        let mut removed_ids =
+            client.known_activity_sessions.keys().filter(|session_id| !current_ids.contains(*session_id)).cloned().collect::<Vec<_>>();
+        removed_ids.sort();
+        for session_id in removed_ids {
+            let Some(removed) = client.known_activity_sessions.remove(&session_id) else {
+                continue;
+            };
+            client.enqueue_control(MSG_CONTROL_ACTIVITY_EVENT, &ActivityEvent::MembershipRemoved {
+                session_id,
+                tags: removed.tags,
+                changed_at_unix_ms: unix_time_ms(),
+            })?;
+        }
+    }
+    Ok(())
 }
 
 fn directory_entry_matches_selectors(entry: &DirectoryEntry, selectors: &[String]) -> bool {
@@ -1221,6 +1334,7 @@ fn service_hosted_session(
     }
     flush_watchers(&mut hosted.watchers);
     push_due_packet_renders(id, &hosted.actor, packet_clients, &mut hosted.packet_render_cache)?;
+    hosted.screen_activity.observe(hosted.actor.observation().render_generation());
 
     if resized || previous_controller_count != hosted.active_client.is_some() || previous_watcher_count != hosted.watchers.len() {
         broadcast_directory_upsert(directory_entry_for_session(layout, hosted, packet_clients)?, packet_clients)?;
@@ -1531,13 +1645,20 @@ fn handle_http_request(
             let mut selectors = subscribe.selectors;
             crate::runtime::normalize_tags(&mut selectors);
             let directory = directory_snapshot_for_sessions(state.layout, state.sessions, state.packet_clients, &selectors)?;
+            let activity = subscribe
+                .screen_activity_stable_ms
+                .map(|stable_threshold_ms| activity_snapshot_for_sessions(state.sessions, &selectors, stable_threshold_ms));
             let packet_stream = stream.try_clone().map_err(|err| format!("clone HTTP packet stream: {err}"))?;
             #[cfg(unix)]
             set_stream_nonblocking(&packet_stream, true).map_err(|err| format!("set HTTP packet stream nonblocking: {err}"))?;
             let client_id = *state.next_packet_client_id;
-            let mut client = PacketClient::new(client_id, packet_stream, selectors, &directory)?;
+            let mut client =
+                PacketClient::new(client_id, packet_stream, selectors, subscribe.screen_activity_stable_ms, &directory, activity.as_ref())?;
             client.enqueue_control(MSG_CONTROL_HELLO, &ControlHello::current())?;
             client.enqueue_control(MSG_CONTROL_DIRECTORY_SNAPSHOT, &directory)?;
+            if let Some(activity) = activity {
+                client.enqueue_control(MSG_CONTROL_ACTIVITY_SNAPSHOT, &activity)?;
+            }
             *response_committed = true;
             http_uds::write_packet_switching_protocols(stream).map_err(|err| format!("write HTTP packet upgrade response: {err}"))?;
             maybe_fail_after_http_upgrade("packet")?;
@@ -1982,6 +2103,8 @@ struct PacketClient {
     input_buffer: Vec<u8>,
     channels: HashMap<u32, PacketSessionChannel>,
     selectors: Vec<String>,
+    screen_activity_stable_ms: Option<u64>,
+    known_activity_sessions: HashMap<String, ActivitySession>,
     known_directory_sessions: HashSet<String>,
     /// Marked when this client's transport fails or its output backlog
     /// overflows. Client failures are never daemon-fatal: the client is
@@ -2016,7 +2139,14 @@ impl PacketRenderCache {
 }
 
 impl PacketClient {
-    fn new(id: u64, stream: SessionStream, selectors: Vec<String>, initial_directory: &DirectorySnapshot) -> Result<Self, String> {
+    fn new(
+        id: u64,
+        stream: SessionStream,
+        selectors: Vec<String>,
+        screen_activity_stable_ms: Option<u64>,
+        initial_directory: &DirectorySnapshot,
+        initial_activity: Option<&ActivitySnapshot>,
+    ) -> Result<Self, String> {
         let input_reader = ActiveClientReader::new(&stream)?;
         Ok(Self {
             id,
@@ -2026,6 +2156,12 @@ impl PacketClient {
             input_buffer: Vec::new(),
             channels: HashMap::new(),
             selectors,
+            screen_activity_stable_ms,
+            known_activity_sessions: initial_activity
+                .into_iter()
+                .flat_map(|snapshot| &snapshot.sessions)
+                .map(|session| (session.session_id.clone(), session.clone()))
+                .collect(),
             known_directory_sessions: initial_directory.sessions.iter().map(|entry| entry.session_id.clone()).collect(),
             dead: false,
         })
@@ -2930,8 +3066,9 @@ mod tests {
     #[test]
     fn packet_client_backlog_overflow_marks_client_dead_not_daemon_fatal() {
         let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
-        let mut client = super::PacketClient::new(1, stream, Vec::new(), &crate::packet::DirectorySnapshot { sessions: Vec::new() })
-            .expect("create packet client");
+        let mut client =
+            super::PacketClient::new(1, stream, Vec::new(), None, &crate::packet::DirectorySnapshot { sessions: Vec::new() }, None)
+                .expect("create packet client");
         client.pending_output = super::PendingOutput::from(vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1]);
 
         let frame = crate::packet::PacketFrame { channel: 1, msg_type: 0, payload: vec![0; 64] };
@@ -2948,8 +3085,9 @@ mod tests {
     #[test]
     fn dead_packet_client_does_not_hold_the_controller_slot() {
         let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
-        let mut client = super::PacketClient::new(7, stream, Vec::new(), &crate::packet::DirectorySnapshot { sessions: Vec::new() })
-            .expect("create packet client");
+        let mut client =
+            super::PacketClient::new(7, stream, Vec::new(), None, &crate::packet::DirectorySnapshot { sessions: Vec::new() }, None)
+                .expect("create packet client");
         let holder = super::PacketChannelRef { client_id: 7, channel: 1 };
 
         assert!(super::packet_controller_holder_is_live(holder, std::slice::from_ref(&client)));

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -281,7 +281,7 @@ fn send_keys_command_parses() {
         hex: false,
         repeat: 1,
         keys: vec!["Enter".into()],
-        mark_before: None,
+        mark_before: None
     });
 }
 
@@ -320,7 +320,7 @@ fn send_keys_command_parses_repeat() {
         hex: false,
         repeat: 3,
         keys: vec!["C-l".into()],
-        mark_before: None,
+        mark_before: None
     });
 }
 
@@ -810,7 +810,7 @@ fn expect_with_since_offset_parses() {
         since: Some(100),
         since_marker: None,
         timeout: 30.0,
-        json: false,
+        json: false
     });
 }
 

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -20,8 +20,9 @@ use cleat::session::foreground_path;
 use cleat::{
     cli::{self, Cli, ExecResult},
     packet::{
-        ControlHello, DirectoryDelta, DirectorySnapshot, PacketFrame, CHANNEL_CONTROL, MSG_CONTROL_DIRECTORY_DELTA,
-        MSG_CONTROL_DIRECTORY_SNAPSHOT, MSG_CONTROL_HELLO, PROTOCOL_VERSION,
+        ActivityEvent, ActivitySnapshot, ControlHello, DirectoryDelta, DirectorySnapshot, PacketFrame, ScreenActivity, CHANNEL_CONTROL,
+        MSG_CONTROL_ACTIVITY_EVENT, MSG_CONTROL_ACTIVITY_SNAPSHOT, MSG_CONTROL_DIRECTORY_DELTA, MSG_CONTROL_DIRECTORY_SNAPSHOT,
+        MSG_CONTROL_HELLO, PROTOCOL_VERSION,
     },
     protocol::{Frame, SessionInfo},
     provider::ProviderFeatures,
@@ -127,6 +128,37 @@ fn http_packet_stream_with_selectors(root: &std::path::Path, id: &str, selectors
     assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{response}");
     assert!(response.contains("Upgrade: cleat-packet/1\r\n"), "{response}");
     stream
+}
+
+fn http_activity_stream(root: &std::path::Path, id: &str, selectors: &[String], stable_threshold: Duration) -> UnixStream {
+    let socket_path = session_socket_path(root, id);
+    let mut stream = UnixStream::connect(&socket_path).expect("connect session socket");
+    let body = serde_json::json!({
+        "selectors": selectors,
+        "screen_activity_stable_ms": stable_threshold.as_millis() as u64,
+    })
+    .to_string();
+    write!(
+        stream,
+        "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n{}",
+        body.len(),
+        body
+    )
+    .expect("write activity upgrade request");
+
+    let response = read_http_response_head(&mut stream);
+    assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{response}");
+    stream
+}
+
+fn read_activity_event(stream: &mut UnixStream, timeout: Duration) -> ActivityEvent {
+    stream.set_read_timeout(Some(timeout)).expect("set activity timeout");
+    loop {
+        let frame = PacketFrame::read(stream).expect("read activity frame");
+        if frame.channel == CHANNEL_CONTROL && frame.msg_type == MSG_CONTROL_ACTIVITY_EVENT {
+            return frame.decode().expect("decode activity event");
+        }
+    }
 }
 
 #[cfg(feature = "ghostty-vt")]
@@ -846,6 +878,168 @@ fn directory_subscription_filters_and_emits_lifecycle_deltas() {
     service.update_tags("alpha", Vec::new(), vec![selector]).expect("untag alpha");
     let delta = read_until_directory_remove(&mut stream, &mut buffer, "alpha", Duration::from_secs(30));
     assert_eq!(delta.removed_session_ids, vec!["alpha"]);
+}
+
+#[test]
+fn activity_subscription_snapshot_covers_all_matching_sessions() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let selector = "role=impl".to_string();
+    for (id, tags) in [
+        ("alpha", vec![selector.clone(), "vessel=one".to_string()]),
+        ("beta", vec![selector.clone(), "vessel=two".to_string()]),
+        ("gamma", vec!["role=review".to_string()]),
+    ] {
+        service
+            .create_with_options(Some(id.into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), SessionStartOptions {
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: cleat::vt::TerminalColors::default(),
+                tags,
+            })
+            .expect("create session");
+    }
+
+    let mut stream = http_activity_stream(temp.path(), "alpha", std::slice::from_ref(&selector), Duration::from_millis(50));
+    let hello = PacketFrame::read(&mut stream).expect("read hello");
+    assert_eq!(hello.msg_type, MSG_CONTROL_HELLO);
+    let directory = PacketFrame::read(&mut stream).expect("read directory");
+    assert_eq!(directory.msg_type, MSG_CONTROL_DIRECTORY_SNAPSHOT);
+    let snapshot = PacketFrame::read(&mut stream).expect("read activity snapshot");
+    assert_eq!(snapshot.channel, CHANNEL_CONTROL);
+    assert_eq!(snapshot.msg_type, MSG_CONTROL_ACTIVITY_SNAPSHOT);
+    let snapshot = snapshot.decode::<ActivitySnapshot>().expect("decode activity snapshot");
+
+    assert_eq!(snapshot.stable_threshold_ms, 50);
+    assert_eq!(snapshot.sessions.iter().map(|session| session.session_id.as_str()).collect::<Vec<_>>(), vec!["alpha", "beta"]);
+    assert_eq!(snapshot.sessions[0].tags, vec!["role=impl", "vessel=one"]);
+    assert_eq!(snapshot.sessions[1].tags, vec!["role=impl", "vessel=two"]);
+
+    let (_client, snapshot) =
+        service.connect_activity(std::slice::from_ref(&selector), Duration::from_millis(50)).expect("connect through activity client API");
+    assert_eq!(snapshot.sessions.iter().map(|session| session.session_id.as_str()).collect::<Vec<_>>(), vec!["alpha", "beta"]);
+}
+
+#[test]
+fn activity_subscription_emits_threshold_transitions() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let selector = "vessel=work".to_string();
+    service
+        .create_with_options(
+            Some("alpha".into()),
+            Some(VtEngineKind::Passthrough),
+            None,
+            Some("sh -c 'stty raw; exec cat'".into()),
+            SessionStartOptions {
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: cleat::vt::TerminalColors::default(),
+                tags: vec![selector.clone()],
+            },
+        )
+        .expect("create alpha");
+
+    let mut stream = http_activity_stream(temp.path(), "alpha", std::slice::from_ref(&selector), Duration::from_millis(500));
+    let _hello = PacketFrame::read(&mut stream).expect("read hello");
+    let _directory = PacketFrame::read(&mut stream).expect("read directory");
+    let snapshot =
+        PacketFrame::read(&mut stream).expect("read activity snapshot").decode::<ActivitySnapshot>().expect("decode activity snapshot");
+    assert_eq!(snapshot.sessions[0].activity, ScreenActivity::Active);
+
+    let first_stable = read_activity_event(&mut stream, Duration::from_secs(2));
+    let ActivityEvent::ActivityChanged { session: stable, changed_at_unix_ms: first_stable_at } = first_stable else {
+        panic!("expected activity change");
+    };
+    assert_eq!(stable.session_id, "alpha");
+    assert_eq!(stable.tags, vec![selector.clone()]);
+    assert_eq!(stable.activity, ScreenActivity::Stable);
+
+    service.send_keys("alpha", b"screen changed").expect("write output-producing input");
+    let active = read_activity_event(&mut stream, Duration::from_secs(2));
+    let ActivityEvent::ActivityChanged { session: active, changed_at_unix_ms: active_at } = active else {
+        panic!("expected activity change");
+    };
+    assert_eq!(active.activity, ScreenActivity::Active);
+    assert!(active.last_output_at_unix_ms.is_some());
+    assert!(active_at >= first_stable_at);
+
+    let stable_again = read_activity_event(&mut stream, Duration::from_secs(2));
+    let ActivityEvent::ActivityChanged { session: stable_again, changed_at_unix_ms: stable_again_at } = stable_again else {
+        panic!("expected activity change");
+    };
+    assert_eq!(stable_again.activity, ScreenActivity::Stable);
+    assert!(stable_again_at >= active_at);
+}
+
+#[test]
+fn activity_subscription_emits_membership_deltas_and_reconnects_with_a_fresh_snapshot() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let selector = "vessel=work".to_string();
+    for (id, tags) in [("alpha", vec![selector.clone()]), ("beta", Vec::new())] {
+        service
+            .create_with_options(Some(id.into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), SessionStartOptions {
+                record: false,
+                initial_size: TerminalSize::default(),
+                colors: cleat::vt::TerminalColors::default(),
+                tags,
+            })
+            .expect("create session");
+    }
+
+    let mut stream = http_activity_stream(temp.path(), "alpha", std::slice::from_ref(&selector), Duration::ZERO);
+    let _hello = PacketFrame::read(&mut stream).expect("read hello");
+    let _directory = PacketFrame::read(&mut stream).expect("read directory");
+    let initial =
+        PacketFrame::read(&mut stream).expect("read activity snapshot").decode::<ActivitySnapshot>().expect("decode activity snapshot");
+    assert_eq!(initial.sessions.iter().map(|session| session.session_id.as_str()).collect::<Vec<_>>(), vec!["alpha"]);
+
+    service
+        .create_with_options(Some("gamma".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), SessionStartOptions {
+            record: false,
+            initial_size: TerminalSize::default(),
+            colors: cleat::vt::TerminalColors::default(),
+            tags: vec![selector.clone()],
+        })
+        .expect("create gamma");
+    let ActivityEvent::MembershipAdded { session: added, .. } = read_activity_event(&mut stream, Duration::from_secs(2)) else {
+        panic!("expected membership add");
+    };
+    assert_eq!(added.session_id, "gamma");
+    assert_eq!(added.tags, vec![selector.clone()]);
+
+    service.update_tags("beta", vec![selector.clone()], Vec::new()).expect("tag beta into selector");
+    let ActivityEvent::MembershipAdded { session: added, .. } = read_activity_event(&mut stream, Duration::from_secs(2)) else {
+        panic!("expected membership add");
+    };
+    assert_eq!(added.session_id, "beta");
+
+    service.update_tags("alpha", Vec::new(), vec![selector.clone()]).expect("tag alpha out of selector");
+    let ActivityEvent::MembershipRemoved { session_id, tags, .. } = read_activity_event(&mut stream, Duration::from_secs(2)) else {
+        panic!("expected membership remove");
+    };
+    assert_eq!(session_id, "alpha");
+    assert_eq!(tags, vec![selector.clone()]);
+
+    service.kill("gamma").expect("kill gamma");
+    let ActivityEvent::MembershipRemoved { session_id, .. } = read_activity_event(&mut stream, Duration::from_secs(2)) else {
+        panic!("expected membership remove");
+    };
+    assert_eq!(session_id, "gamma");
+    drop(stream);
+
+    let mut reconnected = http_activity_stream(temp.path(), "beta", std::slice::from_ref(&selector), Duration::ZERO);
+    let _hello = PacketFrame::read(&mut reconnected).expect("read reconnect hello");
+    let _directory = PacketFrame::read(&mut reconnected).expect("read reconnect directory");
+    let snapshot = PacketFrame::read(&mut reconnected)
+        .expect("read reconnect activity snapshot")
+        .decode::<ActivitySnapshot>()
+        .expect("decode reconnect activity snapshot");
+    assert_eq!(snapshot.sessions.iter().map(|session| session.session_id.as_str()).collect::<Vec<_>>(), vec!["beta"]);
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -956,6 +956,7 @@ fn activity_subscription_emits_threshold_transitions() {
     assert_eq!(stable.session_id, "alpha");
     assert_eq!(stable.tags, vec![selector.clone()]);
     assert_eq!(stable.activity, ScreenActivity::Stable);
+    assert_eq!(first_stable_at, stable.stable_since_unix_ms + 500);
 
     service.send_keys("alpha", b"screen changed").expect("write output-producing input");
     let active = read_activity_event(&mut stream, Duration::from_secs(2));
@@ -964,6 +965,7 @@ fn activity_subscription_emits_threshold_transitions() {
     };
     assert_eq!(active.activity, ScreenActivity::Active);
     assert!(active.last_output_at_unix_ms.is_some());
+    assert_eq!(active_at, active.last_output_at_unix_ms.expect("active transition output timestamp"));
     assert!(active_at >= first_stable_at);
 
     let stable_again = read_activity_event(&mut stream, Duration::from_secs(2));
@@ -971,7 +973,19 @@ fn activity_subscription_emits_threshold_transitions() {
         panic!("expected activity change");
     };
     assert_eq!(stable_again.activity, ScreenActivity::Stable);
+    assert_eq!(stable_again_at, stable_again.stable_since_unix_ms + 500);
     assert!(stable_again_at >= active_at);
+}
+
+#[test]
+fn activity_subscription_rejects_zero_stability_threshold() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+
+    let result = service.connect_activity(&[], Duration::ZERO);
+
+    assert!(result.is_err());
+    assert!(result.err().expect("zero threshold error").contains("greater than zero"));
 }
 
 #[test]
@@ -991,7 +1005,8 @@ fn activity_subscription_emits_membership_deltas_and_reconnects_with_a_fresh_sna
             .expect("create session");
     }
 
-    let mut stream = http_activity_stream(temp.path(), "alpha", std::slice::from_ref(&selector), Duration::ZERO);
+    let stable_threshold = Duration::from_secs(60);
+    let mut stream = http_activity_stream(temp.path(), "alpha", std::slice::from_ref(&selector), stable_threshold);
     let _hello = PacketFrame::read(&mut stream).expect("read hello");
     let _directory = PacketFrame::read(&mut stream).expect("read directory");
     let initial =
@@ -1032,7 +1047,7 @@ fn activity_subscription_emits_membership_deltas_and_reconnects_with_a_fresh_sna
     assert_eq!(session_id, "gamma");
     drop(stream);
 
-    let mut reconnected = http_activity_stream(temp.path(), "beta", std::slice::from_ref(&selector), Duration::ZERO);
+    let mut reconnected = http_activity_stream(temp.path(), "beta", std::slice::from_ref(&selector), stable_threshold);
     let _hello = PacketFrame::read(&mut reconnected).expect("read reconnect hello");
     let _directory = PacketFrame::read(&mut reconnected).expect("read reconnect directory");
     let snapshot = PacketFrame::read(&mut reconnected)


### PR DESCRIPTION
Closes #158

## Summary
- add selector-filtered activity subscriptions on the multiplexed control plane
- emit initial snapshots, threshold-based active/stable transitions, and membership deltas
- resync reconnecting clients with fresh snapshots
- expose typed Rust client APIs and bump the packet protocol to v3

## Why
Flotilla needs one pushed subscription for all crew sessions instead of per-session blocked waits or polling.

## Validation
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`