### PR TITLE
feat: add ambient daemon targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ find .tools/ghostty-install -maxdepth 3 | sort
 
 ## Session Model
 
-**Named daemons host sets of sessions.** A daemon is the process boundary for one named session set. The default daemon is named `default`; pass `--server NAME` to address a different daemon. A session address is therefore `(daemon, id)`, with an unqualified ID meaning "this ID in the selected daemon."
+**Named daemons host sets of sessions.** A daemon is the process boundary for one named session set. The default daemon is named `default`; pass `--server NAME` to address a different daemon. Without `--server`, commands target the ambient daemon named by `$CLEAT_DAEMON` when running inside a session, and `default` otherwise. An explicit `--server` always wins. A session address is therefore `(daemon, id)`, with an unqualified ID meaning "this ID in the selected daemon."
 
 **Session IDs.** You choose the ID (`cleat launch my-session`) or let cleat generate one (`session-<uuid>`). IDs are directory names under their daemon's `sessions/` directory, so use filesystem-safe characters. Launching with an ID that already has a live session in the selected daemon reuses that session; it does not create a duplicate.
 
@@ -74,6 +74,14 @@ find .tools/ghostty-install -maxdepth 3 | sort
 3. `$HOME/.local/state/cleat` on Unix, or `%LOCALAPPDATA%\cleat` on Windows
 
 Discovery fails with an actionable error when no persistent state directory is available; cleat never implicitly stores daemon state or recordings in a temporary directory. `CLEAT_RUNTIME_DIR` retains its historical name as the explicit whole-layout override. Use a short persistent path for this override if the discovered Unix socket path exceeds the platform limit; cleat rejects an unusable socket path before starting a daemon.
+
+Every daemon exports its coordinates into each session child, following the same pattern as tmux's `$TMUX` variable:
+
+- `$CLEAT_RUNTIME_DIR` — the daemon's state root, including private roots
+- `$CLEAT_DAEMON` — the daemon name used for ambient command targeting
+- `$CLEAT_SESSION` — the current session ID
+
+This makes bare commands inside a session use that session's daemon and state root. `cleat daemons` discovers daemon directories at the ambient root and the well-known XDG/platform roots. Discovery is intentionally best-effort, not exhaustive: private roots that are not ambient can remain undiscoverable, and each daemon's own Directory remains authoritative for its sessions. Use `cleat daemons --json` for structured `{name, runtime_root}` coordinates.
 
 Runtime layout v2 is daemon-scoped:
 
@@ -115,7 +123,8 @@ This subscription contract starts with packet protocol v4. Version 3 used raw PT
 
 | Command | Exercises | Notes |
 |---|---|---|
-| `--server NAME` | daemon selection | Selects the named daemon for the command; default is `default` |
+| `--server NAME` | daemon selection | Explicit daemon selection; otherwise `$CLEAT_DAEMON`, then `default` |
+| `daemons [--json]` | daemon discovery | Best-effort discovery across ambient and well-known state roots |
 | `launch [--tag TAG]... [--record|--no-record]` | daemon + VT engine + recording | Creates or reuses a session in the selected daemon |
 | `tag <id> +TAG -TAG` | daemon directory state | Mutates opaque tags; tags are not interpreted by cleat |
 | `attach` / `detach` | host terminal + daemon | While attached, host terminal is authoritative for query replies |

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -6,7 +6,7 @@ use crate::{
     http_uds,
     keys::encode_send_keys,
     protocol::{WaitCondition, WaitStatus},
-    runtime::{TerminalSize, DEFAULT_DAEMON_NAME},
+    runtime::{validate_runtime_name, TerminalSize, AMBIENT_DAEMON_ENV, DEFAULT_DAEMON_NAME},
     server::{EndBound, FallbackReason, SessionService, StartBound},
     vt::VtEngineKind,
 };
@@ -34,8 +34,8 @@ pub struct Cli {
     #[arg(long, hide = true)]
     pub runtime_root: Option<PathBuf>,
 
-    #[arg(long, global = true, default_value = DEFAULT_DAEMON_NAME, value_parser = parse_runtime_name)]
-    pub server: String,
+    #[arg(long, global = true, value_parser = parse_runtime_name, help = "Select daemon (explicit > CLEAT_DAEMON > default)")]
+    pub server: Option<String>,
 
     #[command(subcommand)]
     pub command: Command,
@@ -158,6 +158,11 @@ pub enum Command {
         all: bool,
         #[arg(long = "selector", value_name = "TAG", allow_hyphen_values = true, help = "Require an exact opaque tag match; repeatable")]
         selectors: Vec<String>,
+    },
+    /// List discoverable daemons (best effort; private state roots may not be found)
+    Daemons {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
     /// Add or remove opaque session tags
     Tag {
@@ -473,7 +478,11 @@ impl ExecResult {
 }
 
 pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
-    let service = match service.with_daemon(cli.server.clone()) {
+    let daemon_name = match resolve_daemon_name(cli.server.as_deref(), std::env::var_os(AMBIENT_DAEMON_ENV)) {
+        Ok(daemon_name) => daemon_name,
+        Err(err) => return ExecResult::Err(err),
+    };
+    let service = match service.with_daemon(daemon_name) {
         Ok(service) => service,
         Err(err) => return ExecResult::Err(err),
     };
@@ -579,6 +588,25 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 ExecResult::Ok(None)
             } else {
                 ExecResult::Ok(Some(sessions.iter().map(format_session_human).collect::<Vec<_>>().join("\n")))
+            }
+        }
+        Command::Daemons { json } => {
+            let daemons = service.discover_daemons();
+            if json {
+                match serde_json::to_string(&daemons) {
+                    Ok(output) => ExecResult::Ok(Some(output)),
+                    Err(err) => ExecResult::Err(format!("serialize daemon list: {err}")),
+                }
+            } else if daemons.is_empty() {
+                ExecResult::Ok(None)
+            } else {
+                ExecResult::Ok(Some(
+                    daemons
+                        .iter()
+                        .map(|daemon| format!("{}\t{}", daemon.name, daemon.runtime_root.display()))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                ))
             }
         }
         Command::Tag { id, mutations } => {
@@ -812,6 +840,18 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Err(e) => ExecResult::Err(e),
         },
     }
+}
+
+pub fn resolve_daemon_name(explicit: Option<&str>, ambient: Option<std::ffi::OsString>) -> Result<String, String> {
+    let daemon_name = match explicit {
+        Some(explicit) => explicit.to_string(),
+        None => match ambient {
+            Some(ambient) => ambient.into_string().map_err(|_| format!("{AMBIENT_DAEMON_ENV} must be valid UTF-8"))?,
+            None => DEFAULT_DAEMON_NAME.to_string(),
+        },
+    };
+    validate_runtime_name(&daemon_name)?;
+    Ok(daemon_name)
 }
 
 fn execute_wait(

--- a/crates/cleat/src/platform/pty/unsupported.rs
+++ b/crates/cleat/src/platform/pty/unsupported.rs
@@ -1,12 +1,12 @@
 use crate::{
     platform::ipc::{SessionListener, SessionStream},
-    runtime::SessionMetadata,
+    runtime::{AmbientSessionCoordinates, SessionMetadata},
 };
 
 pub struct PtyChild;
 
 impl PtyChild {
-    pub fn spawn(_session: &SessionMetadata) -> Result<Self, String> {
+    pub fn spawn_with_ambient(_session: &SessionMetadata, _coordinates: Option<&AmbientSessionCoordinates>) -> Result<Self, String> {
         Err("PTY sessions are only supported on Unix".to_string())
     }
 }

--- a/crates/cleat/src/platform/pty/windows.rs
+++ b/crates/cleat/src/platform/pty/windows.rs
@@ -1,7 +1,9 @@
 use std::{
-    ffi::c_void,
+    env,
+    ffi::{c_void, OsStr, OsString},
     io,
     mem::{size_of, zeroed},
+    os::windows::ffi::OsStrExt,
     path::PathBuf,
     ptr::{null, null_mut},
     thread,
@@ -17,8 +19,9 @@ use windows_sys::Win32::{
         Pipes::CreatePipe,
         Threading::{
             CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess, InitializeProcThreadAttributeList, TerminateProcess,
-            UpdateProcThreadAttribute, WaitForSingleObject, CREATE_NEW_PROCESS_GROUP, EXTENDED_STARTUPINFO_PRESENT,
-            LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+            UpdateProcThreadAttribute, WaitForSingleObject, CREATE_NEW_PROCESS_GROUP, CREATE_UNICODE_ENVIRONMENT,
+            EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+            STARTF_USESTDHANDLES, STARTUPINFOEXW,
         },
     },
 };
@@ -26,7 +29,7 @@ use windows_sys::Win32::{
 use crate::{
     platform::ipc::{handle_has_available_bytes, SessionListener, SessionStream},
     protocol::SignalTarget,
-    runtime::SessionMetadata,
+    runtime::{AmbientSessionCoordinates, SessionMetadata, AMBIENT_COORDINATE_ENV_NAMES},
 };
 
 const POSIX_SIGINT: i32 = 2;
@@ -43,10 +46,10 @@ pub struct PtyChild {
 }
 
 impl PtyChild {
-    pub fn spawn(session: &SessionMetadata) -> Result<Self, String> {
+    pub fn spawn_with_ambient(session: &SessionMetadata, coordinates: Option<&AmbientSessionCoordinates>) -> Result<Self, String> {
         let pipes = Pipes::new()?;
         let conpty = create_pseudo_console(session.initial_size.cols, session.initial_size.rows, pipes.input_read, pipes.output_write)?;
-        let process = spawn_with_conpty(&windows_shell_command(session), conpty, session.cwd.as_ref())?;
+        let process = spawn_with_conpty(&windows_shell_command(session), conpty, session.cwd.as_ref(), coordinates)?;
         unsafe {
             CloseHandle(pipes.input_read);
             CloseHandle(pipes.output_write);
@@ -252,7 +255,12 @@ fn create_pseudo_console(cols: u16, rows: u16, input: HANDLE, output: HANDLE) ->
     }
 }
 
-fn spawn_with_conpty(command_line: &str, conpty: HPCON, cwd: Option<&PathBuf>) -> Result<PROCESS_INFORMATION, String> {
+fn spawn_with_conpty(
+    command_line: &str,
+    conpty: HPCON,
+    cwd: Option<&PathBuf>,
+    coordinates: Option<&AmbientSessionCoordinates>,
+) -> Result<PROCESS_INFORMATION, String> {
     let mut attr_size = 0;
     unsafe {
         InitializeProcThreadAttributeList(null_mut(), 1, 0, &mut attr_size);
@@ -296,6 +304,10 @@ fn spawn_with_conpty(command_line: &str, conpty: HPCON, cwd: Option<&PathBuf>) -
     let mut command_line = wide_null(command_line);
     let cwd = cwd.map(|path| wide_null(&path.to_string_lossy()));
     let cwd_ptr = cwd.as_ref().map(|value| value.as_ptr()).unwrap_or_else(null);
+    let mut environment = coordinates.map(child_environment_block).transpose()?;
+    let environment_ptr = environment.as_mut().map(|block| block.as_mut_ptr().cast::<c_void>()).unwrap_or_else(null_mut);
+    let creation_flags =
+        EXTENDED_STARTUPINFO_PRESENT | CREATE_NEW_PROCESS_GROUP | if environment.is_some() { CREATE_UNICODE_ENVIRONMENT } else { 0 };
 
     let created = unsafe {
         CreateProcessW(
@@ -304,8 +316,8 @@ fn spawn_with_conpty(command_line: &str, conpty: HPCON, cwd: Option<&PathBuf>) -
             null(),
             null(),
             0,
-            EXTENDED_STARTUPINFO_PRESENT | CREATE_NEW_PROCESS_GROUP,
-            null(),
+            creation_flags,
+            environment_ptr,
             cwd_ptr,
             &startup_info as *const STARTUPINFOEXW as *const _,
             &mut process_info,
@@ -321,6 +333,27 @@ fn spawn_with_conpty(command_line: &str, conpty: HPCON, cwd: Option<&PathBuf>) -
     } else {
         Ok(process_info)
     }
+}
+
+fn child_environment_block(coordinates: &AmbientSessionCoordinates) -> Result<Vec<u16>, String> {
+    let mut variables: Vec<(OsString, OsString)> = env::vars_os()
+        .filter(|(key, _)| !AMBIENT_COORDINATE_ENV_NAMES.iter().any(|name| key.eq_ignore_ascii_case(OsStr::new(name))))
+        .collect();
+    variables.extend(coordinates.child_environment().map(|(name, value)| (OsString::from(name), value.to_os_string())));
+    variables
+        .sort_by(|(left, _), (right, _)| left.to_string_lossy().to_ascii_lowercase().cmp(&right.to_string_lossy().to_ascii_lowercase()));
+
+    let mut block = Vec::new();
+    for (key, value) in variables {
+        let mut entry: Vec<u16> = key.encode_wide().chain(std::iter::once('=' as u16)).chain(value.encode_wide()).collect();
+        if entry.contains(&0) {
+            return Err("environment contains interior nul".to_string());
+        }
+        block.append(&mut entry);
+        block.push(0);
+    }
+    block.push(0);
+    Ok(block)
 }
 
 fn windows_shell_command(session: &SessionMetadata) -> String {

--- a/crates/cleat/src/platform/unix.rs
+++ b/crates/cleat/src/platform/unix.rs
@@ -28,7 +28,7 @@ use nix::{
 use crate::{
     platform::ipc::{SessionListener, SessionStream},
     protocol::SignalTarget,
-    runtime::SessionMetadata,
+    runtime::{AmbientSessionCoordinates, SessionMetadata, AMBIENT_COORDINATE_ENV_NAMES},
 };
 
 const STRIP_ENV_VARS: &[&str] = &["SSH_TTY", "SSH_CONNECTION", "SSH_CLIENT"];
@@ -49,8 +49,8 @@ pub struct PtyChild {
 static SPAWN_CLOEXEC_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 impl PtyChild {
-    pub fn spawn(session: &SessionMetadata) -> Result<Self, String> {
-        let exec_spec = ChildExecSpec::new(session)?;
+    pub fn spawn_with_ambient(session: &SessionMetadata, coordinates: Option<&AmbientSessionCoordinates>) -> Result<Self, String> {
+        let exec_spec = ChildExecSpec::new(session, coordinates)?;
         let winsize = Winsize { ws_row: session.initial_size.rows, ws_col: session.initial_size.cols, ws_xpixel: 0, ws_ypixel: 0 };
         // The child never touches this lock (it only execs or exits), so
         // inheriting it in a locked state across the fork is harmless.
@@ -391,7 +391,7 @@ struct ChildExecSpec {
 }
 
 impl ChildExecSpec {
-    fn new(session: &SessionMetadata) -> Result<Self, String> {
+    fn new(session: &SessionMetadata, coordinates: Option<&AmbientSessionCoordinates>) -> Result<Self, String> {
         let shell = env::var_os("SHELL").unwrap_or_else(|| OsString::from("/bin/sh"));
         let program = cstring_from_os(resolve_shell_program(&shell).as_os_str(), "shell path contains interior nul")?;
         let mut argv = vec![cstring_from_os(&shell, "shell contains interior nul")?];
@@ -399,7 +399,7 @@ impl ChildExecSpec {
             argv.push(CString::new("-lc").map_err(|_| "invalid -lc".to_string())?);
             argv.push(CString::new(cmd.as_str()).map_err(|_| "cmd contains interior nul".to_string())?);
         }
-        let envp = filtered_envp_from(env::vars_os())?;
+        let envp = child_envp_from(env::vars_os(), coordinates)?;
         let cwd = session.cwd.as_ref().map(|cwd| cstring_from_os(cwd.as_os_str(), "cwd contains interior nul")).transpose()?;
         let argv_ptrs = null_terminated_ptrs(&argv);
         let envp_ptrs = null_terminated_ptrs(&envp);
@@ -447,10 +447,20 @@ fn is_executable_file(path: &Path) -> bool {
     unsafe { libc::access(path_c.as_ptr(), libc::X_OK) == 0 }
 }
 
+#[cfg(test)]
 fn filtered_envp_from(env: impl IntoIterator<Item = (OsString, OsString)>) -> Result<Vec<CString>, String> {
+    child_envp_from(env, None)
+}
+
+fn child_envp_from(
+    env: impl IntoIterator<Item = (OsString, OsString)>,
+    coordinates: Option<&AmbientSessionCoordinates>,
+) -> Result<Vec<CString>, String> {
     let mut envp = Vec::new();
     for (key, value) in env {
-        if STRIP_ENV_VARS.iter().any(|strip| key == OsStr::new(strip)) {
+        if STRIP_ENV_VARS.iter().any(|strip| key == OsStr::new(strip))
+            || coordinates.is_some() && AMBIENT_COORDINATE_ENV_NAMES.iter().any(|ambient| key == OsStr::new(ambient))
+        {
             continue;
         }
         let mut entry = Vec::with_capacity(key.as_bytes().len() + 1 + value.as_bytes().len());
@@ -458,6 +468,16 @@ fn filtered_envp_from(env: impl IntoIterator<Item = (OsString, OsString)>) -> Re
         entry.push(b'=');
         entry.extend_from_slice(value.as_bytes());
         envp.push(CString::new(entry).map_err(|_| "environment contains interior nul".to_string())?);
+    }
+    if let Some(coordinates) = coordinates {
+        for (key, value) in coordinates.child_environment() {
+            let key = OsStr::new(key);
+            let mut entry = Vec::with_capacity(key.as_bytes().len() + 1 + value.as_bytes().len());
+            entry.extend_from_slice(key.as_bytes());
+            entry.push(b'=');
+            entry.extend_from_slice(value.as_bytes());
+            envp.push(CString::new(entry).map_err(|_| "ambient session coordinates contain interior nul".to_string())?);
+        }
     }
     Ok(envp)
 }
@@ -655,7 +675,7 @@ mod tests {
             initial_size: TerminalSize::default(),
             colors: TerminalColors::default(),
         };
-        let pty_child = super::PtyChild::spawn(&session).expect("spawn pty child");
+        let pty_child = super::PtyChild::spawn_with_ambient(&session, None).expect("spawn pty child");
         pty_child.set_nonblocking().expect("set pty nonblocking");
         let deadline = Instant::now() + Duration::from_secs(5);
 
@@ -682,7 +702,7 @@ mod tests {
             initial_size: TerminalSize::default(),
             colors: TerminalColors::default(),
         };
-        let pty_child = super::PtyChild::spawn(&session).expect("spawn pty child");
+        let pty_child = super::PtyChild::spawn_with_ambient(&session, None).expect("spawn pty child");
         let master_fd = pty_child.master_fd();
         let pid = pty_child.leader_pid() as libc::pid_t;
 

--- a/crates/cleat/src/runtime.rs
+++ b/crates/cleat/src/runtime.rs
@@ -9,6 +9,10 @@ use crate::vt::{TerminalColors, VtEngineKind};
 
 const SESSION_ROOT_DIR: &str = "cleat";
 const SESSIONS_DIR: &str = "sessions";
+pub const RUNTIME_DIR_ENV: &str = "CLEAT_RUNTIME_DIR";
+pub const AMBIENT_DAEMON_ENV: &str = "CLEAT_DAEMON";
+pub const AMBIENT_SESSION_ENV: &str = "CLEAT_SESSION";
+pub const AMBIENT_COORDINATE_ENV_NAMES: [&str; 3] = [RUNTIME_DIR_ENV, AMBIENT_DAEMON_ENV, AMBIENT_SESSION_ENV];
 pub const DEFAULT_DAEMON_NAME: &str = "default";
 pub const DEFAULT_TERMINAL_COLS: u16 = 80;
 pub const DEFAULT_TERMINAL_ROWS: u16 = 24;
@@ -50,10 +54,45 @@ pub struct RuntimeLayout {
     daemon_name: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmbientSessionCoordinates {
+    runtime_root: PathBuf,
+    daemon_name: String,
+    session_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct DaemonCoordinates {
+    pub name: String,
+    pub runtime_root: PathBuf,
+}
+
+impl AmbientSessionCoordinates {
+    pub fn runtime_root(&self) -> &Path {
+        &self.runtime_root
+    }
+
+    pub fn daemon_name(&self) -> &str {
+        &self.daemon_name
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    pub fn child_environment(&self) -> [(&'static str, &std::ffi::OsStr); 3] {
+        [
+            (RUNTIME_DIR_ENV, self.runtime_root.as_os_str()),
+            (AMBIENT_DAEMON_ENV, std::ffi::OsStr::new(&self.daemon_name)),
+            (AMBIENT_SESSION_ENV, std::ffi::OsStr::new(&self.session_id)),
+        ]
+    }
+}
+
 impl RuntimeLayout {
     pub fn discover() -> Result<Self, String> {
         Ok(Self {
-            root: discover_runtime_root(env::var_os("CLEAT_RUNTIME_DIR"), env::var_os("XDG_STATE_HOME"), platform_state_dir())?,
+            root: discover_runtime_root(env::var_os(RUNTIME_DIR_ENV), env::var_os("XDG_STATE_HOME"), platform_state_dir())?,
             daemon_name: DEFAULT_DAEMON_NAME.to_string(),
         })
     }
@@ -74,6 +113,15 @@ impl RuntimeLayout {
 
     pub fn daemon_name(&self) -> &str {
         &self.daemon_name
+    }
+
+    pub fn session_coordinates(&self, session_id: &str) -> Result<AmbientSessionCoordinates, String> {
+        let runtime_root = if self.root.is_absolute() {
+            self.root.clone()
+        } else {
+            env::current_dir().map_err(|err| format!("resolve relative runtime root {}: {err}", self.root.display()))?.join(&self.root)
+        };
+        Ok(AmbientSessionCoordinates { runtime_root, daemon_name: self.daemon_name.clone(), session_id: session_id.to_string() })
     }
 
     pub fn daemon_dir(&self) -> PathBuf {
@@ -146,6 +194,30 @@ impl RuntimeLayout {
     }
 }
 
+pub fn discoverable_runtime_roots() -> Vec<PathBuf> {
+    discoverable_runtime_roots_from(env::var_os(RUNTIME_DIR_ENV), env::var_os("XDG_STATE_HOME"), platform_state_dir())
+}
+
+fn discoverable_runtime_roots_from(
+    ambient_root: Option<std::ffi::OsString>,
+    xdg_state_home: Option<std::ffi::OsString>,
+    platform_state_dir: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(root) = ambient_root {
+        roots.push(PathBuf::from(root));
+    }
+    if let Some(xdg_state_home) = xdg_state_home.map(PathBuf::from).filter(|path| path.is_absolute()) {
+        roots.push(xdg_state_home.join(SESSION_ROOT_DIR));
+    }
+    if let Some(platform_state_dir) = platform_state_dir {
+        roots.push(platform_state_dir.join(SESSION_ROOT_DIR));
+    }
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
 pub fn validate_runtime_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("name must not be empty".to_string());
@@ -196,7 +268,24 @@ fn platform_state_dir() -> Option<PathBuf> {
 mod tests {
     use std::{ffi::OsString, path::PathBuf};
 
-    use super::discover_runtime_root;
+    use super::{discover_runtime_root, RuntimeLayout, AMBIENT_DAEMON_ENV, AMBIENT_SESSION_ENV, RUNTIME_DIR_ENV};
+
+    #[test]
+    fn relative_layout_defines_absolute_child_coordinates() {
+        let coordinates = RuntimeLayout::new(PathBuf::from("relative/private-state"))
+            .with_daemon("agent-loop".to_string())
+            .expect("named daemon")
+            .session_coordinates("worker")
+            .expect("session coordinates");
+
+        assert!(coordinates.runtime_root().is_absolute());
+        assert!(coordinates.runtime_root().ends_with("relative/private-state"));
+        assert_eq!(coordinates.child_environment().map(|(name, value)| (name, value.to_string_lossy().into_owned())), [
+            (RUNTIME_DIR_ENV, coordinates.runtime_root().display().to_string()),
+            (AMBIENT_DAEMON_ENV, "agent-loop".to_string()),
+            (AMBIENT_SESSION_ENV, "worker".to_string()),
+        ]);
+    }
 
     #[test]
     fn discover_runtime_root_prefers_explicit_root() {

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -15,7 +15,7 @@ use crate::{
         ipc::{set_stream_read_timeout, try_connect_session_stream, SessionStream},
     },
     protocol::{SessionInfo, SessionStatus},
-    runtime::{RuntimeLayout, TerminalSize},
+    runtime::{discoverable_runtime_roots, validate_runtime_name, DaemonCoordinates, RuntimeLayout, TerminalSize},
     session::{attach_foreground, ensure_session_started, run_session_daemon, watch_foreground, ForegroundAttach, SessionStartOptions},
     vt::VtEngineKind,
 };
@@ -82,6 +82,36 @@ impl SessionService {
 
     pub fn layout_root(&self) -> &std::path::Path {
         self.layout.root()
+    }
+
+    pub fn discover_daemons(&self) -> Vec<DaemonCoordinates> {
+        let mut roots = discoverable_runtime_roots();
+        roots.push(self.layout.root().to_path_buf());
+        roots.sort();
+        roots.dedup();
+
+        let mut daemons = Vec::new();
+        for root in roots {
+            let Ok(entries) = std::fs::read_dir(&root) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_dir() || !path.join("sessions").is_dir() {
+                    continue;
+                }
+                let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                    continue;
+                };
+                if validate_runtime_name(name).is_err() {
+                    continue;
+                }
+                daemons.push(DaemonCoordinates { name: name.to_string(), runtime_root: root.clone() });
+            }
+        }
+        daemons.sort_by(|left, right| left.runtime_root.cmp(&right.runtime_root).then_with(|| left.name.cmp(&right.name)));
+        daemons.dedup();
+        daemons
     }
 
     pub fn session_dir(&self, id: &str) -> std::path::PathBuf {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -38,7 +38,7 @@ use crate::{
     provider::{
         DirtyState, TerminalInputEvent, TerminalKey, TerminalMouseButton, TerminalMouseEventKind, TerminalNamedKey, TerminalRenderUpdate,
     },
-    runtime::{RuntimeLayout, SessionMetadata, TerminalSize},
+    runtime::{AmbientSessionCoordinates, RuntimeLayout, SessionMetadata, TerminalSize},
     vt::{self, ScreenGrid, VtEngine, VtEngineKind},
 };
 
@@ -538,12 +538,17 @@ struct HostedSession {
 }
 
 impl HostedSession {
-    fn spawn(session_dir: PathBuf, session: SessionMetadata) -> Result<Self, String> {
+    fn spawn(session_dir: PathBuf, session: SessionMetadata, coordinates: AmbientSessionCoordinates) -> Result<Self, String> {
         let should_keep_session_dir = session.record;
         let actor_session_dir = session_dir;
         let actor_session = session.clone();
         let actor = SessionActor::spawn(session.initial_size.rows, Arc::new(|| {}), move || {
-            crate::session_runtime::SessionRuntime::spawn(actor_session_dir, &actor_session, default_vt_engine(&actor_session)?)
+            crate::session_runtime::SessionRuntime::spawn_in_daemon(
+                actor_session_dir,
+                &actor_session,
+                default_vt_engine(&actor_session)?,
+                &coordinates,
+            )
         })?;
         let raw_output_tap = actor.subscribe_raw_output()?;
         Ok(Self {
@@ -1591,7 +1596,8 @@ fn handle_http_request(
             if !state.sessions.contains_key(&session.id) {
                 let session_dir = state.layout.session_dir(&session.id);
                 fs::create_dir_all(&session_dir).map_err(|err| format!("create session dir {}: {err}", session_dir.display()))?;
-                let hosted = HostedSession::spawn(session_dir, session.clone())?;
+                let coordinates = state.layout.session_coordinates(&session.id)?;
+                let hosted = HostedSession::spawn(session_dir, session.clone(), coordinates)?;
                 state.sessions.insert(session.id.clone(), hosted);
                 created = true;
             }

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -16,7 +16,7 @@ use crate::{
         ViewportCommandOutcome,
     },
     recording::SessionRecorder,
-    runtime::{normalize_tags, SessionMetadata},
+    runtime::{normalize_tags, AmbientSessionCoordinates, SessionMetadata},
     screen_activity::{ScreenActivityTime, ScreenActivityTracker},
     vt::{self, TerminalModeState, VtEngine},
 };
@@ -59,7 +59,25 @@ pub(crate) struct PtyOutput {
 }
 
 impl SessionRuntime {
-    pub(crate) fn spawn(session_dir: PathBuf, session: &SessionMetadata, mut vt_engine: Box<dyn VtEngine>) -> Result<Self, String> {
+    pub(crate) fn spawn(session_dir: PathBuf, session: &SessionMetadata, vt_engine: Box<dyn VtEngine>) -> Result<Self, String> {
+        Self::spawn_inner(session_dir, session, vt_engine, None)
+    }
+
+    pub(crate) fn spawn_in_daemon(
+        session_dir: PathBuf,
+        session: &SessionMetadata,
+        vt_engine: Box<dyn VtEngine>,
+        coordinates: &AmbientSessionCoordinates,
+    ) -> Result<Self, String> {
+        Self::spawn_inner(session_dir, session, vt_engine, Some(coordinates))
+    }
+
+    fn spawn_inner(
+        session_dir: PathBuf,
+        session: &SessionMetadata,
+        mut vt_engine: Box<dyn VtEngine>,
+        coordinates: Option<&AmbientSessionCoordinates>,
+    ) -> Result<Self, String> {
         // Recreation from recording (ADR 0001): if the session dir already holds
         // a recording from a prior activation, replay it into the fresh engine so
         // its history returns as scrollback above the freshly-invoked command.
@@ -76,7 +94,7 @@ impl SessionRuntime {
             let _ = vt_engine.drain_replies();
         }
 
-        let pty_child = PtyChild::spawn(session)?;
+        let pty_child = PtyChild::spawn_with_ambient(session, coordinates)?;
         pty_child.set_nonblocking()?;
         let detached_da = match session.vt_engine {
             // The DA tracker is the only DA source for the passthrough engine.

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -1,11 +1,39 @@
 use clap::{CommandFactory, Parser};
 use cleat::{
-    cli::{self, execute, Cli, Command, ExecResult, RecordFlags},
+    cli::{self, execute, resolve_daemon_name, Cli, Command, ExecResult, RecordFlags},
     runtime::{RuntimeLayout, TerminalSize},
     server::SessionService,
     session::session_socket_path,
     vt::{self, VtEngineKind},
 };
+
+#[test]
+fn daemon_target_resolution_prefers_explicit_server_over_ambient() {
+    let resolved = resolve_daemon_name(Some("explicit"), Some("ambient".into())).expect("resolve daemon");
+
+    assert_eq!(resolved, "explicit");
+}
+
+#[test]
+fn daemon_target_resolution_uses_ambient_server_when_unqualified() {
+    let resolved = resolve_daemon_name(None, Some("ambient".into())).expect("resolve daemon");
+
+    assert_eq!(resolved, "ambient");
+}
+
+#[test]
+fn daemon_target_resolution_falls_back_to_default_outside_a_session() {
+    let resolved = resolve_daemon_name(None, None).expect("resolve daemon");
+
+    assert_eq!(resolved, cleat::runtime::DEFAULT_DAEMON_NAME);
+}
+
+#[test]
+fn daemon_target_resolution_rejects_an_invalid_ambient_server() {
+    let err = resolve_daemon_name(None, Some("not/a/name".into())).expect_err("reject invalid ambient daemon");
+
+    assert!(err.contains("invalid filesystem-safe name"), "{err}");
+}
 
 #[test]
 fn help_lists_expected_subcommands() {
@@ -17,6 +45,7 @@ fn help_lists_expected_subcommands() {
         "packets",
         "launch",
         "list",
+        "daemons",
         "tag",
         "capture",
         "transcript",
@@ -249,6 +278,13 @@ fn list_command_rejects_all_with_watch() {
 }
 
 #[test]
+fn daemons_command_parses_json() {
+    let cli = Cli::try_parse_from(["cleat", "daemons", "--json"]).expect("daemons --json parses");
+
+    assert_eq!(cli.command, Command::Daemons { json: true });
+}
+
+#[test]
 fn capture_command_parses() {
     let cli = Cli::try_parse_from(["cleat", "capture", "session-1"]).expect("capture parses");
     assert_eq!(cli.command, Command::Capture { id: "session-1".into() });
@@ -405,7 +441,7 @@ fn record_flags_explicit_record_enables() {
 #[test]
 fn serve_parses_as_daemon_scoped_command() {
     let cli = Cli::try_parse_from(["cleat", "--server", "alternate", "serve"]).expect("parse serve");
-    assert_eq!(cli.server, "alternate");
+    assert_eq!(cli.server.as_deref(), Some("alternate"));
     assert!(matches!(cli.command, Command::Serve));
 }
 
@@ -419,7 +455,7 @@ fn mark_command_parses_session_id() {
 fn send_keys_execute_reports_missing_session() {
     let cli = Cli {
         runtime_root: None,
-        server: cleat::runtime::DEFAULT_DAEMON_NAME.to_string(),
+        server: Some(cleat::runtime::DEFAULT_DAEMON_NAME.to_string()),
         command: Command::SendKeys {
             id: "demo".into(),
             literal: false,

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -514,6 +514,84 @@ fn create_existing_session_returns_its_running_metadata() {
 }
 
 #[test]
+fn daemon_exports_private_root_name_and_session_id_to_the_child() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let layout = RuntimeLayout::new(temp.path().join("private-state")).with_daemon("agent-loop".to_string()).expect("named daemon layout");
+    let service = SessionService::new(layout.clone());
+    let output_path = temp.path().join("ambient-coordinates");
+    let command = "printf '%s\\n%s\\n%s\\n' \"$CLEAT_RUNTIME_DIR\" \"$CLEAT_DAEMON\" \"$CLEAT_SESSION\" > ambient-coordinates; sleep 30";
+
+    service
+        .create(Some("worker".into()), Some(VtEngineKind::Passthrough), Some(temp.path().to_path_buf()), Some(command.into()), false)
+        .expect("create session");
+    wait_until("ambient coordinates file", || output_path.exists());
+
+    let coordinates = std::fs::read_to_string(&output_path).expect("read ambient coordinates");
+    assert_eq!(coordinates, format!("{}\nagent-loop\nworker\n", layout.root().display()));
+
+    service.kill("worker").expect("kill session");
+}
+
+#[test]
+fn daemons_lists_ambient_and_well_known_roots_best_effort() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let ambient_root = temp.path().join("private-state");
+    let xdg_home = temp.path().join("xdg-state");
+    let well_known_root = xdg_home.join("cleat");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(ambient_root.join("ambient-daemon/sessions")).expect("create ambient daemon directory");
+    std::fs::create_dir_all(well_known_root.join("well-known/sessions")).expect("create well-known daemon directory");
+    std::fs::create_dir_all(well_known_root.join("not a daemon/sessions")).expect("create malformed daemon directory");
+    let _runtime = EnvVarGuard::set("CLEAT_RUNTIME_DIR", ambient_root.to_str().expect("utf8 ambient root"));
+    let _daemon = EnvVarGuard::set("CLEAT_DAEMON", "ambient-daemon");
+    let _xdg = EnvVarGuard::set("XDG_STATE_HOME", xdg_home.to_str().expect("utf8 xdg root"));
+    let _home = EnvVarGuard::set("HOME", home.to_str().expect("utf8 home"));
+    let service = SessionService::new(RuntimeLayout::new(ambient_root.clone()));
+    let cli = Cli::try_parse_from(["cleat", "daemons", "--json"]).expect("parse daemons");
+
+    let output = cli::execute(cli, &service).expect("execute daemons").expect("daemon list output");
+    let daemons: serde_json::Value = serde_json::from_str(&output).expect("parse daemon list JSON");
+
+    assert_eq!(
+        daemons,
+        serde_json::json!([
+            {"name": "ambient-daemon", "runtime_root": ambient_root},
+            {"name": "well-known", "runtime_root": well_known_root},
+        ])
+    );
+}
+
+#[test]
+fn bare_list_targets_ambient_daemon_and_explicit_server_wins() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let ambient = service.with_daemon("agent-loop".to_string()).expect("ambient daemon service");
+    service
+        .create(Some("default-session".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+        .expect("create default session");
+    ambient
+        .create(Some("ambient-session".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+        .expect("create ambient session");
+    let _daemon = EnvVarGuard::set("CLEAT_DAEMON", "agent-loop");
+
+    let bare = Cli::try_parse_from(["cleat", "list", "--json"]).expect("parse bare list");
+    let bare_output = cli::execute(bare, &service).expect("execute bare list").expect("bare list output");
+    let bare_sessions: Vec<SessionInfo> = serde_json::from_str(&bare_output).expect("parse bare list JSON");
+    assert_eq!(bare_sessions.iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), ["ambient-session"]);
+
+    let explicit = Cli::try_parse_from(["cleat", "--server", "default", "list", "--json"]).expect("parse explicit list");
+    let explicit_output = cli::execute(explicit, &service).expect("execute explicit list").expect("explicit list output");
+    let explicit_sessions: Vec<SessionInfo> = serde_json::from_str(&explicit_output).expect("parse explicit list JSON");
+    assert_eq!(explicit_sessions.iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), ["default-session"]);
+
+    ambient.kill("ambient-session").expect("kill ambient session");
+    service.kill("default-session").expect("kill default session");
+}
+
+#[test]
 fn failures_after_protocol_upgrade_close_without_an_http_error() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     for route in ["attach", "watch", "packet"] {


### PR DESCRIPTION
## Summary

- export `CLEAT_RUNTIME_DIR`, `CLEAT_DAEMON`, and `CLEAT_SESSION` into daemon-hosted session children
- resolve every CLI target with explicit `--server` first, then the ambient daemon, then `default`
- add best-effort `cleat daemons` discovery across ambient and well-known state roots
- document targeting precedence, exported coordinates, and non-exhaustive discovery

## Why

Named daemons are isolation boundaries, so an unqualified command inside a session should stay with the daemon that hosts that session. Carrying the state root and daemon name in the child environment also preserves this behavior for private roots.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #167