### PR TITLE
Expose screen activity state in JSON output

### DIFF
--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -338,6 +338,7 @@ pub(crate) enum SessionCommand {
     ValidateTextMatching { reply: mpsc::Sender<Result<(), String>> },
     ScreenContains { text: String, reply: mpsc::Sender<Result<bool, String>> },
     LastPtyOutputAt { reply: mpsc::Sender<Result<Option<Instant>, String>> },
+    FlushScreenActivity,
     FlushRecording { reply: mpsc::Sender<Result<(), String>> },
     RecordingActive { reply: mpsc::Sender<Result<bool, String>> },
     RecordAttach { reply: mpsc::Sender<Result<(), String>> },
@@ -764,6 +765,10 @@ impl SessionActor {
         self.request_result(|reply| SessionCommand::LastPtyOutputAt { reply })
     }
 
+    pub(crate) fn enqueue_screen_activity_flush(&self) -> Result<(), String> {
+        self.tx.send(SessionCommand::FlushScreenActivity).map_err(|_| "session actor is not running".to_string())
+    }
+
     pub(crate) fn flush_recording(&self) -> Result<(), String> {
         self.request_result(|reply| SessionCommand::FlushRecording { reply })
     }
@@ -1109,6 +1114,9 @@ fn session_actor_handle_command(
         }
         SessionCommand::LastPtyOutputAt { reply } => {
             let _ = reply.send(Ok(runtime.last_pty_output_at()));
+        }
+        SessionCommand::FlushScreenActivity => {
+            runtime.flush_screen_activity();
         }
         SessionCommand::FlushRecording { reply } => {
             runtime.flush_recording();

--- a/crates/cleat/src/lib.rs
+++ b/crates/cleat/src/lib.rs
@@ -16,6 +16,7 @@ pub mod recording;
 pub mod recreate;
 pub mod replay;
 pub mod runtime;
+mod screen_activity;
 pub mod server;
 pub mod session;
 mod session_runtime;

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -18,6 +18,7 @@ pub struct SessionInfo {
     #[serde(default)]
     pub tags: Vec<String>,
     pub status: SessionStatus,
+    /// Engines without screen-activity observation support report `stable`.
     #[serde(default)]
     pub screen_activity: ScreenActivity,
     /// Unix timestamp in milliseconds when the current stable period began.
@@ -51,6 +52,7 @@ pub struct InspectResult {
     pub process: ProcessInspect,
     pub attachments: Vec<AttachmentInspect>,
     pub recording: RecordingInspect,
+    /// Engines without screen-activity observation support report `stable`.
     #[serde(default)]
     pub screen_activity: ScreenActivity,
     /// Unix timestamp in milliseconds when the current stable period began.

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -18,6 +18,14 @@ pub struct SessionInfo {
     #[serde(default)]
     pub tags: Vec<String>,
     pub status: SessionStatus,
+    #[serde(default)]
+    pub screen_activity: ScreenActivity,
+    /// Unix timestamp in milliseconds when the current stable period began.
+    #[serde(default)]
+    pub stable_since: Option<u64>,
+    /// Unix timestamp in milliseconds of the most recent render-changing output.
+    #[serde(default)]
+    pub last_output_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -28,6 +36,14 @@ pub enum SessionStatus {
     Detached,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ScreenActivity {
+    Active,
+    #[default]
+    Stable,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InspectResult {
     pub session: SessionInspect,
@@ -35,6 +51,14 @@ pub struct InspectResult {
     pub process: ProcessInspect,
     pub attachments: Vec<AttachmentInspect>,
     pub recording: RecordingInspect,
+    #[serde(default)]
+    pub screen_activity: ScreenActivity,
+    /// Unix timestamp in milliseconds when the current stable period began.
+    #[serde(default)]
+    pub stable_since: Option<u64>,
+    /// Unix timestamp in milliseconds of the most recent render-changing output.
+    #[serde(default)]
+    pub last_output_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/cleat/src/screen_activity.rs
+++ b/crates/cleat/src/screen_activity.rs
@@ -1,0 +1,91 @@
+use std::time::{Duration, Instant};
+
+use crate::protocol::ScreenActivity;
+
+pub(crate) const SCREEN_ACTIVITY_STABLE_AFTER: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ScreenActivitySnapshot {
+    pub(crate) screen_activity: ScreenActivity,
+    pub(crate) stable_since: Option<u64>,
+    pub(crate) last_output_at: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ScreenActivityTracker {
+    initial_stable_since: u64,
+    last_render_change: Option<(Instant, u64)>,
+}
+
+impl ScreenActivityTracker {
+    pub(crate) fn new(started_at_unix_ms: u64) -> Self {
+        Self { initial_stable_since: started_at_unix_ms, last_render_change: None }
+    }
+
+    pub(crate) fn render_changed(&mut self, changed_at: Instant, changed_at_unix_ms: u64) {
+        self.last_render_change = Some((changed_at, changed_at_unix_ms));
+    }
+
+    pub(crate) fn snapshot(&self, now: Instant) -> ScreenActivitySnapshot {
+        let Some((changed_at, changed_at_unix_ms)) = self.last_render_change else {
+            return ScreenActivitySnapshot {
+                screen_activity: ScreenActivity::Stable,
+                stable_since: Some(self.initial_stable_since),
+                last_output_at: None,
+            };
+        };
+
+        if now.saturating_duration_since(changed_at) < SCREEN_ACTIVITY_STABLE_AFTER {
+            ScreenActivitySnapshot { screen_activity: ScreenActivity::Active, stable_since: None, last_output_at: Some(changed_at_unix_ms) }
+        } else {
+            ScreenActivitySnapshot {
+                screen_activity: ScreenActivity::Stable,
+                stable_since: Some(changed_at_unix_ms.saturating_add(SCREEN_ACTIVITY_STABLE_AFTER.as_millis() as u64)),
+                last_output_at: Some(changed_at_unix_ms),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::ScreenActivityTracker;
+    use crate::protocol::ScreenActivity;
+
+    #[test]
+    fn render_change_decays_from_active_to_stable_after_one_second() {
+        let started_at = Instant::now();
+        let mut tracker = ScreenActivityTracker::new(1_000);
+
+        assert_eq!(tracker.snapshot(started_at).screen_activity, ScreenActivity::Stable);
+        assert_eq!(tracker.snapshot(started_at).stable_since, Some(1_000));
+        assert_eq!(tracker.snapshot(started_at).last_output_at, None);
+
+        tracker.render_changed(started_at + Duration::from_millis(100), 1_100);
+
+        let active = tracker.snapshot(started_at + Duration::from_millis(1_099));
+        assert_eq!(active.screen_activity, ScreenActivity::Active);
+        assert_eq!(active.stable_since, None);
+        assert_eq!(active.last_output_at, Some(1_100));
+
+        let stable = tracker.snapshot(started_at + Duration::from_millis(1_100));
+        assert_eq!(stable.screen_activity, ScreenActivity::Stable);
+        assert_eq!(stable.stable_since, Some(2_100));
+        assert_eq!(stable.last_output_at, Some(1_100));
+    }
+
+    #[test]
+    fn later_render_change_starts_a_new_active_period() {
+        let started_at = Instant::now();
+        let mut tracker = ScreenActivityTracker::new(5_000);
+        tracker.render_changed(started_at + Duration::from_secs(2), 7_000);
+
+        let active = tracker.snapshot(started_at + Duration::from_millis(2_500));
+
+        assert_eq!(active.screen_activity, ScreenActivity::Active);
+        assert_eq!(active.stable_since, None);
+        assert_eq!(active.last_output_at, Some(7_000));
+    }
+}

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -138,6 +138,9 @@ impl SessionService {
             cmd: session.cmd,
             tags: session.tags,
             status: SessionStatus::Detached,
+            screen_activity: crate::protocol::ScreenActivity::Stable,
+            stable_since: None,
+            last_output_at: None,
             error: None,
         })
     }
@@ -221,6 +224,9 @@ impl SessionService {
                         cmd: result.session.cmd,
                         tags: result.session.tags,
                         status,
+                        screen_activity: result.screen_activity,
+                        stable_since: result.stable_since,
+                        last_output_at: result.last_output_at,
                         error: None,
                     };
                     if session_matches_selectors(&info, selectors) {
@@ -462,6 +468,9 @@ impl SessionService {
                 cmd: session.cmd,
                 tags: session.tags,
                 status: SessionStatus::Attached,
+                screen_activity: crate::protocol::ScreenActivity::Stable,
+                stable_since: None,
+                last_output_at: None,
                 error: None,
             }
         };
@@ -755,6 +764,9 @@ fn sweep_dead_daemon_sessions(layout: &RuntimeLayout, err: String) -> Result<Vec
             cmd: None,
             tags: Vec::new(),
             status: SessionStatus::Detached,
+            screen_activity: crate::protocol::ScreenActivity::Stable,
+            stable_since: None,
+            last_output_at: None,
             error: Some(err.clone()),
         });
     }
@@ -828,6 +840,9 @@ fn session_info_from_inspect(result: crate::protocol::InspectResult, status: Ses
         cmd: result.session.cmd,
         tags: result.session.tags,
         status,
+        screen_activity: result.screen_activity,
+        stable_since: result.stable_since,
+        last_output_at: result.last_output_at,
         error: None,
     }
 }

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1170,8 +1170,9 @@ fn service_hosted_session(
     let previous_watcher_count = hosted.watchers.len();
     let mut resized = false;
 
-    did_work |=
+    let output_drained =
         drain_raw_output_tap(layout, id, &hosted.actor, &mut hosted.raw_output_tap, &mut hosted.active_client, &mut hosted.watchers)?;
+    did_work |= output_drained;
     drain_watcher_inputs(&mut hosted.watchers);
 
     if hosted.active_client.is_some() {
@@ -1221,6 +1222,9 @@ fn service_hosted_session(
     }
     flush_watchers(&mut hosted.watchers);
     push_due_packet_renders(id, &hosted.actor, packet_clients, &mut hosted.packet_render_cache)?;
+    if output_drained {
+        hosted.actor.enqueue_screen_activity_flush()?;
+    }
 
     if resized || previous_controller_count != hosted.active_client.is_some() || previous_watcher_count != hosted.watchers.len() {
         broadcast_directory_upsert(directory_entry_for_session(layout, hosted, packet_clients)?, packet_clients)?;

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -4,7 +4,7 @@ use std::{
     collections::HashMap,
     path::PathBuf,
     sync::Arc,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use crate::{
@@ -17,6 +17,7 @@ use crate::{
     },
     recording::SessionRecorder,
     runtime::{normalize_tags, SessionMetadata},
+    screen_activity::ScreenActivityTracker,
     vt::{self, TerminalModeState, VtEngine},
 };
 
@@ -41,6 +42,8 @@ pub(crate) struct SessionRuntime {
     markers: HashMap<String, u64>,
     epoch: Instant,
     last_pty_output_at: Option<Instant>,
+    screen_activity: ScreenActivityTracker,
+    pending_screen_activity_at: Option<(Instant, u64)>,
     // Current cell pixel size, used to fill the PTY winsize ws_xpixel/ws_ypixel
     // so TIOCGWINSZ-based apps (e.g. katzensteg) can compute image aspect. Zero
     // until the first geometry/set_cell_size, matching a terminal that hasn't
@@ -100,7 +103,7 @@ impl SessionRuntime {
             None
         };
 
-        Ok(Self {
+        let mut runtime = Self {
             session: session.clone(),
             session_dir,
             pty_child,
@@ -110,9 +113,14 @@ impl SessionRuntime {
             markers: HashMap::new(),
             epoch: Instant::now(),
             last_pty_output_at: None,
+            screen_activity: ScreenActivityTracker::new(unix_timestamp_millis(SystemTime::now())),
+            pending_screen_activity_at: None,
             cell_width_px: 0,
             cell_height_px: 0,
-        })
+        };
+        // Establish a clean activity baseline before the child emits output.
+        let _ = runtime.vt_engine.screen_grid();
+        Ok(runtime)
     }
 
     fn pty_pixel_size(&self, cols: u16, rows: u16) -> (u32, u32) {
@@ -174,6 +182,7 @@ impl SessionRuntime {
     }
 
     pub(crate) fn snapshot(&mut self, dirty: DirtyState) -> Result<TerminalSnapshot, String> {
+        self.observe_pending_screen_activity();
         let grid = self.vt_engine.screen_grid()?;
         let scrollbar = self.vt_engine.scrollbar_state()?;
         let mut snapshot = TerminalSnapshot::from_screen_grid(grid, dirty);
@@ -185,6 +194,7 @@ impl SessionRuntime {
     }
 
     pub(crate) fn render_update(&mut self, dirty: DirtyState) -> Result<TerminalRenderUpdate, String> {
+        self.observe_pending_screen_activity();
         let scrollbar = self.vt_engine.scrollbar_state()?;
         let mut update = self.vt_engine.render_update(dirty)?;
         update.viewport_kind = scrollbar.viewport_kind;
@@ -290,6 +300,7 @@ impl SessionRuntime {
         }
         attachments.extend((0..watcher_count).map(|_| crate::protocol::AttachmentInspect { role: "watcher".to_string() }));
 
+        let activity = self.screen_activity.snapshot(Instant::now());
         InspectResult {
             session: crate::protocol::SessionInspect {
                 id: self.session.id.clone(),
@@ -314,6 +325,9 @@ impl SessionRuntime {
                 bytes_written: self.recorder.as_ref().map(|r| r.bytes_written()).unwrap_or(0),
                 markers: self.markers.clone(),
             },
+            screen_activity: activity.screen_activity,
+            stable_since: activity.stable_since,
+            last_output_at: activity.last_output_at,
         }
     }
 
@@ -443,7 +457,30 @@ impl SessionRuntime {
                 Err(err) => return Err(format!("read pty output: {err}")),
             }
         }
+        if !chunks.is_empty() {
+            self.note_screen_activity_candidate(Instant::now(), unix_timestamp_millis(SystemTime::now()));
+        }
         Ok(PtyOutput { chunks })
+    }
+
+    fn note_screen_activity_candidate(&mut self, changed_at: Instant, changed_at_unix_ms: u64) {
+        if self.vt_engine.screen_activity_changed().is_ok_and(|changed| changed == Some(true)) {
+            self.pending_screen_activity_at = Some((changed_at, changed_at_unix_ms));
+        }
+    }
+
+    fn observe_pending_screen_activity(&mut self) -> bool {
+        let Some((changed_at, changed_at_unix_ms)) = self.pending_screen_activity_at.take() else {
+            return false;
+        };
+        self.screen_activity.render_changed(changed_at, changed_at_unix_ms);
+        true
+    }
+
+    pub(crate) fn flush_screen_activity(&mut self) {
+        if self.observe_pending_screen_activity() {
+            let _ = self.vt_engine.screen_grid();
+        }
     }
 
     fn write_detached_replies(&mut self, pty_output: &[u8], engine_reply: &[u8]) -> Result<(), String> {
@@ -491,6 +528,10 @@ fn write_replay_snapshot(engine: &mut dyn VtEngine, recorder: &mut SessionRecord
 
 fn replay_snapshot_payload(engine: &mut dyn VtEngine) -> Option<Vec<u8>> {
     engine.replay_payload(&vt::ClientCapabilities::conservative_fallback()).ok().flatten()
+}
+
+fn unix_timestamp_millis(time: SystemTime) -> u64 {
+    time.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_millis().try_into().unwrap_or(u64::MAX)
 }
 
 fn is_pty_eof_after_exit(err: &std::io::Error) -> bool {

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -464,8 +464,10 @@ impl SessionRuntime {
     }
 
     fn note_screen_activity_candidate(&mut self, changed_at: Instant, changed_at_unix_ms: u64) {
-        if self.vt_engine.screen_activity_changed().is_ok_and(|changed| changed == Some(true)) {
-            self.pending_screen_activity_at = Some((changed_at, changed_at_unix_ms));
+        match self.vt_engine.screen_activity_changed() {
+            Ok(Some(true)) => self.pending_screen_activity_at = Some((changed_at, changed_at_unix_ms)),
+            Ok(Some(false) | None) => {}
+            Err(err) => eprintln!("screen activity observation error: {err}"),
         }
     }
 
@@ -479,7 +481,9 @@ impl SessionRuntime {
 
     pub(crate) fn flush_screen_activity(&mut self) {
         if self.observe_pending_screen_activity() {
-            let _ = self.vt_engine.screen_grid();
+            if let Err(err) = self.vt_engine.screen_grid() {
+                eprintln!("screen activity render flush error: {err}");
+            }
         }
     }
 

--- a/crates/cleat/src/vt/ghostty.rs
+++ b/crates/cleat/src/vt/ghostty.rs
@@ -37,6 +37,8 @@ pub struct GhosttyVtEngine {
     mouse_encoder: MouseEncoder,
     saw_output: bool,
     cached_grid: Option<ScreenGrid>,
+    deferred_render_dirty: GhosttyRenderStateDirty,
+    deferred_render_dirty_rows: Vec<u16>,
 }
 
 impl GhosttyVtEngine {
@@ -70,6 +72,8 @@ impl GhosttyVtEngine {
             mouse_encoder,
             saw_output: false,
             cached_grid: None,
+            deferred_render_dirty: GhosttyRenderStateDirty::False,
+            deferred_render_dirty_rows: Vec::new(),
         }
     }
 
@@ -187,6 +191,54 @@ impl GhosttyVtEngine {
             dirty,
         })
     }
+
+    fn capture_activity_damage(&mut self) -> Result<bool, String> {
+        self.render_state.update(&self.terminal)?;
+        let dirty = self.render_state.get_dirty()?;
+        if dirty == GhosttyRenderStateDirty::False {
+            return Ok(false);
+        }
+
+        if dirty == GhosttyRenderStateDirty::Full {
+            self.deferred_render_dirty = GhosttyRenderStateDirty::Full;
+            self.deferred_render_dirty_rows.clear();
+        } else if self.deferred_render_dirty != GhosttyRenderStateDirty::Full {
+            self.deferred_render_dirty = GhosttyRenderStateDirty::Partial;
+        }
+
+        self.render_state.populate_row_iterator(&mut self.row_iter)?;
+        let mut row_idx = 0u16;
+        while self.row_iter.next() {
+            if dirty == GhosttyRenderStateDirty::Partial
+                && self.deferred_render_dirty != GhosttyRenderStateDirty::Full
+                && self.row_iter.get_dirty().unwrap_or(true)
+                && !self.deferred_render_dirty_rows.contains(&row_idx)
+            {
+                self.deferred_render_dirty_rows.push(row_idx);
+            }
+            self.row_iter.set_dirty(false)?;
+            row_idx = row_idx.saturating_add(1);
+        }
+        self.render_state.set_dirty(GhosttyRenderStateDirty::False)?;
+        Ok(true)
+    }
+
+    fn deferred_render_damage(&self) -> (GhosttyRenderStateDirty, Vec<u16>) {
+        (self.deferred_render_dirty, self.deferred_render_dirty_rows.clone())
+    }
+
+    fn clear_deferred_render_damage(&mut self) {
+        self.deferred_render_dirty = GhosttyRenderStateDirty::False;
+        self.deferred_render_dirty_rows.clear();
+    }
+}
+
+fn combined_render_dirty(left: GhosttyRenderStateDirty, right: GhosttyRenderStateDirty) -> GhosttyRenderStateDirty {
+    match (left, right) {
+        (GhosttyRenderStateDirty::Full, _) | (_, GhosttyRenderStateDirty::Full) => GhosttyRenderStateDirty::Full,
+        (GhosttyRenderStateDirty::Partial, _) | (_, GhosttyRenderStateDirty::Partial) => GhosttyRenderStateDirty::Partial,
+        _ => GhosttyRenderStateDirty::False,
+    }
 }
 
 fn apply_colors(terminal: &mut TerminalHandle, colors: TerminalColors) -> Result<(), String> {
@@ -207,6 +259,10 @@ impl VtEngine for GhosttyVtEngine {
             self.saw_output = true;
         }
         Ok(())
+    }
+
+    fn screen_activity_changed(&mut self) -> Result<Option<bool>, String> {
+        self.capture_activity_damage().map(Some)
     }
 
     fn drain_replies(&mut self) -> Vec<u8> {
@@ -299,7 +355,9 @@ impl VtEngine for GhosttyVtEngine {
     fn screen_grid(&mut self) -> Result<ScreenGrid, String> {
         self.render_state.update(&self.terminal)?;
 
-        let dirty = self.render_state.get_dirty()?;
+        let live_dirty = self.render_state.get_dirty()?;
+        let (deferred_dirty, deferred_dirty_rows) = self.deferred_render_damage();
+        let dirty = combined_render_dirty(live_dirty, deferred_dirty);
         if dirty == GhosttyRenderStateDirty::False {
             let cursor = self.read_cursor_state()?;
             if let Some(cached) = self.cached_grid.as_mut() {
@@ -330,7 +388,9 @@ impl VtEngine for GhosttyVtEngine {
         let mut row_idx: usize = 0;
         let mut dirty_rows = Vec::new();
         while self.row_iter.next() {
-            let skip = partial && !self.row_iter.get_dirty().unwrap_or(true);
+            let row = u16::try_from(row_idx).unwrap_or(u16::MAX);
+            let row_dirty = self.row_iter.get_dirty().unwrap_or(true) || deferred_dirty_rows.contains(&row);
+            let skip = partial && !row_dirty;
             if skip {
                 row_idx += 1;
                 continue;
@@ -360,6 +420,7 @@ impl VtEngine for GhosttyVtEngine {
         let cursor = self.read_cursor_state()?;
 
         self.render_state.set_dirty(GhosttyRenderStateDirty::False)?;
+        self.clear_deferred_render_damage();
 
         let grid = ScreenGrid { cells, cols, rows, cursor, dirty_rows };
         self.cached_grid = Some(grid.clone());
@@ -369,7 +430,9 @@ impl VtEngine for GhosttyVtEngine {
     fn render_update(&mut self, dirty: DirtyState) -> Result<TerminalRenderUpdate, String> {
         self.render_state.update(&self.terminal)?;
 
-        let render_dirty = self.render_state.get_dirty()?;
+        let live_dirty = self.render_state.get_dirty()?;
+        let (deferred_dirty, deferred_dirty_rows) = self.deferred_render_damage();
+        let render_dirty = combined_render_dirty(live_dirty, deferred_dirty);
         let cols = self.render_state.get_cols()?;
         let rows = self.render_state.get_rows()?;
         let colors = self.render_state.get_colors()?;
@@ -389,14 +452,14 @@ impl VtEngine for GhosttyVtEngine {
             self.render_state.populate_row_iterator(&mut self.row_iter)?;
             let mut row_idx: usize = 0;
             while self.row_iter.next() {
-                let row_dirty = self.row_iter.get_dirty().unwrap_or(true);
+                let row = u16::try_from(row_idx).unwrap_or(u16::MAX);
+                let row_dirty = self.row_iter.get_dirty().unwrap_or(true) || deferred_dirty_rows.contains(&row);
                 let include_row = match effective_dirty {
                     DirtyState::Clean => false,
                     DirtyState::Partial => row_dirty,
                     DirtyState::Full => true,
                 };
                 if include_row {
-                    let row = u16::try_from(row_idx).unwrap_or(u16::MAX);
                     let raw_row = self.row_iter.get_raw_row()?;
                     let row_start = row_idx * row_stride;
                     let row_end = row_start + row_stride;
@@ -414,6 +477,7 @@ impl VtEngine for GhosttyVtEngine {
             }
             self.render_state.set_dirty(GhosttyRenderStateDirty::False)?;
         }
+        self.clear_deferred_render_damage();
 
         let effective_dirty =
             if effective_dirty == DirtyState::Partial && update_rows.is_empty() { DirtyState::Clean } else { effective_dirty };

--- a/crates/cleat/src/vt/mod.rs
+++ b/crates/cleat/src/vt/mod.rs
@@ -307,6 +307,11 @@ pub struct MouseModifiers {
 // handles that are only accessed from the single session daemon event loop.
 pub trait VtEngine {
     fn feed(&mut self, bytes: &[u8]) -> Result<(), String>;
+    /// Report whether output fed since the engine's render state was last
+    /// consumed caused screen damage. `None` means activity is unobservable.
+    fn screen_activity_changed(&mut self) -> Result<Option<bool>, String> {
+        Ok(None)
+    }
     fn resize(&mut self, cols: u16, rows: u16) -> Result<(), String>;
     fn set_cell_size(&mut self, _cell_width_px: u32, _cell_height_px: u32) -> Result<(), String> {
         Ok(())

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -666,6 +666,84 @@ fn list_and_inspect_report_opaque_tags() {
 }
 
 #[test]
+fn list_and_inspect_json_report_screen_activity_for_detached_sessions() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service
+        .create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+        .expect("create detached session");
+
+    let list_cli = Cli::try_parse_from(["cleat", "list", "--json"]).expect("parse list --json");
+    let list_output = cli::execute(list_cli, &service).expect("execute list --json").expect("list JSON");
+    let list: serde_json::Value = serde_json::from_str(&list_output).expect("parse list JSON");
+    let row = &list.as_array().expect("list array")[0];
+    assert_eq!(row["screen_activity"], "stable");
+    assert!(row.get("stable_since").is_some(), "stable_since field should be present: {row}");
+    assert!(row.get("last_output_at").is_some(), "last_output_at field should be present: {row}");
+
+    let inspect_cli = Cli::try_parse_from(["cleat", "inspect", "alpha", "--json"]).expect("parse inspect --json");
+    let inspect_output = cli::execute(inspect_cli, &service).expect("execute inspect --json").expect("inspect JSON");
+    let inspect: serde_json::Value = serde_json::from_str(&inspect_output).expect("parse inspect JSON");
+    assert_eq!(inspect["screen_activity"], "stable");
+    assert!(inspect.get("stable_since").is_some(), "stable_since field should be present: {inspect}");
+    assert!(inspect.get("last_output_at").is_some(), "last_output_at field should be present: {inspect}");
+
+    service.kill("alpha").expect("kill detached session");
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn detached_spinner_activity_changes_from_active_to_stable() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let vt_engine = VtEngineKind::Ghostty;
+    service
+        .create(
+            Some("alpha".into()),
+            Some(vt_engine),
+            None,
+            Some("sh -c 'i=0; while [ $i -lt 25 ]; do printf \"\\r%s\" \"$((i % 10))\"; i=$((i + 1)); sleep 0.1; done; sleep 30'".into()),
+            false,
+        )
+        .expect("create outputting detached session");
+
+    let active_deadline = Instant::now() + Duration::from_secs(5);
+    let active = loop {
+        let inspected = service.inspect("alpha").expect("inspect active session");
+        if inspected.screen_activity == cleat::protocol::ScreenActivity::Active {
+            break inspected;
+        }
+        assert!(Instant::now() < active_deadline, "session never reported active: {inspected:?}");
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    let last_output_at = active.last_output_at.expect("active session last_output_at");
+    assert_eq!(active.stable_since, None);
+    assert!(active.attachments.is_empty(), "session should remain detached");
+
+    let stable_deadline = Instant::now() + Duration::from_secs(8);
+    let stable = loop {
+        let inspected = service.inspect("alpha").expect("inspect stabilizing session");
+        if inspected.screen_activity == cleat::protocol::ScreenActivity::Stable && inspected.last_output_at.is_some() {
+            break inspected;
+        }
+        assert!(Instant::now() < stable_deadline, "session never reported stable: {inspected:?}");
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    assert!(stable.last_output_at.expect("stable session last_output_at") >= last_output_at);
+    assert_eq!(stable.stable_since, stable.last_output_at.map(|timestamp| timestamp + 1_000));
+    assert!(stable.attachments.is_empty(), "session should remain detached");
+
+    let listed = service.list().expect("list stable session");
+    assert_eq!(listed[0].screen_activity, cleat::protocol::ScreenActivity::Stable);
+    assert_eq!(listed[0].stable_since, stable.stable_since);
+    assert_eq!(listed[0].last_output_at, stable.last_output_at);
+
+    service.kill("alpha").expect("kill detached session");
+}
+
+#[test]
 fn list_selector_requires_exact_opaque_tag_matches() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/cleat/tests/vt.rs
+++ b/crates/cleat/tests/vt.rs
@@ -89,6 +89,24 @@ fn vt_ghostty_formatter_alloc_round_trips_output() {
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
+fn vt_ghostty_screen_activity_detects_coalesced_changes_but_not_queries() {
+    let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(80, 24);
+    engine.screen_grid().expect("initialize render state");
+
+    engine.feed(b"|").expect("draw initial spinner frame");
+    assert_eq!(engine.screen_activity_changed().expect("initial spinner activity"), Some(true));
+
+    engine.feed(b"\x1b[6n").expect("feed cursor-position query while render damage is deferred");
+    assert_eq!(engine.screen_activity_changed().expect("query activity"), Some(false));
+
+    engine.feed(b"\r/\r|").expect("draw a complete spinner cycle");
+    assert_eq!(engine.screen_activity_changed().expect("coalesced spinner activity"), Some(true));
+    let grid = engine.screen_grid().expect("consume deferred spinner activity");
+    assert_eq!(grid.row_text(0).trim_end(), "|");
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
 fn vt_ghostty_screen_text_round_trips_output() {
     let mut engine = cleat::vt::ghostty::GhosttyVtEngine::new(80, 24);
 


### PR DESCRIPTION
Closes #157.

## What changed

- expose `screen_activity`, `stable_since`, and `last_output_at` from both `cleat list --json` and `cleat inspect --json`
- track render-changing output in the session actor and decay active sessions to stable after one second
- detect activity for detached Ghostty sessions without requiring an attached client
- preserve Ghostty render damage for packet and grid consumers while independently filtering query-only terminal output
- keep the optional `ghostty-vt` implementation feature-gated

## Why

Callers need a machine-readable indication of whether a session is actively changing or has reached a stable screen. PTY output alone is insufficient because terminal queries can generate traffic without changing the rendered screen.

## Impact and scope

Automation can distinguish active TUIs and spinners from stable prompts using either JSON surface, including when sessions are detached. Timestamps are Unix epoch milliseconds.

Render-changing activity requires a VT engine that implements screen-activity observation. Ghostty does; unsupported engines report `stable`, as documented on the protocol fields. The default Rust-only build contains only the nonfunctional passthrough/testing engine, so real terminal usage—and meaningful activity observation—requires the optional `ghostty-vt` feature.

This PR implements #157's fixed one-second, poll-friendly JSON surface. The separately shipped #158 packet subscription currently uses raw PTY-output timing and a client-selected threshold, so the two surfaces can differ for query-only traffic. #162 tracks unifying those semantics and naming with an explicit compatibility review.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `./tools/prepare-ghostty-vt.sh`
- `cargo build -p cleat --locked --features ghostty-vt`
- `cargo test -p cleat --locked --features ghostty-vt`

Focused coverage includes detached spinner active-to-stable behavior, coalesced same-final spinner frames, query-only output, and preservation of deferred render damage. #163 tracks an additional attached-session JSON lifecycle contract.
