### PR TITLE
Launch sibling sessions in the source daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ find .tools/ghostty-install -maxdepth 3 | sort
 
 **Session IDs.** You choose the ID (`cleat launch my-session`) or let cleat generate one (`session-<uuid>`). IDs are directory names under their daemon's `sessions/` directory, so use filesystem-safe characters. Launching with an ID that already has a live session in the selected daemon reuses that session; it does not create a duplicate.
 
+**Sibling sessions.** `cleat launch [ID] --from SOURCE` resolves the daemon that owns `SOURCE` and applies the normal launch behavior there. The new session shares that daemon's initial execution context, not the source session's current cwd or exported variables. `--from` and `--server` are mutually exclusive; use `--server` directly when the same source ID exists in more than one daemon.
+
 **Tags.** Sessions may carry flat, opaque tags. Add them at launch with repeated `--tag TAG`, mutate them with `cleat tag <id> +TAG -TAG`, and filter directory reads with repeated `--selector TAG`. Selectors are exact whole-tag matches and are ANDed when repeated. `key=value` is only a client convention; cleat does not interpret tag keys, values, hierarchy, or globs.
 
 **State directory.** The daemon registration, control socket, session state, and recordings share one root, discovered in priority order:
@@ -116,7 +118,7 @@ This subscription contract starts with packet protocol v4. Version 3 used raw PT
 | Command | Exercises | Notes |
 |---|---|---|
 | `--server NAME` | daemon selection | Selects the named daemon for the command; default is `default` |
-| `launch [--tag TAG]... [--record|--no-record]` | daemon + VT engine + recording | Creates or reuses a session in the selected daemon |
+| `launch [--from SOURCE] [--tag TAG]... [--record|--no-record]` | daemon + VT engine + recording | Creates or reuses a session in the selected daemon, or in `SOURCE`'s daemon with `--from` |
 | `tag <id> +TAG -TAG` | daemon directory state | Mutates opaque tags; tags are not interpreted by cleat |
 | `attach` / `detach` | host terminal + daemon | While attached, host terminal is authoritative for query replies |
 | `watch` | host terminal + daemon | Read-only live view; does not take foreground control |

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -42,6 +42,8 @@ pub struct Cli {
 }
 
 impl Cli {
+    /// Adds product-level validation that clap cannot express across a global
+    /// option and a field on one subcommand.
     pub fn try_parse_from<I, T>(args: I) -> Result<Self, clap::Error>
     where
         I: IntoIterator<Item = T>,
@@ -51,7 +53,7 @@ impl Cli {
     }
 
     fn validate_daemon_target(self) -> Result<Self, clap::Error> {
-        if self.server.is_some() && matches!(&self.command, Command::Launch { from: Some(_), .. }) {
+        if self.has_conflicting_daemon_targets() {
             return Err(clap::Error::raw(
                 clap::error::ErrorKind::ArgumentConflict,
                 "the argument '--server <SERVER>' cannot be used with '--from <SESSION>'",
@@ -59,6 +61,10 @@ impl Cli {
             .with_cmd(&Self::command()));
         }
         Ok(self)
+    }
+
+    fn has_conflicting_daemon_targets(&self) -> bool {
+        self.server.is_some() && matches!(&self.command, Command::Launch { from: Some(_), .. })
     }
 }
 
@@ -498,7 +504,7 @@ impl ExecResult {
 }
 
 pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
-    if cli.server.is_some() && matches!(&cli.command, Command::Launch { from: Some(_), .. }) {
+    if cli.has_conflicting_daemon_targets() {
         return ExecResult::Err("--server cannot be used with --from".to_string());
     }
     let daemon_target = match resolve_daemon_target(&cli, service) {

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -7,7 +7,7 @@ use crate::{
     keys::encode_send_keys,
     protocol::{WaitCondition, WaitStatus},
     runtime::{TerminalSize, DEFAULT_DAEMON_NAME},
-    server::{EndBound, FallbackReason, SessionService, StartBound},
+    server::{DaemonInstance, EndBound, FallbackReason, SessionService, StartBound},
     vt::VtEngineKind,
 };
 
@@ -501,11 +501,11 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
     if cli.server.is_some() && matches!(&cli.command, Command::Launch { from: Some(_), .. }) {
         return ExecResult::Err("--server cannot be used with --from".to_string());
     }
-    let daemon_name = match resolve_daemon_target(&cli, service) {
-        Ok(daemon_name) => daemon_name,
+    let daemon_target = match resolve_daemon_target(&cli, service) {
+        Ok(daemon_target) => daemon_target,
         Err(err) => return ExecResult::Err(err),
     };
-    let service = match service.with_daemon(daemon_name) {
+    let service = match service.with_daemon(daemon_target.name().to_string()) {
         Ok(service) => service,
         Err(err) => return ExecResult::Err(err),
     };
@@ -558,7 +558,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Ok(lines) => ExecResult::Ok(Some(lines.join("\n"))),
             Err(err) => ExecResult::Err(err),
         },
-        Command::Launch { id, from, json, size, vt, cwd, cmd, tags, record } => {
+        Command::Launch { id, from: _, json, size, vt, cwd, cmd, tags, record } => {
             // Windows can provide basic sessions through ConPTY plus the
             // passthrough engine while Ghostty VT support is still optional.
             #[cfg(not(windows))]
@@ -575,11 +575,11 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 colors: crate::vt::TerminalColors::default(),
                 tags,
             };
-            let created = match if from.is_some() {
-                service.create_with_options_in_running_daemon(id, vt, cwd, cmd, options)
-            } else {
-                service.create_with_options(id, vt, cwd, cmd, options)
-            } {
+            let create_result = match &daemon_target {
+                DaemonTarget::Running(daemon) => service.create_with_options_in_running_daemon(daemon, id, vt, cwd, cmd, options),
+                DaemonTarget::AutoStart(_) => service.create_with_options(id, vt, cwd, cmd, options),
+            };
+            let created = match create_result {
                 Ok(v) => v,
                 Err(e) => return ExecResult::Err(e),
             };
@@ -851,16 +851,30 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
     }
 }
 
-fn resolve_daemon_target(cli: &Cli, service: &SessionService) -> Result<String, String> {
+enum DaemonTarget {
+    AutoStart(String),
+    Running(DaemonInstance),
+}
+
+impl DaemonTarget {
+    fn name(&self) -> &str {
+        match self {
+            Self::AutoStart(name) => name,
+            Self::Running(daemon) => daemon.name(),
+        }
+    }
+}
+
+fn resolve_daemon_target(cli: &Cli, service: &SessionService) -> Result<DaemonTarget, String> {
     if let Some(daemon_name) = &cli.server {
-        return Ok(daemon_name.clone());
+        return Ok(DaemonTarget::AutoStart(daemon_name.clone()));
     }
 
     let Command::Launch { from: Some(source), .. } = &cli.command else {
-        return Ok(DEFAULT_DAEMON_NAME.to_string());
+        return Ok(DaemonTarget::AutoStart(DEFAULT_DAEMON_NAME.to_string()));
     };
 
-    service.daemon_owning_session(source)
+    service.daemon_owning_session(source).map(DaemonTarget::Running)
 }
 
 fn execute_wait(

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -42,16 +42,16 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn try_parse_from<I, T>(itr: I) -> Result<Self, clap::Error>
+    pub fn try_parse_from<I, T>(args: I) -> Result<Self, clap::Error>
     where
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        <Self as Parser>::try_parse_from(itr)?.validate_daemon_target()
+        <Self as Parser>::try_parse_from(args)?.validate_daemon_target()
     }
 
     fn validate_daemon_target(self) -> Result<Self, clap::Error> {
-        if self.server.is_some() && matches!(self.command, Command::Launch { from: Some(_), .. }) {
+        if self.server.is_some() && matches!(&self.command, Command::Launch { from: Some(_), .. }) {
             return Err(clap::Error::raw(
                 clap::error::ErrorKind::ArgumentConflict,
                 "the argument '--server <SERVER>' cannot be used with '--from <SESSION>'",
@@ -498,6 +498,9 @@ impl ExecResult {
 }
 
 pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
+    if cli.server.is_some() && matches!(&cli.command, Command::Launch { from: Some(_), .. }) {
+        return ExecResult::Err("--server cannot be used with --from".to_string());
+    }
     let daemon_name = match resolve_daemon_target(&cli, service) {
         Ok(daemon_name) => daemon_name,
         Err(err) => return ExecResult::Err(err),
@@ -555,7 +558,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Ok(lines) => ExecResult::Ok(Some(lines.join("\n"))),
             Err(err) => ExecResult::Err(err),
         },
-        Command::Launch { id, from: _, json, size, vt, cwd, cmd, tags, record } => {
+        Command::Launch { id, from, json, size, vt, cwd, cmd, tags, record } => {
             // Windows can provide basic sessions through ConPTY plus the
             // passthrough engine while Ghostty VT support is still optional.
             #[cfg(not(windows))]
@@ -566,12 +569,17 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 Ok(tags) => tags,
                 Err(err) => return ExecResult::Err(err),
             };
-            let created = match service.create_with_options(id, vt, cwd, cmd, crate::session::SessionStartOptions {
+            let options = crate::session::SessionStartOptions {
                 record: record.enabled(),
                 initial_size: size.unwrap_or_default(),
                 colors: crate::vt::TerminalColors::default(),
                 tags,
-            }) {
+            };
+            let created = match if from.is_some() {
+                service.create_with_options_in_running_daemon(id, vt, cwd, cmd, options)
+            } else {
+                service.create_with_options(id, vt, cwd, cmd, options)
+            } {
                 Ok(v) => v,
                 Err(e) => return ExecResult::Err(e),
             };
@@ -852,40 +860,7 @@ fn resolve_daemon_target(cli: &Cli, service: &SessionService) -> Result<String, 
         return Ok(DEFAULT_DAEMON_NAME.to_string());
     };
 
-    let root = service.layout_root();
-    let entries = match std::fs::read_dir(root) {
-        Ok(entries) => entries,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Err(format!("missing session {source}")),
-        Err(err) => return Err(format!("read runtime root {}: {err}", root.display())),
-    };
-    let mut owners = Vec::new();
-    let mut candidate_errors = Vec::new();
-    for entry in entries {
-        let entry = entry.map_err(|err| format!("read runtime entry: {err}"))?;
-        let path = entry.path();
-        if !path.join("sessions").join(source).is_dir() {
-            continue;
-        }
-        let Some(daemon_name) = path.file_name().and_then(|name| name.to_str()) else {
-            continue;
-        };
-        let daemon_service = service.with_daemon(daemon_name.to_string())?;
-        match daemon_service.inspect(source) {
-            Ok(_) => owners.push(daemon_name.to_string()),
-            Err(err) => candidate_errors.push(format!("{daemon_name}: {err}")),
-        }
-    }
-    owners.sort();
-
-    match owners.as_slice() {
-        [] if candidate_errors.is_empty() => Err(format!("missing session {source}")),
-        [] => Err(format!("unable to resolve session {source}: {}", candidate_errors.join("; "))),
-        [daemon_name] => Ok(daemon_name.clone()),
-        _ => Err(format!(
-            "session {source} exists in multiple daemons ({}); use --server to select the target daemon instead",
-            owners.join(", ")
-        )),
-    }
+    service.daemon_owning_session(source)
 }
 
 fn execute_wait(

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -34,11 +34,32 @@ pub struct Cli {
     #[arg(long, hide = true)]
     pub runtime_root: Option<PathBuf>,
 
-    #[arg(long, global = true, default_value = DEFAULT_DAEMON_NAME, value_parser = parse_runtime_name)]
-    pub server: String,
+    #[arg(long, global = true, value_parser = parse_runtime_name)]
+    pub server: Option<String>,
 
     #[command(subcommand)]
     pub command: Command,
+}
+
+impl Cli {
+    pub fn try_parse_from<I, T>(itr: I) -> Result<Self, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<std::ffi::OsString> + Clone,
+    {
+        <Self as Parser>::try_parse_from(itr)?.validate_daemon_target()
+    }
+
+    fn validate_daemon_target(self) -> Result<Self, clap::Error> {
+        if self.server.is_some() && matches!(self.command, Command::Launch { from: Some(_), .. }) {
+            return Err(clap::Error::raw(
+                clap::error::ErrorKind::ArgumentConflict,
+                "the argument '--server <SERVER>' cannot be used with '--from <SESSION>'",
+            )
+            .with_cmd(&Self::command()));
+        }
+        Ok(self)
+    }
 }
 
 // Bracketed paste marks the paste/submit boundary explicitly; the delay only
@@ -133,6 +154,9 @@ pub enum Command {
     Launch {
         #[arg(value_name = "ID")]
         id: Option<String>,
+        /// Launch in the daemon that owns this source session
+        #[arg(long, value_name = "SESSION", value_parser = parse_runtime_name)]
+        from: Option<String>,
         #[arg(long, help = "Output as JSON")]
         json: bool,
         #[arg(long, value_name = "COLSxROWS", value_parser = parse_terminal_size, help = "Initial terminal size, e.g. 120x40")]
@@ -429,7 +453,8 @@ resolved through the live daemon socket. \n\
 /// snippet alongside BUILD_SUPPORT_MESSAGE (which can't be concatenated at
 /// compile time since it's a const &str, not a literal).
 pub fn parse() -> Cli {
-    Cli::from_arg_matches(&command().get_matches()).expect("clap arg parsing should not fail after get_matches succeeds")
+    let cli = Cli::from_arg_matches(&command().get_matches()).expect("clap arg parsing should not fail after get_matches succeeds");
+    cli.validate_daemon_target().unwrap_or_else(|err| err.exit())
 }
 
 pub fn command() -> clap::Command {
@@ -473,7 +498,11 @@ impl ExecResult {
 }
 
 pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
-    let service = match service.with_daemon(cli.server.clone()) {
+    let daemon_name = match resolve_daemon_target(&cli, service) {
+        Ok(daemon_name) => daemon_name,
+        Err(err) => return ExecResult::Err(err),
+    };
+    let service = match service.with_daemon(daemon_name) {
         Ok(service) => service,
         Err(err) => return ExecResult::Err(err),
     };
@@ -526,7 +555,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Ok(lines) => ExecResult::Ok(Some(lines.join("\n"))),
             Err(err) => ExecResult::Err(err),
         },
-        Command::Launch { id, json, size, vt, cwd, cmd, tags, record } => {
+        Command::Launch { id, from: _, json, size, vt, cwd, cmd, tags, record } => {
             // Windows can provide basic sessions through ConPTY plus the
             // passthrough engine while Ghostty VT support is still optional.
             #[cfg(not(windows))]
@@ -811,6 +840,51 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
             Ok(()) => ExecResult::Ok(None),
             Err(e) => ExecResult::Err(e),
         },
+    }
+}
+
+fn resolve_daemon_target(cli: &Cli, service: &SessionService) -> Result<String, String> {
+    if let Some(daemon_name) = &cli.server {
+        return Ok(daemon_name.clone());
+    }
+
+    let Command::Launch { from: Some(source), .. } = &cli.command else {
+        return Ok(DEFAULT_DAEMON_NAME.to_string());
+    };
+
+    let root = service.layout_root();
+    let entries = match std::fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Err(format!("missing session {source}")),
+        Err(err) => return Err(format!("read runtime root {}: {err}", root.display())),
+    };
+    let mut owners = Vec::new();
+    let mut candidate_errors = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|err| format!("read runtime entry: {err}"))?;
+        let path = entry.path();
+        if !path.join("sessions").join(source).is_dir() {
+            continue;
+        }
+        let Some(daemon_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let daemon_service = service.with_daemon(daemon_name.to_string())?;
+        match daemon_service.inspect(source) {
+            Ok(_) => owners.push(daemon_name.to_string()),
+            Err(err) => candidate_errors.push(format!("{daemon_name}: {err}")),
+        }
+    }
+    owners.sort();
+
+    match owners.as_slice() {
+        [] if candidate_errors.is_empty() => Err(format!("missing session {source}")),
+        [] => Err(format!("unable to resolve session {source}: {}", candidate_errors.join("; "))),
+        [daemon_name] => Ok(daemon_name.clone()),
+        _ => Err(format!(
+            "session {source} exists in multiple daemons ({}); use --server to select the target daemon instead",
+            owners.join(", ")
+        )),
     }
 }
 

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -16,6 +16,7 @@ use crate::{
 
 const MAX_HEADER_BYTES: usize = 16 * 1024;
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+pub(crate) const DAEMON_INSTANCE_HEADER: &str = "x-cleat-daemon-pid";
 
 pub(crate) type HttpRequest = Request<Vec<u8>>;
 
@@ -420,6 +421,15 @@ pub(crate) fn write_request(writer: &mut impl Write, method: Method, path: &str,
     write!(
         writer,
         "{method} {path} HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )?;
+    writer.write_all(body)
+}
+
+pub(crate) fn write_session_create_request(writer: &mut impl Write, body: &[u8], expected_daemon_pid: u32) -> std::io::Result<()> {
+    write!(
+        writer,
+        "POST /sessions HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n{DAEMON_INSTANCE_HEADER}: {expected_daemon_pid}\r\n\r\n",
         body.len()
     )?;
     writer.write_all(body)

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -64,6 +64,18 @@ pub struct SessionService {
     layout: RuntimeLayout,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonInstance {
+    name: String,
+    pid: u32,
+}
+
+impl DaemonInstance {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ListScope {
     Current,
@@ -133,13 +145,17 @@ impl SessionService {
 
     pub fn create_with_options_in_running_daemon(
         &self,
+        daemon: &DaemonInstance,
         name: Option<String>,
         vt_engine: Option<VtEngineKind>,
         cwd: Option<std::path::PathBuf>,
         cmd: Option<String>,
         options: SessionStartOptions,
     ) -> Result<SessionInfo, String> {
-        let session = start_session_in_running_daemon(&self.layout, name, vt_engine, cwd, cmd, options)?;
+        if self.layout.daemon_name() != daemon.name {
+            return Err(format!("daemon instance {} does not match target {}", daemon.name, self.layout.daemon_name()));
+        }
+        let session = start_session_in_running_daemon(&self.layout, daemon.pid, name, vt_engine, cwd, cmd, options)?;
         Ok(self.session_info_after_create(session))
     }
 
@@ -176,7 +192,7 @@ impl SessionService {
         self.list_daemons(selectors, ListScope::All)
     }
 
-    pub fn daemon_owning_session(&self, id: &str) -> Result<String, String> {
+    pub fn daemon_owning_session(&self, id: &str) -> Result<DaemonInstance, String> {
         if !self.layout.root().exists() {
             return Err(format!("missing session {id}"));
         }
@@ -187,8 +203,13 @@ impl SessionService {
             if !daemon_service.session_dir(id).is_dir() {
                 continue;
             }
+            let pid_before = daemon_service.registered_daemon_pid();
             match daemon_service.inspect(id) {
-                Ok(_) => owners.push(daemon_name),
+                Ok(_) => match (pid_before, daemon_service.registered_daemon_pid()) {
+                    (Ok(before), Ok(after)) if before == after => owners.push(DaemonInstance { name: daemon_name, pid: after }),
+                    (Ok(_), Ok(_)) => candidate_errors.push(format!("{daemon_name}: daemon changed while resolving session")),
+                    (_, Err(err)) | (Err(err), _) => candidate_errors.push(format!("{daemon_name}: {err}")),
+                },
                 Err(err) => candidate_errors.push(format!("{daemon_name}: {err}")),
             }
         }
@@ -196,12 +217,18 @@ impl SessionService {
         match owners.as_slice() {
             [] if candidate_errors.is_empty() => Err(format!("missing session {id}")),
             [] => Err(format!("unable to resolve session {id}: {}", candidate_errors.join("; "))),
-            [daemon_name] => Ok(daemon_name.clone()),
+            [daemon] => Ok(daemon.clone()),
             _ => Err(format!(
                 "session {id} exists in multiple daemons ({}); use --server to select the target daemon instead",
-                owners.join(", ")
+                owners.iter().map(|daemon| daemon.name.as_str()).collect::<Vec<_>>().join(", ")
             )),
         }
+    }
+
+    fn registered_daemon_pid(&self) -> Result<u32, String> {
+        let path = self.layout.daemon_pid_path();
+        let value = std::fs::read_to_string(&path).map_err(|err| format!("read daemon registration {}: {err}", path.display()))?;
+        value.trim().parse().map_err(|err| format!("parse daemon registration {}: {err}", path.display()))
     }
 
     fn list_daemons(&self, selectors: &[String], scope: ListScope) -> Result<Vec<SessionInfo>, String> {

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -16,7 +16,10 @@ use crate::{
     },
     protocol::{SessionInfo, SessionStatus},
     runtime::{RuntimeLayout, TerminalSize},
-    session::{attach_foreground, ensure_session_started, run_session_daemon, watch_foreground, ForegroundAttach, SessionStartOptions},
+    session::{
+        attach_foreground, ensure_session_started, run_session_daemon, start_session_in_running_daemon, watch_foreground, ForegroundAttach,
+        SessionStartOptions,
+    },
     vt::VtEngineKind,
 };
 
@@ -125,11 +128,27 @@ impl SessionService {
         options: SessionStartOptions,
     ) -> Result<SessionInfo, String> {
         let session = ensure_session_started(&self.layout, name, vt_engine, cwd, cmd, options)?;
+        Ok(self.session_info_after_create(session))
+    }
+
+    pub fn create_with_options_in_running_daemon(
+        &self,
+        name: Option<String>,
+        vt_engine: Option<VtEngineKind>,
+        cwd: Option<std::path::PathBuf>,
+        cmd: Option<String>,
+        options: SessionStartOptions,
+    ) -> Result<SessionInfo, String> {
+        let session = start_session_in_running_daemon(&self.layout, name, vt_engine, cwd, cmd, options)?;
+        Ok(self.session_info_after_create(session))
+    }
+
+    fn session_info_after_create(&self, session: crate::runtime::SessionMetadata) -> SessionInfo {
         // If the daemon was already running, get real config via inspect.
         if let Ok(result) = self.inspect(&session.id) {
-            return Ok(session_info_from_inspect(result, SessionStatus::Detached));
+            return session_info_from_inspect(result, SessionStatus::Detached);
         }
-        Ok(SessionInfo {
+        SessionInfo {
             id: session.id,
             vt_engine: session.vt_engine,
             vt_engine_status: crate::vt::vt_engine_status(session.vt_engine).to_string(),
@@ -142,7 +161,7 @@ impl SessionService {
             stable_since: None,
             last_output_at: None,
             error: None,
-        })
+        }
     }
 
     pub fn list(&self) -> Result<Vec<SessionInfo>, String> {
@@ -155,6 +174,34 @@ impl SessionService {
 
     pub fn list_all_with_selectors(&self, selectors: &[String]) -> Result<Vec<SessionInfo>, String> {
         self.list_daemons(selectors, ListScope::All)
+    }
+
+    pub fn daemon_owning_session(&self, id: &str) -> Result<String, String> {
+        if !self.layout.root().exists() {
+            return Err(format!("missing session {id}"));
+        }
+        let mut owners = Vec::new();
+        let mut candidate_errors = Vec::new();
+        for daemon_name in self.daemon_names(ListScope::All)? {
+            let daemon_service = self.with_daemon(daemon_name.clone())?;
+            if !daemon_service.session_dir(id).is_dir() {
+                continue;
+            }
+            match daemon_service.inspect(id) {
+                Ok(_) => owners.push(daemon_name),
+                Err(err) => candidate_errors.push(format!("{daemon_name}: {err}")),
+            }
+        }
+
+        match owners.as_slice() {
+            [] if candidate_errors.is_empty() => Err(format!("missing session {id}")),
+            [] => Err(format!("unable to resolve session {id}: {}", candidate_errors.join("; "))),
+            [daemon_name] => Ok(daemon_name.clone()),
+            _ => Err(format!(
+                "session {id} exists in multiple daemons ({}); use --server to select the target daemon instead",
+                owners.join(", ")
+            )),
+        }
     }
 
     fn list_daemons(&self, selectors: &[String], scope: ListScope) -> Result<Vec<SessionInfo>, String> {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -1622,11 +1622,10 @@ fn handle_http_request(
         }
         http_uds::Route::SessionCreate => {
             if let Some(expected_pid) = request.headers().get(http_uds::DAEMON_INSTANCE_HEADER) {
-                let expected_pid = expected_pid
-                    .to_str()
-                    .ok()
-                    .and_then(|value| value.parse::<u32>().ok())
-                    .ok_or_else(|| "invalid daemon instance header".to_string())?;
+                let Some(expected_pid) = expected_pid.to_str().ok().and_then(|value| value.parse::<u32>().ok()) else {
+                    return http_uds::write_error(stream, StatusCode::BAD_REQUEST, "invalid daemon instance header")
+                        .map_err(|err| format!("write HTTP error response: {err}"));
+                };
                 if expected_pid != std::process::id() {
                     return http_uds::write_error(stream, StatusCode::CONFLICT, "source daemon instance changed")
                         .map_err(|err| format!("write HTTP error response: {err}"));

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -256,6 +256,35 @@ pub fn ensure_session_started(
     cmd: Option<String>,
     options: SessionStartOptions,
 ) -> Result<SessionMetadata, String> {
+    start_session(layout, id, vt_engine, cwd, cmd, options, DaemonRequirement::AutoStart)
+}
+
+pub(crate) fn start_session_in_running_daemon(
+    layout: &RuntimeLayout,
+    id: Option<String>,
+    vt_engine: Option<VtEngineKind>,
+    cwd: Option<PathBuf>,
+    cmd: Option<String>,
+    options: SessionStartOptions,
+) -> Result<SessionMetadata, String> {
+    start_session(layout, id, vt_engine, cwd, cmd, options, DaemonRequirement::AlreadyRunning)
+}
+
+#[derive(Clone, Copy)]
+enum DaemonRequirement {
+    AutoStart,
+    AlreadyRunning,
+}
+
+fn start_session(
+    layout: &RuntimeLayout,
+    id: Option<String>,
+    vt_engine: Option<VtEngineKind>,
+    cwd: Option<PathBuf>,
+    cmd: Option<String>,
+    options: SessionStartOptions,
+    daemon_requirement: DaemonRequirement,
+) -> Result<SessionMetadata, String> {
     let vt_engine = vt_engine.unwrap_or_else(vt::default_vt_engine_kind);
     vt_engine.ensure_available()?;
     let id = id.unwrap_or_else(|| format!("session-{}", uuid::Uuid::new_v4()));
@@ -267,8 +296,13 @@ pub fn ensure_session_started(
     session.tags = options.tags;
     crate::runtime::normalize_tags(&mut session.tags);
 
-    ensure_daemon_started(layout)?;
-    let mut stream = connect_session_stream(&layout.socket_path())?;
+    if matches!(daemon_requirement, DaemonRequirement::AutoStart) {
+        ensure_daemon_started(layout)?;
+    }
+    let mut stream = connect_session_stream(&layout.socket_path()).map_err(|err| match daemon_requirement {
+        DaemonRequirement::AutoStart => err,
+        DaemonRequirement::AlreadyRunning => format!("source daemon {} is no longer running: {err}", layout.daemon_name()),
+    })?;
     let body = serde_json::to_vec(&session).map_err(|err| format!("serialize session create request: {err}"))?;
     http_uds::write_request(&mut stream, http::Method::POST, "/sessions", &body)
         .map_err(|err| format!("write session create request: {err}"))?;

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -261,19 +261,20 @@ pub fn ensure_session_started(
 
 pub(crate) fn start_session_in_running_daemon(
     layout: &RuntimeLayout,
+    expected_daemon_pid: u32,
     id: Option<String>,
     vt_engine: Option<VtEngineKind>,
     cwd: Option<PathBuf>,
     cmd: Option<String>,
     options: SessionStartOptions,
 ) -> Result<SessionMetadata, String> {
-    start_session(layout, id, vt_engine, cwd, cmd, options, DaemonRequirement::AlreadyRunning)
+    start_session(layout, id, vt_engine, cwd, cmd, options, DaemonRequirement::AlreadyRunning(expected_daemon_pid))
 }
 
 #[derive(Clone, Copy)]
 enum DaemonRequirement {
     AutoStart,
-    AlreadyRunning,
+    AlreadyRunning(u32),
 }
 
 fn start_session(
@@ -301,11 +302,14 @@ fn start_session(
     }
     let mut stream = connect_session_stream(&layout.socket_path()).map_err(|err| match daemon_requirement {
         DaemonRequirement::AutoStart => err,
-        DaemonRequirement::AlreadyRunning => format!("source daemon {} is no longer running: {err}", layout.daemon_name()),
+        DaemonRequirement::AlreadyRunning(_) => format!("source daemon {} is no longer running: {err}", layout.daemon_name()),
     })?;
     let body = serde_json::to_vec(&session).map_err(|err| format!("serialize session create request: {err}"))?;
-    http_uds::write_request(&mut stream, http::Method::POST, "/sessions", &body)
-        .map_err(|err| format!("write session create request: {err}"))?;
+    match daemon_requirement {
+        DaemonRequirement::AutoStart => http_uds::write_request(&mut stream, http::Method::POST, "/sessions", &body),
+        DaemonRequirement::AlreadyRunning(expected_pid) => http_uds::write_session_create_request(&mut stream, &body, expected_pid),
+    }
+    .map_err(|err| format!("write session create request: {err}"))?;
     let response = http_uds::read_response(&mut stream).map_err(|err| format!("read session create response: {err}"))?;
     if response.status != StatusCode::OK {
         return Err(http_error_message(http_uds::HttpResponse { status: response.status, body: response.body }));
@@ -1617,6 +1621,17 @@ fn handle_http_request(
                 .map_err(|err| format!("write HTTP sessions response: {err}"))
         }
         http_uds::Route::SessionCreate => {
+            if let Some(expected_pid) = request.headers().get(http_uds::DAEMON_INSTANCE_HEADER) {
+                let expected_pid = expected_pid
+                    .to_str()
+                    .ok()
+                    .and_then(|value| value.parse::<u32>().ok())
+                    .ok_or_else(|| "invalid daemon instance header".to_string())?;
+                if expected_pid != std::process::id() {
+                    return http_uds::write_error(stream, StatusCode::CONFLICT, "source daemon instance changed")
+                        .map_err(|err| format!("write HTTP error response: {err}"));
+                }
+            }
             let session: SessionMetadata =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP session create request: {err}"))?;
             crate::runtime::validate_runtime_name(&session.id)?;

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -128,6 +128,13 @@ fn launch_from_parses_and_rejects_an_explicit_server() {
     assert!(matches!(cli.command, Command::Launch { from: Some(ref source), .. } if source == "source"));
 
     assert!(Cli::try_parse_from(["cleat", "--server", "other", "launch", "sibling", "--from", "source"]).is_err());
+
+    let raw_cli = <Cli as clap::Parser>::try_parse_from(["cleat", "--server", "other", "launch", "sibling", "--from", "source"])
+        .expect("raw clap parser accepts cross-scope globals");
+    let service = SessionService::new(RuntimeLayout::new(tempfile::tempdir().expect("tempdir").path().to_path_buf()));
+    assert!(execute(raw_cli, &service)
+        .expect_err("execute must reject an invalid parsed CLI")
+        .contains("--server cannot be used with --from"));
 }
 
 #[test]

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -1,4 +1,4 @@
-use clap::{CommandFactory, Parser};
+use clap::CommandFactory;
 use cleat::{
     cli::{self, execute, Cli, Command, ExecResult, RecordFlags},
     runtime::{RuntimeLayout, TerminalSize},
@@ -111,6 +111,7 @@ fn launch_command_parses() {
     let cli = Cli::try_parse_from(["cleat", "launch", "--cmd", "bash"]).expect("launch parses");
     assert_eq!(cli.command, Command::Launch {
         id: None,
+        from: None,
         json: false,
         size: None,
         vt: None,
@@ -119,6 +120,25 @@ fn launch_command_parses() {
         tags: Vec::new(),
         record: RecordFlags::default()
     });
+}
+
+#[test]
+fn launch_from_parses_and_rejects_an_explicit_server() {
+    let cli = Cli::try_parse_from(["cleat", "launch", "sibling", "--from", "source"]).expect("launch --from parses");
+    assert!(matches!(cli.command, Command::Launch { from: Some(ref source), .. } if source == "source"));
+
+    assert!(Cli::try_parse_from(["cleat", "--server", "other", "launch", "sibling", "--from", "source"]).is_err());
+}
+
+#[test]
+fn launch_from_rejects_a_missing_source_session() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = SessionService::new(RuntimeLayout::new(temp.path().to_path_buf()));
+    let cli = Cli::try_parse_from(["cleat", "launch", "sibling", "--from", "missing", "--vt", "passthrough"]).expect("parse launch --from");
+
+    let err = execute(cli, &service).expect_err("missing source should fail");
+
+    assert!(err.contains("missing session missing"), "{err}");
 }
 
 #[test]
@@ -145,6 +165,7 @@ fn launch_command_parses_positional_name() {
     let cli = Cli::try_parse_from(["cleat", "launch", "demo", "--cmd", "bash"]).expect("launch positional parses");
     assert_eq!(cli.command, Command::Launch {
         id: Some("demo".into()),
+        from: None,
         json: false,
         size: None,
         vt: None,
@@ -173,6 +194,7 @@ fn launch_command_parses_json() {
     let cli = Cli::try_parse_from(["cleat", "launch", "--json", "demo"]).expect("launch --json parses");
     assert_eq!(cli.command, Command::Launch {
         id: Some("demo".into()),
+        from: None,
         json: true,
         size: None,
         vt: None,
@@ -188,6 +210,7 @@ fn launch_command_parses_vt() {
     let cli = Cli::try_parse_from(["cleat", "launch", "--vt", "ghostty", "demo"]).expect("launch --vt parses");
     assert_eq!(cli.command, Command::Launch {
         id: Some("demo".into()),
+        from: None,
         json: false,
         size: None,
         vt: Some(VtEngineKind::Ghostty),
@@ -203,6 +226,7 @@ fn create_alias_still_parses_as_launch() {
     let cli = Cli::try_parse_from(["cleat", "create", "--cmd", "bash"]).expect("create alias parses");
     assert_eq!(cli.command, Command::Launch {
         id: None,
+        from: None,
         json: false,
         size: None,
         vt: None,
@@ -405,7 +429,7 @@ fn record_flags_explicit_record_enables() {
 #[test]
 fn serve_parses_as_daemon_scoped_command() {
     let cli = Cli::try_parse_from(["cleat", "--server", "alternate", "serve"]).expect("parse serve");
-    assert_eq!(cli.server, "alternate");
+    assert_eq!(cli.server.as_deref(), Some("alternate"));
     assert!(matches!(cli.command, Command::Serve));
 }
 
@@ -419,7 +443,7 @@ fn mark_command_parses_session_id() {
 fn send_keys_execute_reports_missing_session() {
     let cli = Cli {
         runtime_root: None,
-        server: cleat::runtime::DEFAULT_DAEMON_NAME.to_string(),
+        server: Some(cleat::runtime::DEFAULT_DAEMON_NAME.to_string()),
         command: Command::SendKeys {
             id: "demo".into(),
             literal: false,

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -1273,6 +1273,14 @@ fn session_daemon_accepts_http_control_requests_on_session_socket() {
     let inspect_json: serde_json::Value = serde_json::from_str(http_body(&inspect)).expect("inspect json");
     assert_eq!(inspect_json["session"]["id"], "alpha");
 
+    let invalid_daemon_instance = http_session_request(
+        temp.path(),
+        "alpha",
+        "POST /sessions HTTP/1.1\r\nHost: cleat\r\nx-cleat-daemon-pid: invalid\r\nContent-Length: 0\r\n\r\n",
+    );
+    assert!(invalid_daemon_instance.starts_with("HTTP/1.1 400 Bad Request\r\n"), "{invalid_daemon_instance}");
+    assert!(http_body(&invalid_daemon_instance).contains("invalid daemon instance header"));
+
     let keys_body = r#"{"bytes":[104,105,10]}"#;
     let keys = http_session_request(
         temp.path(),

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -14,7 +14,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use clap::Parser;
 #[cfg(feature = "ghostty-vt")]
 use cleat::packet::ScreenActivity;
 #[cfg(feature = "ghostty-vt")]
@@ -472,6 +471,70 @@ fn create_makes_session_directory_and_returns_metadata() {
     let output = cli::execute(cli, &service).expect("execute create").expect("create output");
     assert_eq!(output, "alpha");
     assert!(service.session_dir("alpha").exists());
+}
+
+#[cfg(feature = "ghostty-vt")]
+#[test]
+fn launch_from_creates_a_sibling_in_the_source_daemon() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    let source_daemon = service.with_daemon("source-daemon".to_string()).expect("source daemon service");
+    let _ssh_tty = EnvVarGuard::set("SSH_TTY", "/dev/stale-tty");
+    let _ssh_connection = EnvVarGuard::set("SSH_CONNECTION", "stale connection");
+    let _ssh_client = EnvVarGuard::set("SSH_CLIENT", "stale client");
+    source_daemon
+        .create(Some("source".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+        .expect("create source session");
+
+    let mut observer = UnixStream::connect(temp.path().join("source-daemon/socket")).expect("connect source daemon");
+    write!(
+        observer,
+        "POST /connect HTTP/1.1\r\nHost: cleat\r\nContent-Length: 0\r\nConnection: Upgrade\r\nUpgrade: cleat-packet/1\r\n\r\n"
+    )
+    .expect("write packet upgrade request");
+    let response = read_http_response_head(&mut observer);
+    assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{response}");
+    let _hello = PacketFrame::read(&mut observer).expect("read hello");
+    let initial_directory = PacketFrame::read(&mut observer).expect("read initial directory");
+    let initial_directory = initial_directory.decode::<DirectorySnapshot>().expect("decode initial directory");
+    assert_eq!(initial_directory.sessions.iter().map(|entry| entry.session_id.as_str()).collect::<Vec<_>>(), vec!["source"]);
+
+    let env_output = temp.path().join("sibling-env");
+    let sibling_command = format!(
+        "sh -c 'printf \"%s|%s|%s\" \"${{SSH_TTY-unset}}\" \"${{SSH_CONNECTION-unset}}\" \"${{SSH_CLIENT-unset}}\" > {}; sleep 30'",
+        env_output.display()
+    );
+    let cli = Cli::try_parse_from([
+        "cleat",
+        "launch",
+        "sibling",
+        "--from",
+        "source",
+        "--tag",
+        "kind=sibling",
+        "--no-record",
+        "--cmd",
+        &sibling_command,
+    ])
+    .expect("parse launch --from");
+
+    let output = cli::execute(cli, &service).expect("launch sibling").expect("sibling id");
+
+    assert_eq!(output, "sibling");
+    let mut packet_buffer = Vec::new();
+    let delta = read_directory_delta_named(&mut observer, &mut packet_buffer, Duration::from_secs(2), "sibling directory delta");
+    let sibling = delta.upserted.iter().find(|entry| entry.session_id == "sibling").expect("sibling upsert");
+    assert_eq!(sibling.tags, vec!["kind=sibling"]);
+    wait_until("sibling environment output", || std::fs::read_to_string(&env_output).as_deref() == Ok("unset|unset|unset"));
+    assert_eq!(std::fs::read_to_string(&env_output).expect("read sibling environment"), "unset|unset|unset");
+    assert!(service.list().expect("list default daemon").is_empty());
+    assert_eq!(source_daemon.list().expect("list source daemon").iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), vec![
+        "sibling", "source"
+    ]);
+
+    source_daemon.kill("sibling").expect("kill sibling");
+    source_daemon.kill("source").expect("kill source");
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -526,7 +526,7 @@ fn launch_from_creates_a_sibling_in_the_source_daemon() {
     let delta = read_directory_delta_named(&mut observer, &mut packet_buffer, Duration::from_secs(2), "sibling directory delta");
     let sibling = delta.upserted.iter().find(|entry| entry.session_id == "sibling").expect("sibling upsert");
     assert_eq!(sibling.tags, vec!["kind=sibling"]);
-    wait_until("sibling environment output", || std::fs::read_to_string(&env_output).as_deref() == Ok("unset|unset|unset"));
+    wait_until("sibling environment output", || matches!(std::fs::read_to_string(&env_output), Ok(value) if value == "unset|unset|unset"));
     assert_eq!(std::fs::read_to_string(&env_output).expect("read sibling environment"), "unset|unset|unset");
     assert!(service.list().expect("list default daemon").is_empty());
     assert_eq!(source_daemon.list().expect("list source daemon").iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), vec![
@@ -574,6 +574,25 @@ fn create_existing_session_returns_its_running_metadata() {
     assert_eq!(second, expected);
 
     service.kill("alpha").expect("kill session");
+}
+
+#[test]
+fn create_in_running_daemon_does_not_start_a_missing_daemon() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path()).with_daemon("gone".to_string()).expect("named daemon service");
+
+    let err = service
+        .create_with_options_in_running_daemon(
+            Some("sibling".into()),
+            Some(VtEngineKind::Passthrough),
+            None,
+            Some("sleep 30".into()),
+            SessionStartOptions::default(),
+        )
+        .expect_err("missing source daemon must not be started");
+
+    assert!(err.contains("source daemon gone is no longer running"), "{err}");
+    assert!(!temp.path().join("gone").exists(), "failed sibling launch must not create a daemon directory");
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -577,22 +577,39 @@ fn create_existing_session_returns_its_running_metadata() {
 }
 
 #[test]
-fn create_in_running_daemon_does_not_start_a_missing_daemon() {
+fn create_in_running_daemon_rejects_a_replacement_daemon() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");
-    let service = service_for(temp.path()).with_daemon("gone".to_string()).expect("named daemon service");
+    let service = service_for(temp.path());
+    let source_daemon = service.with_daemon("source-daemon".to_string()).expect("named daemon service");
+    source_daemon
+        .create(Some("source".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+        .expect("create source");
+    let resolved = service.daemon_owning_session("source").expect("resolve source daemon instance");
 
-    let err = service
+    cleat::platform::daemon::terminate_session_daemon_if_expected(temp.path(), "source-daemon");
+    let socket_path = temp.path().join("source-daemon/socket");
+    wait_until("source daemon exit", || UnixStream::connect(&socket_path).is_err());
+    source_daemon
+        .create(Some("replacement".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 30".into()), false)
+        .expect("start replacement daemon");
+
+    let err = source_daemon
         .create_with_options_in_running_daemon(
+            &resolved,
             Some("sibling".into()),
             Some(VtEngineKind::Passthrough),
             None,
             Some("sleep 30".into()),
             SessionStartOptions::default(),
         )
-        .expect_err("missing source daemon must not be started");
+        .expect_err("replacement daemon must reject sibling launch");
 
-    assert!(err.contains("source daemon gone is no longer running"), "{err}");
-    assert!(!temp.path().join("gone").exists(), "failed sibling launch must not create a daemon directory");
+    assert!(err.contains("source daemon instance changed"), "{err}");
+    assert_eq!(source_daemon.list().expect("list replacement daemon").iter().map(|session| session.id.as_str()).collect::<Vec<_>>(), vec![
+        "replacement"
+    ]);
+    source_daemon.kill("replacement").expect("kill replacement");
 }
 
 #[test]

--- a/crates/cleat/tests/replay.rs
+++ b/crates/cleat/tests/replay.rs
@@ -3,7 +3,6 @@
 
 use std::{io::Write, path::PathBuf, time::Duration};
 
-use clap::Parser;
 use cleat::{
     asciicast::{encode_event, encode_header, Event, EventCode, Header},
     cli::{Cli, Command},


### PR DESCRIPTION
Closes #7.

## What changed

- Adds `cleat launch [ID] --from <session>` and rejects combining `--from` with `--server`.
- Resolves the live daemon instance that owns the source and launches through its existing SessionCreate path.
- Binds creation to the resolved daemon PID so a same-name replacement cannot receive the sibling.
- Preserves normal launch options and environment filtering, and emits ordinary Directory deltas.
- Documents sibling-launch semantics.

## Why

Under ADR 0004's M:N model, the daemon is the execution-context boundary. A sibling is therefore an ordinary new session in the source's daemon, not a new daemon or PTY transfer.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `./tools/prepare-ghostty-vt.sh`
- `cargo build -p cleat --locked --features ghostty-vt`
- `cargo test -p cleat --locked --features ghostty-vt`
- Parallel standards and specification review; no material findings remain.