### PR TITLE
Unify JSON and subscription screen activity semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Four surfaces cooperate during a session. Knowing which surface is authoritative
 - **Recording** — default-on raw PTY output tee, stored as asciicast v3 in `session.cast`. Authoritative source for `transcript` and `expect`.
 - **Packet surface** — structured multiplexed control/render/directory protocol. `cleat packets` exposes the raw probe surface, and `cleat list --watch` uses the directory subscription to print a snapshot followed by lifecycle deltas. Rust clients can use `SessionService::connect_activity` to subscribe once for every session matching a tag selector: the stream starts with an activity snapshot, then emits threshold-based `active`/`stable` transitions and membership changes with session IDs, tags, and Unix-millisecond timestamps.
 
+Screen activity has one meaning across JSON polling and packet subscriptions: a session is `active` only after PTY output changes its rendered screen, so terminal queries do not count. A never-rendered session starts `stable`, and an engine that cannot observe render damage remains `stable`. JSON uses a fixed one-second stability threshold; each packet subscriber applies its requested threshold to the same render-change timeline. `stable_since` on JSON is when stability was reached, while packet `stable_since_unix_ms` is the beginning of the quiet window that will reach the subscriber's threshold.
+
+This subscription contract starts with packet protocol v4. Version 3 used raw PTY-output timing for subscriptions, so v3 clients and daemons are rejected instead of silently disagreeing about query-only activity. The activity message shapes are otherwise unchanged.
+
 ### Command Map
 
 | Command | Exercises | Notes |

--- a/crates/cleat/src/host/actor.rs
+++ b/crates/cleat/src/host/actor.rs
@@ -31,6 +31,7 @@ use crate::{
         DirtyState, TerminalRenderUpdate, TerminalScrollbackExtent, TerminalScrollbarState, TerminalSnapshot, TerminalViewportKind,
         ViewportCommand, ViewportCommandOutcome,
     },
+    screen_activity::ScreenActivityTracker,
     session_runtime::{PtyOutput, SessionRuntime},
     vt,
 };
@@ -364,6 +365,7 @@ pub(crate) enum SessionCommand {
 pub(crate) struct SessionActor {
     tx: CommandSender,
     observation: Arc<ObservationMirror>,
+    screen_activity: ScreenActivityTracker,
     worker: Option<thread::JoinHandle<()>>,
 }
 
@@ -634,7 +636,7 @@ impl SessionActor {
         #[cfg(not(unix))]
         let tx = CommandSender::new(tx);
         match ready_rx.recv().map_err(|_| "session actor did not report startup".to_string())? {
-            Ok(()) => Ok(Self { tx, observation, worker: Some(worker) }),
+            Ok(screen_activity) => Ok(Self { tx, observation, screen_activity, worker: Some(worker) }),
             Err(err) => {
                 let _ = worker.join();
                 Err(err)
@@ -648,11 +650,15 @@ impl SessionActor {
         observation: Arc<ObservationMirror>,
         worker: Option<thread::JoinHandle<()>>,
     ) -> Self {
-        Self { tx: CommandSender::inert(tx), observation, worker }
+        Self { tx: CommandSender::inert(tx), observation, screen_activity: ScreenActivityTracker::new(0), worker }
     }
 
     pub(crate) fn observation(&self) -> &ObservationMirror {
         &self.observation
+    }
+
+    pub(crate) fn screen_activity(&self) -> &ScreenActivityTracker {
+        &self.screen_activity
     }
 
     /// True when the actor's worker thread has stopped. Combined with a
@@ -931,7 +937,7 @@ fn session_actor_loop(
     wake: WakeCallback,
     rows: u16,
     mirror: Arc<ObservationMirror>,
-    ready: mpsc::Sender<Result<(), String>>,
+    ready: mpsc::Sender<Result<ScreenActivityTracker, String>>,
     rx: mpsc::Receiver<SessionCommand>,
     #[cfg(unix)] command_wake: CommandWakeReader,
 ) {
@@ -943,7 +949,7 @@ fn session_actor_loop(
         raw_output_taps: Vec::new(),
         last_raw_output_sequence: 0,
     };
-    let _ = ready.send(Ok(()));
+    let _ = ready.send(Ok(runtime.screen_activity_tracker()));
     #[cfg(unix)]
     loop {
         let readiness = match wait_actor_ready(runtime.pty_child(), command_wake.raw_fd()) {

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -3,8 +3,10 @@ use std::io::{Error, ErrorKind, Read, Write};
 use serde::{Deserialize, Serialize};
 
 use crate::provider::{TerminalInputEvent, TerminalRenderUpdate};
+pub use crate::screen_activity::ScreenActivity;
 
-pub const PROTOCOL_VERSION: u16 = 3;
+/// Version 4 defines activity as render damage rather than raw PTY output.
+pub const PROTOCOL_VERSION: u16 = 4;
 pub const CHANNEL_CONTROL: u32 = 0;
 
 pub const MSG_CONTROL_HELLO: u8 = 1;
@@ -73,13 +75,6 @@ pub struct DirectoryEntry {
     pub rows: u16,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ScreenActivity {
-    Active,
-    Stable,
-}
-
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ActivitySession {
@@ -90,8 +85,8 @@ pub struct ActivitySession {
     /// window. While activity is `Active`, this is the quiet window that will
     /// become `Stable` once the configured threshold elapses.
     pub stable_since_unix_ms: u64,
-    /// Unix timestamp in milliseconds for the most recently observed render
-    /// generation change, or `None` before the session has rendered.
+    /// Unix timestamp in milliseconds for the most recently observed
+    /// render-changing output, or `None` before the screen has changed.
     pub last_output_at_unix_ms: Option<u64>,
 }
 
@@ -359,6 +354,11 @@ mod tests {
     #[test]
     fn current_hello_accepts_current_protocol_version() {
         assert!(ControlHello::current().accepts(PROTOCOL_VERSION));
+    }
+
+    #[test]
+    fn render_damage_activity_semantics_start_at_protocol_version_four() {
+        assert_eq!(PROTOCOL_VERSION, 4);
     }
 
     #[test]

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -5,6 +5,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+pub use crate::screen_activity::ScreenActivity;
 use crate::vt::VtEngineKind;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -35,14 +36,6 @@ pub struct SessionInfo {
 pub enum SessionStatus {
     Attached,
     Detached,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ScreenActivity {
-    Active,
-    #[default]
-    Stable,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/cleat/src/screen_activity.rs
+++ b/crates/cleat/src/screen_activity.rs
@@ -1,91 +1,177 @@
-use std::time::{Duration, Instant};
+//! Canonical screen-activity domain model.
+//!
+//! Activity is driven only by output that changes the rendered screen. Engines
+//! that cannot observe render changes leave the timeline untouched and
+//! therefore report a stable screen. JSON consumers project the timeline with
+//! [`JSON_SCREEN_ACTIVITY_STABLE_AFTER`]; packet subscribers project the same
+//! timeline with their requested threshold.
 
-use crate::protocol::ScreenActivity;
+use std::{
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
 
-pub(crate) const SCREEN_ACTIVITY_STABLE_AFTER: Duration = Duration::from_secs(1);
+use serde::{Deserialize, Serialize};
+
+pub(crate) const JSON_SCREEN_ACTIVITY_STABLE_AFTER: Duration = Duration::from_secs(1);
+
+/// Whether a session's rendered screen is changing within a stability window.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ScreenActivity {
+    Active,
+    #[default]
+    Stable,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ScreenActivitySnapshot {
     pub(crate) screen_activity: ScreenActivity,
+    /// Unix timestamp when the screen actually entered the stable state.
     pub(crate) stable_since: Option<u64>,
+    /// Unix timestamp at the beginning of the current quiet window.
+    pub(crate) quiet_since: u64,
+    /// Unix timestamp of the most recent render-changing output.
     pub(crate) last_output_at: Option<u64>,
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct ScreenActivityTracker {
+pub(crate) struct ScreenActivityTime {
+    instant: Instant,
+    unix_ms: u64,
+}
+
+impl ScreenActivityTime {
+    pub(crate) fn new(instant: Instant, unix_ms: u64) -> Self {
+        Self { instant, unix_ms }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ScreenActivityTimeline {
     initial_stable_since: u64,
-    last_render_change: Option<(Instant, u64)>,
+    last_render_change: Option<ScreenActivityTime>,
+}
+
+/// Shared render-change timeline used by JSON polling and packet subscriptions.
+#[derive(Clone, Debug)]
+pub(crate) struct ScreenActivityTracker {
+    timeline: Arc<RwLock<ScreenActivityTimeline>>,
 }
 
 impl ScreenActivityTracker {
     pub(crate) fn new(started_at_unix_ms: u64) -> Self {
-        Self { initial_stable_since: started_at_unix_ms, last_render_change: None }
+        Self {
+            timeline: Arc::new(RwLock::new(ScreenActivityTimeline { initial_stable_since: started_at_unix_ms, last_render_change: None })),
+        }
     }
 
-    pub(crate) fn render_changed(&mut self, changed_at: Instant, changed_at_unix_ms: u64) {
-        self.last_render_change = Some((changed_at, changed_at_unix_ms));
+    pub(crate) fn render_changed(&self, changed_at: ScreenActivityTime) {
+        self.timeline.write().unwrap_or_else(|poisoned| poisoned.into_inner()).last_render_change = Some(changed_at);
     }
 
-    pub(crate) fn snapshot(&self, now: Instant) -> ScreenActivitySnapshot {
-        let Some((changed_at, changed_at_unix_ms)) = self.last_render_change else {
+    pub(crate) fn json_snapshot(&self, now: Instant) -> ScreenActivitySnapshot {
+        self.snapshot(now, JSON_SCREEN_ACTIVITY_STABLE_AFTER)
+    }
+
+    pub(crate) fn snapshot(&self, now: Instant, stable_after: Duration) -> ScreenActivitySnapshot {
+        let timeline = *self.timeline.read().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(changed_at) = timeline.last_render_change else {
             return ScreenActivitySnapshot {
                 screen_activity: ScreenActivity::Stable,
-                stable_since: Some(self.initial_stable_since),
+                stable_since: Some(timeline.initial_stable_since),
+                quiet_since: timeline.initial_stable_since,
                 last_output_at: None,
             };
         };
 
-        if now.saturating_duration_since(changed_at) < SCREEN_ACTIVITY_STABLE_AFTER {
-            ScreenActivitySnapshot { screen_activity: ScreenActivity::Active, stable_since: None, last_output_at: Some(changed_at_unix_ms) }
+        if now.saturating_duration_since(changed_at.instant) < stable_after {
+            ScreenActivitySnapshot {
+                screen_activity: ScreenActivity::Active,
+                stable_since: None,
+                quiet_since: changed_at.unix_ms,
+                last_output_at: Some(changed_at.unix_ms),
+            }
         } else {
             ScreenActivitySnapshot {
                 screen_activity: ScreenActivity::Stable,
-                stable_since: Some(changed_at_unix_ms.saturating_add(SCREEN_ACTIVITY_STABLE_AFTER.as_millis() as u64)),
-                last_output_at: Some(changed_at_unix_ms),
+                stable_since: Some(changed_at.unix_ms.saturating_add(duration_millis(stable_after))),
+                quiet_since: changed_at.unix_ms,
+                last_output_at: Some(changed_at.unix_ms),
             }
         }
     }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::ScreenActivityTracker;
-    use crate::protocol::ScreenActivity;
+    use super::{ScreenActivity, ScreenActivityTime, ScreenActivityTracker, JSON_SCREEN_ACTIVITY_STABLE_AFTER};
+
+    fn activity_time(instant: Instant, unix_ms: u64) -> ScreenActivityTime {
+        ScreenActivityTime::new(instant, unix_ms)
+    }
 
     #[test]
     fn render_change_decays_from_active_to_stable_after_one_second() {
         let started_at = Instant::now();
-        let mut tracker = ScreenActivityTracker::new(1_000);
+        let tracker = ScreenActivityTracker::new(1_000);
 
-        assert_eq!(tracker.snapshot(started_at).screen_activity, ScreenActivity::Stable);
-        assert_eq!(tracker.snapshot(started_at).stable_since, Some(1_000));
-        assert_eq!(tracker.snapshot(started_at).last_output_at, None);
+        let initial = tracker.snapshot(started_at, JSON_SCREEN_ACTIVITY_STABLE_AFTER);
+        assert_eq!(initial.screen_activity, ScreenActivity::Stable);
+        assert_eq!(initial.stable_since, Some(1_000));
+        assert_eq!(initial.quiet_since, 1_000);
+        assert_eq!(initial.last_output_at, None);
 
-        tracker.render_changed(started_at + Duration::from_millis(100), 1_100);
+        tracker.render_changed(activity_time(started_at + Duration::from_millis(100), 1_100));
 
-        let active = tracker.snapshot(started_at + Duration::from_millis(1_099));
+        let active = tracker.snapshot(started_at + Duration::from_millis(1_099), JSON_SCREEN_ACTIVITY_STABLE_AFTER);
         assert_eq!(active.screen_activity, ScreenActivity::Active);
         assert_eq!(active.stable_since, None);
+        assert_eq!(active.quiet_since, 1_100);
         assert_eq!(active.last_output_at, Some(1_100));
 
-        let stable = tracker.snapshot(started_at + Duration::from_millis(1_100));
+        let stable = tracker.snapshot(started_at + Duration::from_millis(1_100), JSON_SCREEN_ACTIVITY_STABLE_AFTER);
         assert_eq!(stable.screen_activity, ScreenActivity::Stable);
         assert_eq!(stable.stable_since, Some(2_100));
+        assert_eq!(stable.quiet_since, 1_100);
         assert_eq!(stable.last_output_at, Some(1_100));
     }
 
     #[test]
     fn later_render_change_starts_a_new_active_period() {
         let started_at = Instant::now();
-        let mut tracker = ScreenActivityTracker::new(5_000);
-        tracker.render_changed(started_at + Duration::from_secs(2), 7_000);
+        let tracker = ScreenActivityTracker::new(5_000);
+        tracker.render_changed(activity_time(started_at + Duration::from_secs(2), 7_000));
 
-        let active = tracker.snapshot(started_at + Duration::from_millis(2_500));
+        let active = tracker.snapshot(started_at + Duration::from_millis(2_500), JSON_SCREEN_ACTIVITY_STABLE_AFTER);
 
         assert_eq!(active.screen_activity, ScreenActivity::Active);
         assert_eq!(active.stable_since, None);
         assert_eq!(active.last_output_at, Some(7_000));
+    }
+
+    #[test]
+    fn json_and_subscription_project_the_same_render_change_with_distinct_thresholds() {
+        let started_at = Instant::now();
+        let tracker = ScreenActivityTracker::new(1_000);
+        tracker.render_changed(activity_time(started_at + Duration::from_millis(100), 1_100));
+
+        let observed_at = started_at + Duration::from_millis(600);
+        let subscription = tracker.snapshot(observed_at, Duration::from_millis(400));
+        let json = tracker.json_snapshot(observed_at);
+
+        assert_eq!(subscription.screen_activity, ScreenActivity::Stable);
+        assert_eq!(subscription.stable_since, Some(1_500));
+        assert_eq!(subscription.quiet_since, 1_100);
+        assert_eq!(json.screen_activity, ScreenActivity::Active);
+        assert_eq!(json.stable_since, None);
+        assert_eq!(json.quiet_since, 1_100);
+        assert_eq!(subscription.last_output_at, json.last_output_at);
     }
 }

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -494,93 +494,6 @@ impl ScreenStableState {
     }
 }
 
-#[derive(Clone, Debug)]
-struct ScreenActivityTracker {
-    render_generation: u64,
-    stable_since: Instant,
-    stable_since_unix_ms: u64,
-    last_output_at: Option<Instant>,
-    last_output_at_unix_ms: Option<u64>,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct ActivityTime {
-    instant: Instant,
-    unix_ms: u64,
-}
-
-impl ActivityTime {
-    fn now() -> Self {
-        Self { instant: Instant::now(), unix_ms: unix_time_ms() }
-    }
-
-    fn unix_ms_for(self, earlier: Instant) -> u64 {
-        let elapsed_ms = self.instant.checked_duration_since(earlier).map(|elapsed| elapsed.as_millis()).unwrap_or(0);
-        self.unix_ms.saturating_sub(u64::try_from(elapsed_ms).unwrap_or(u64::MAX))
-    }
-}
-
-impl ScreenActivityTracker {
-    fn new(render_generation: u64) -> Self {
-        Self::new_at(render_generation, ActivityTime::now())
-    }
-
-    fn new_at(render_generation: u64, now: ActivityTime) -> Self {
-        Self {
-            render_generation,
-            stable_since: now.instant,
-            stable_since_unix_ms: now.unix_ms,
-            last_output_at: None,
-            last_output_at_unix_ms: None,
-        }
-    }
-
-    fn needs_observation(&self, render_generation: u64) -> bool {
-        render_generation != self.render_generation
-    }
-
-    fn observe(&mut self, render_generation: u64, last_output_at: Option<Instant>) {
-        self.observe_at(render_generation, last_output_at, ActivityTime::now());
-    }
-
-    fn observe_at(&mut self, render_generation: u64, last_output_at: Option<Instant>, observed_at: ActivityTime) {
-        if render_generation == self.render_generation {
-            return;
-        }
-        self.render_generation = render_generation;
-        if last_output_at == self.last_output_at {
-            return;
-        }
-        let Some(last_output_at) = last_output_at else {
-            return;
-        };
-        let last_output_at_unix_ms = observed_at.unix_ms_for(last_output_at);
-        self.stable_since = last_output_at;
-        self.stable_since_unix_ms = last_output_at_unix_ms;
-        self.last_output_at = Some(last_output_at);
-        self.last_output_at_unix_ms = Some(last_output_at_unix_ms);
-    }
-
-    fn session(&self, session_id: String, tags: Vec<String>, stable_threshold_ms: u64) -> ActivitySession {
-        self.session_at(session_id, tags, stable_threshold_ms, Instant::now())
-    }
-
-    fn session_at(&self, session_id: String, tags: Vec<String>, stable_threshold_ms: u64, observed_at: Instant) -> ActivitySession {
-        let stable_for_ms = observed_at
-            .checked_duration_since(self.stable_since)
-            .map(|elapsed| u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
-            .unwrap_or(0);
-        let activity = if stable_for_ms >= stable_threshold_ms { ScreenActivity::Stable } else { ScreenActivity::Active };
-        ActivitySession {
-            session_id,
-            tags,
-            activity,
-            stable_since_unix_ms: self.stable_since_unix_ms,
-            last_output_at_unix_ms: self.last_output_at_unix_ms,
-        }
-    }
-}
-
 fn unix_time_ms() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -621,7 +534,6 @@ struct HostedSession {
     /// Render generation at the last screen-stable fingerprint snapshot; lets
     /// the servicing loop skip full-grid snapshots while nothing has rendered.
     screen_stable_snapshot_generation: Option<u64>,
-    screen_activity: ScreenActivityTracker,
     should_keep_session_dir: bool,
 }
 
@@ -634,7 +546,6 @@ impl HostedSession {
             crate::session_runtime::SessionRuntime::spawn(actor_session_dir, &actor_session, default_vt_engine(&actor_session)?)
         })?;
         let raw_output_tap = actor.subscribe_raw_output()?;
-        let screen_activity = ScreenActivityTracker::new(actor.observation().render_generation());
         Ok(Self {
             metadata: session,
             actor,
@@ -647,21 +558,19 @@ impl HostedSession {
             pending_waits: Vec::new(),
             pending_expects: Vec::new(),
             screen_stable_snapshot_generation: None,
-            screen_activity,
             should_keep_session_dir,
         })
     }
 
-    fn observe_screen_activity(&mut self) -> Result<(), String> {
-        let render_generation = self.actor.observation().render_generation();
-        if self.screen_activity.needs_observation(render_generation) {
-            self.screen_activity.observe(render_generation, self.actor.last_pty_output_at()?);
-        }
-        Ok(())
-    }
-
     fn activity_session(&self, stable_threshold_ms: u64) -> ActivitySession {
-        self.screen_activity.session(self.metadata.id.clone(), self.metadata.tags.clone(), stable_threshold_ms)
+        let activity = self.actor.screen_activity().snapshot(Instant::now(), Duration::from_millis(stable_threshold_ms));
+        ActivitySession {
+            session_id: self.metadata.id.clone(),
+            tags: self.metadata.tags.clone(),
+            activity: activity.screen_activity,
+            stable_since_unix_ms: activity.quiet_since,
+            last_output_at_unix_ms: activity.last_output_at,
+        }
     }
 }
 
@@ -1206,14 +1115,11 @@ fn directory_snapshot_for_sessions(
 }
 
 fn activity_snapshot_for_sessions(
-    sessions: &mut HashMap<String, HostedSession>,
+    sessions: &HashMap<String, HostedSession>,
     selectors: &[String],
     stable_threshold_ms: u64,
-) -> Result<ActivitySnapshot, String> {
-    for hosted in sessions.values_mut() {
-        hosted.observe_screen_activity()?;
-    }
-    Ok(ActivitySnapshot { stable_threshold_ms, sessions: matching_activity_sessions(sessions, selectors, stable_threshold_ms) })
+) -> ActivitySnapshot {
+    ActivitySnapshot { stable_threshold_ms, sessions: matching_activity_sessions(sessions, selectors, stable_threshold_ms) }
 }
 
 fn matching_activity_sessions(
@@ -1408,8 +1314,6 @@ fn service_hosted_session(
     if output_drained {
         hosted.actor.enqueue_screen_activity_flush()?;
     }
-    hosted.observe_screen_activity()?;
-
     if resized || previous_controller_count != hosted.active_client.is_some() || previous_watcher_count != hosted.watchers.len() {
         broadcast_directory_upsert(directory_entry_for_session(layout, hosted, packet_clients)?, packet_clients)?;
     }
@@ -1726,8 +1630,7 @@ fn handle_http_request(
             let directory = directory_snapshot_for_sessions(state.layout, state.sessions, state.packet_clients, &selectors)?;
             let activity = subscribe
                 .screen_activity_stable_ms
-                .map(|stable_threshold_ms| activity_snapshot_for_sessions(state.sessions, &selectors, stable_threshold_ms))
-                .transpose()?;
+                .map(|stable_threshold_ms| activity_snapshot_for_sessions(state.sessions, &selectors, stable_threshold_ms));
             let packet_stream = stream.try_clone().map_err(|err| format!("clone HTTP packet stream: {err}"))?;
             #[cfg(unix)]
             set_stream_nonblocking(&packet_stream, true).map_err(|err| format!("set HTTP packet stream nonblocking: {err}"))?;
@@ -3364,25 +3267,6 @@ mod tests {
         assert!(!super::screen_stable_needs_snapshot(7, Some(7)));
         // A pump advanced the generation: re-fingerprint.
         assert!(super::screen_stable_needs_snapshot(8, Some(7)));
-    }
-
-    #[test]
-    fn screen_activity_only_resets_for_new_pty_output() {
-        let started_at = Instant::now();
-        let mut tracker = super::ScreenActivityTracker::new_at(1, super::ActivityTime { instant: started_at, unix_ms: 1_000 });
-
-        tracker.observe_at(2, None, super::ActivityTime { instant: started_at + Duration::from_millis(20), unix_ms: 1_020 });
-        let unchanged = tracker.session_at("alpha".to_string(), Vec::new(), 10, started_at + Duration::from_millis(20));
-        assert_eq!(unchanged.activity, crate::packet::ScreenActivity::Stable);
-        assert_eq!(unchanged.stable_since_unix_ms, 1_000);
-        assert_eq!(unchanged.last_output_at_unix_ms, None);
-
-        let output_at = started_at + Duration::from_millis(30);
-        tracker.observe_at(3, Some(output_at), super::ActivityTime { instant: started_at + Duration::from_millis(35), unix_ms: 1_035 });
-        let active = tracker.session_at("alpha".to_string(), Vec::new(), 10, started_at + Duration::from_millis(35));
-        assert_eq!(active.activity, crate::packet::ScreenActivity::Active);
-        assert_eq!(active.stable_since_unix_ms, 1_030);
-        assert_eq!(active.last_output_at_unix_ms, Some(1_030));
     }
 
     #[test]

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     recording::SessionRecorder,
     runtime::{normalize_tags, SessionMetadata},
-    screen_activity::ScreenActivityTracker,
+    screen_activity::{ScreenActivityTime, ScreenActivityTracker},
     vt::{self, TerminalModeState, VtEngine},
 };
 
@@ -43,7 +43,7 @@ pub(crate) struct SessionRuntime {
     epoch: Instant,
     last_pty_output_at: Option<Instant>,
     screen_activity: ScreenActivityTracker,
-    pending_screen_activity_at: Option<(Instant, u64)>,
+    pending_screen_activity_at: Option<ScreenActivityTime>,
     // Current cell pixel size, used to fill the PTY winsize ws_xpixel/ws_ypixel
     // so TIOCGWINSZ-based apps (e.g. katzensteg) can compute image aspect. Zero
     // until the first geometry/set_cell_size, matching a terminal that hasn't
@@ -133,6 +133,10 @@ impl SessionRuntime {
 
     pub(crate) fn last_pty_output_at(&self) -> Option<Instant> {
         self.last_pty_output_at
+    }
+
+    pub(crate) fn screen_activity_tracker(&self) -> ScreenActivityTracker {
+        self.screen_activity.clone()
     }
 
     pub(crate) fn recording_active(&self) -> bool {
@@ -300,7 +304,7 @@ impl SessionRuntime {
         }
         attachments.extend((0..watcher_count).map(|_| crate::protocol::AttachmentInspect { role: "watcher".to_string() }));
 
-        let activity = self.screen_activity.snapshot(Instant::now());
+        let activity = self.screen_activity.json_snapshot(Instant::now());
         InspectResult {
             session: crate::protocol::SessionInspect {
                 id: self.session.id.clone(),
@@ -458,24 +462,24 @@ impl SessionRuntime {
             }
         }
         if !chunks.is_empty() {
-            self.note_screen_activity_candidate(Instant::now(), unix_timestamp_millis(SystemTime::now()));
+            self.note_screen_activity_candidate(ScreenActivityTime::new(Instant::now(), unix_timestamp_millis(SystemTime::now())));
         }
         Ok(PtyOutput { chunks })
     }
 
-    fn note_screen_activity_candidate(&mut self, changed_at: Instant, changed_at_unix_ms: u64) {
+    fn note_screen_activity_candidate(&mut self, changed_at: ScreenActivityTime) {
         match self.vt_engine.screen_activity_changed() {
-            Ok(Some(true)) => self.pending_screen_activity_at = Some((changed_at, changed_at_unix_ms)),
+            Ok(Some(true)) => self.pending_screen_activity_at = Some(changed_at),
             Ok(Some(false) | None) => {}
             Err(err) => eprintln!("screen activity observation error: {err}"),
         }
     }
 
     fn observe_pending_screen_activity(&mut self) -> bool {
-        let Some((changed_at, changed_at_unix_ms)) = self.pending_screen_activity_at.take() else {
+        let Some(changed_at) = self.pending_screen_activity_at.take() else {
             return false;
         };
-        self.screen_activity.render_changed(changed_at, changed_at_unix_ms);
+        self.screen_activity.render_changed(changed_at);
         true
     }
 

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -16,11 +16,13 @@ use std::{
 
 use clap::Parser;
 #[cfg(feature = "ghostty-vt")]
+use cleat::packet::ScreenActivity;
+#[cfg(feature = "ghostty-vt")]
 use cleat::session::foreground_path;
 use cleat::{
     cli::{self, Cli, ExecResult},
     packet::{
-        ActivityEvent, ActivitySnapshot, ControlHello, DirectoryDelta, DirectorySnapshot, PacketFrame, ScreenActivity, CHANNEL_CONTROL,
+        ActivityEvent, ActivitySnapshot, ControlHello, DirectoryDelta, DirectorySnapshot, PacketFrame, CHANNEL_CONTROL,
         MSG_CONTROL_ACTIVITY_EVENT, MSG_CONTROL_ACTIVITY_SNAPSHOT, MSG_CONTROL_DIRECTORY_DELTA, MSG_CONTROL_DIRECTORY_SNAPSHOT,
         MSG_CONTROL_HELLO, PROTOCOL_VERSION,
     },
@@ -999,6 +1001,7 @@ fn activity_subscription_snapshot_covers_all_matching_sessions() {
     assert_eq!(snapshot.sessions.iter().map(|session| session.session_id.as_str()).collect::<Vec<_>>(), vec!["alpha", "beta"]);
 }
 
+#[cfg(feature = "ghostty-vt")]
 #[test]
 fn activity_subscription_emits_threshold_transitions() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
@@ -1008,7 +1011,7 @@ fn activity_subscription_emits_threshold_transitions() {
     service
         .create_with_options(
             Some("alpha".into()),
-            Some(VtEngineKind::Passthrough),
+            Some(VtEngineKind::Ghostty),
             None,
             Some("sh -c 'stty raw; exec cat'".into()),
             SessionStartOptions {
@@ -1025,16 +1028,8 @@ fn activity_subscription_emits_threshold_transitions() {
     let _directory = PacketFrame::read(&mut stream).expect("read directory");
     let snapshot =
         PacketFrame::read(&mut stream).expect("read activity snapshot").decode::<ActivitySnapshot>().expect("decode activity snapshot");
-    assert_eq!(snapshot.sessions[0].activity, ScreenActivity::Active);
-
-    let first_stable = read_activity_event(&mut stream, Duration::from_secs(2));
-    let ActivityEvent::ActivityChanged { session: stable, changed_at_unix_ms: first_stable_at } = first_stable else {
-        panic!("expected activity change");
-    };
-    assert_eq!(stable.session_id, "alpha");
-    assert_eq!(stable.tags, vec![selector.clone()]);
-    assert_eq!(stable.activity, ScreenActivity::Stable);
-    assert_eq!(first_stable_at, stable.stable_since_unix_ms + 500);
+    assert_eq!(snapshot.sessions[0].activity, ScreenActivity::Stable);
+    assert_eq!(snapshot.sessions[0].last_output_at_unix_ms, None);
 
     service.send_keys("alpha", b"screen changed").expect("write output-producing input");
     let active = read_activity_event(&mut stream, Duration::from_secs(2));
@@ -1042,9 +1037,9 @@ fn activity_subscription_emits_threshold_transitions() {
         panic!("expected activity change");
     };
     assert_eq!(active.activity, ScreenActivity::Active);
+    assert_eq!(active.tags, vec![selector]);
     assert!(active.last_output_at_unix_ms.is_some());
     assert_eq!(active_at, active.last_output_at_unix_ms.expect("active transition output timestamp"));
-    assert!(active_at >= first_stable_at);
 
     let stable_again = read_activity_event(&mut stream, Duration::from_secs(2));
     let ActivityEvent::ActivityChanged { session: stable_again, changed_at_unix_ms: stable_again_at } = stable_again else {


### PR DESCRIPTION
Closes #162.

## What changed

- define one canonical render-damage-based screen activity type and shared timeline for JSON polling and packet subscriptions
- keep JSON's fixed one-second projection while applying each packet subscriber's configurable stability threshold to the same timeline
- preserve multi-session membership and transition behavior, with unsupported engines remaining `stable`
- re-export the canonical activity enum from both existing public module paths
- advance the packet protocol to v4 so v3 raw-PTY activity semantics cannot silently interoperate with the new contract

## Why

The JSON surface filtered terminal query traffic through render damage, while packet subscriptions used raw PTY-output timing. The same session could therefore be `stable` in JSON but briefly `active` for subscribers. The two paths also maintained separate same-named enums and trackers.

## Impact and compatibility

Terminal queries no longer count as subscription activity where render-damage observation is supported. A never-rendered session starts `stable`; engines without activity observation remain `stable`. Packet activity message shapes are unchanged, but the semantic boundary is explicit in protocol v4 and v3 peers are rejected.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `./tools/prepare-ghostty-vt.sh`
- `cargo build -p cleat --locked --features ghostty-vt`
- `cargo test -p cleat --locked --features ghostty-vt`
- independent standards and issue-spec reviews, both with no remaining findings
