### PR TITLE
Add controller seat management

### DIFF
--- a/crates/cleat/include/cleat_provider.h
+++ b/crates/cleat/include/cleat_provider.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-#define CLEAT_PROVIDER_ABI_VERSION 7u
+#define CLEAT_PROVIDER_ABI_VERSION 8u
 #define CLEAT_PROVIDER_BACKEND_MOCK 0u
 #define CLEAT_PROVIDER_BACKEND_IN_PROCESS 1u
 #define CLEAT_PROVIDER_BACKEND_DAEMON 2u
@@ -25,6 +25,9 @@ extern "C" {
 #define CLEAT_ROLE_UNKNOWN 0u
 #define CLEAT_ROLE_WATCHER 1u
 #define CLEAT_ROLE_CONTROLLER 2u
+#define CLEAT_ATTACHMENT_PRINCIPAL 0u
+#define CLEAT_ATTACHMENT_SUPERVISOR 1u
+#define CLEAT_ATTACHMENT_TOOL 2u
 #define CLEAT_INPUT_KEY 1u
 #define CLEAT_INPUT_TEXT 2u
 #define CLEAT_INPUT_MOUSE 3u
@@ -202,6 +205,13 @@ typedef struct cleat_session_desc {
      * read-only. The granted role is reported by cleat_session_role.
      */
     uint32_t role;
+    /*
+     * Daemon-backend attachment identity. The name is UTF-8 and paired with
+     * attachment_name_len; kind is one of CLEAT_ATTACHMENT_*.
+     */
+    const uint8_t *attachment_name;
+    size_t attachment_name_len;
+    uint32_t attachment_kind;
 } cleat_session_desc;
 
 /*

--- a/crates/cleat/src/cli.rs
+++ b/crates/cleat/src/cli.rs
@@ -5,9 +5,9 @@ use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use crate::{
     http_uds,
     keys::encode_send_keys,
-    protocol::{WaitCondition, WaitStatus},
+    protocol::{AttachmentIdentity, AttachmentKind, WaitCondition, WaitStatus},
     runtime::{validate_runtime_name, TerminalSize, AMBIENT_DAEMON_ENV, DEFAULT_DAEMON_NAME},
-    server::{DaemonInstance, EndBound, FallbackReason, SessionService, StartBound},
+    server::{AttachOptions, DaemonInstance, EndBound, FallbackReason, SessionService, StartBound},
     vt::VtEngineKind,
 };
 
@@ -85,6 +85,28 @@ pub struct RecordFlags {
     pub no_record: bool,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Args)]
+pub struct AttachmentFlags {
+    /// Name this attachment in seat status and watcher banners
+    #[arg(long, env = "CLEAT_ATTACHMENT_IDENTITY", value_name = "NAME")]
+    pub identity: Option<String>,
+    /// Describe what owns this attachment
+    #[arg(long = "identity-kind", env = "CLEAT_ATTACHMENT_KIND", value_parser = parse_attachment_kind, default_value = "principal")]
+    pub identity_kind: AttachmentKind,
+}
+
+impl AttachmentFlags {
+    fn resolve(self) -> AttachmentIdentity {
+        let name = self
+            .identity
+            .or_else(|| std::env::var("USER").ok())
+            .or_else(|| std::env::var("USERNAME").ok())
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(|| format!("cleat-{}", std::process::id()));
+        AttachmentIdentity { kind: self.identity_kind, name }
+    }
+}
+
 impl RecordFlags {
     /// Resolve the effective recording setting. Default is on; `CLEAT_RECORD`
     /// provides a boolish opt-out baseline that an explicit flag overrides.
@@ -123,6 +145,10 @@ pub enum Command {
                            Unlike launch, attach enters interactive foreground mode — your terminal\n\
                            is connected to the session's PTY until you detach.\n\
                            \n\
+                           If another attachment holds control, attach falls back to read-only watch\n\
+                           mode. Use --strict to refuse instead, or --take to demote the holder and\n\
+                           claim control. --identity and --identity-kind name the attachment.\n\
+                           \n\
                            To detach, run 'cleat detach <ID>' from another terminal.")]
     Attach {
         #[arg(value_name = "ID")]
@@ -135,6 +161,12 @@ pub enum Command {
         cwd: Option<PathBuf>,
         #[arg(long, help = "Command to run (default: user's shell)")]
         cmd: Option<String>,
+        #[arg(long, conflicts_with = "take", help = "Fail when another attachment holds the controller seat")]
+        strict: bool,
+        #[arg(long, conflicts_with = "strict", help = "Take control and demote the current controller to watcher")]
+        take: bool,
+        #[command(flatten)]
+        attachment: AttachmentFlags,
         #[command(flatten)]
         record: RecordFlags,
     },
@@ -144,6 +176,8 @@ pub enum Command {
     Watch {
         #[arg(value_name = "ID")]
         id: String,
+        #[command(flatten)]
+        attachment: AttachmentFlags,
     },
     /// Subscribe to packet render updates and print debug summaries
     Packets {
@@ -528,7 +562,7 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
     };
     let service = &service;
     match cli.command {
-        Command::Attach { id, no_create, vt, cwd, cmd, record } => {
+        Command::Attach { id, no_create, vt, cwd, cmd, strict, take, attachment, record } => {
             // Windows can provide basic sessions through ConPTY plus the
             // passthrough engine while Ghostty VT support is still optional.
             #[cfg(not(windows))]
@@ -542,10 +576,11 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 Ok(handlers) => handlers,
                 Err(e) => return ExecResult::Err(e),
             };
-            let (attached, guard) = match service.attach(id, vt, cwd, cmd, no_create) {
-                Ok(v) => v,
-                Err(e) => return ExecResult::Err(e),
-            };
+            let (attached, guard) =
+                match service.attach(id, vt, cwd, cmd, no_create, AttachOptions { identity: attachment.resolve(), strict, take }) {
+                    Ok(v) => v,
+                    Err(e) => return ExecResult::Err(e),
+                };
             if record.enabled() {
                 if let Err(e) = service.record(&attached.id, true) {
                     return ExecResult::Err(e);
@@ -556,12 +591,12 @@ pub fn execute(cli: Cli, service: &SessionService) -> ExecResult {
                 Err(e) => ExecResult::Err(e),
             }
         }
-        Command::Watch { id } => {
+        Command::Watch { id, attachment } => {
             let signal_handlers = match crate::platform::terminal::AttachSignalHandlers::install() {
                 Ok(handlers) => handlers,
                 Err(e) => return ExecResult::Err(e),
             };
-            let guard = match service.watch(&id) {
+            let guard = match service.watch(&id, attachment.resolve()) {
                 Ok(v) => v,
                 Err(e) => return ExecResult::Err(e),
             };
@@ -1076,6 +1111,9 @@ fn format_session_human(session: &crate::protocol::SessionInfo) -> String {
     if !session.tags.is_empty() {
         fields.push(format!("tags={}", session.tags.join(",")));
     }
+    if let Some(controller) = &session.controller {
+        fields.push(format!("controller={} ({})", controller.name, controller.kind.as_str()));
+    }
     fields.join("\t")
 }
 
@@ -1188,6 +1226,9 @@ fn format_directory_entry(entry: &crate::packet::DirectoryEntry) -> String {
         format!("watchers={}", entry.watcher_count),
         format!("recreatable={}", if entry.recreatable { "yes" } else { "no" }),
     ];
+    if let Some(controller) = &entry.controller {
+        fields.push(format!("controller={} ({})", controller.name, controller.kind.as_str()));
+    }
     if !entry.tags.is_empty() {
         fields.push(format!("tags={}", entry.tags.join(",")));
     }
@@ -1296,7 +1337,12 @@ fn format_inspect_human(result: &crate::protocol::InspectResult) -> String {
         table.add_row(vec!["fg_cwd", &cwd.display().to_string()]);
     }
     if !result.attachments.is_empty() {
-        let attachments = result.attachments.iter().map(|attachment| attachment.role.as_str()).collect::<Vec<_>>().join(", ");
+        let attachments = result
+            .attachments
+            .iter()
+            .map(|attachment| format!("{}: {} ({})", attachment.role, attachment.identity.name, attachment.identity.kind.as_str()))
+            .collect::<Vec<_>>()
+            .join(", ");
         table.add_row(vec!["attachments", &attachments]);
     }
     table.add_row(vec!["recording", if result.recording.active { "active" } else { "off" }]);
@@ -1328,6 +1374,15 @@ fn parse_environment(value: &str) -> Result<(String, String), String> {
     let environment = (name.to_string(), value.to_string());
     crate::runtime::validate_environment(std::slice::from_ref(&environment))?;
     Ok(environment)
+}
+
+fn parse_attachment_kind(value: &str) -> Result<AttachmentKind, String> {
+    match value {
+        "principal" => Ok(AttachmentKind::Principal),
+        "supervisor" => Ok(AttachmentKind::Supervisor),
+        "tool" => Ok(AttachmentKind::Tool),
+        other => Err(format!("unknown attachment kind {other:?}; expected principal, supervisor, or tool")),
+    }
 }
 
 fn parse_terminal_size(value: &str) -> Result<TerminalSize, String> {

--- a/crates/cleat/src/http_uds.rs
+++ b/crates/cleat/src/http_uds.rs
@@ -86,6 +86,12 @@ pub(crate) struct AttachRequest {
     pub cols: u16,
     pub rows: u16,
     pub capabilities: AttachCapabilitiesRequest,
+    #[serde(default)]
+    pub identity: crate::protocol::AttachmentIdentity,
+    #[serde(default)]
+    pub take: bool,
+    #[serde(default)]
+    pub strict: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/cleat/src/packet.rs
+++ b/crates/cleat/src/packet.rs
@@ -2,11 +2,14 @@ use std::io::{Error, ErrorKind, Read, Write};
 
 use serde::{Deserialize, Serialize};
 
-use crate::provider::{TerminalInputEvent, TerminalRenderUpdate};
 pub use crate::screen_activity::ScreenActivity;
+use crate::{
+    protocol::AttachmentIdentity,
+    provider::{TerminalInputEvent, TerminalRenderUpdate},
+};
 
-/// Version 4 defines activity as render damage rather than raw PTY output.
-pub const PROTOCOL_VERSION: u16 = 4;
+/// Version 5 adds structured attachment identity and controller seat state.
+pub const PROTOCOL_VERSION: u16 = 5;
 pub const CHANNEL_CONTROL: u32 = 0;
 
 pub const MSG_CONTROL_HELLO: u8 = 1;
@@ -70,6 +73,8 @@ pub struct DirectoryEntry {
     #[serde(default)]
     pub watcher_count: u32,
     #[serde(default)]
+    pub controller: Option<AttachmentIdentity>,
+    #[serde(default)]
     pub recreatable: bool,
     pub cols: u16,
     pub rows: u16,
@@ -120,9 +125,10 @@ pub struct OpenChannel {
     /// Requested role; the granted role arrives as a `RoleState` before the
     /// initial render packet (a controller request may be granted Watcher).
     pub role: ChannelRole,
-    /// Preempt an existing packet controller. Never preempts a legacy stream
-    /// controller (there is no way to demote a raw attach to read-only).
+    /// Preempt the existing controller, which remains connected as a watcher.
     pub take: bool,
+    #[serde(default)]
+    pub identity: AttachmentIdentity,
 }
 
 /// Client→server on an open session channel: request a role change.
@@ -134,9 +140,11 @@ pub struct RoleRequest {
 
 /// Server→client on a session channel: the granted role, sent on open and on
 /// any later change (e.g. demotion because another client took control).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RoleState {
     pub role: ChannelRole,
+    #[serde(default)]
+    pub controller: Option<AttachmentIdentity>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -265,6 +273,7 @@ impl<S: Read + Write> PacketClient<S> {
             session_id: session_id.to_string(),
             role,
             take: false,
+            identity: AttachmentIdentity::default(),
         })
     }
 
@@ -357,8 +366,8 @@ mod tests {
     }
 
     #[test]
-    fn render_damage_activity_semantics_start_at_protocol_version_four() {
-        assert_eq!(PROTOCOL_VERSION, 4);
+    fn attachment_identity_semantics_start_at_protocol_version_five() {
+        assert_eq!(PROTOCOL_VERSION, 5);
     }
 
     #[test]
@@ -385,6 +394,7 @@ mod tests {
                 state: "running".to_string(),
                 controller_count: 0,
                 watcher_count: 0,
+                controller: None,
                 recreatable: false,
                 cols: 80,
                 rows: 24,

--- a/crates/cleat/src/protocol.rs
+++ b/crates/cleat/src/protocol.rs
@@ -28,6 +28,8 @@ pub struct SessionInfo {
     /// Unix timestamp in milliseconds of the most recent render-changing output.
     #[serde(default)]
     pub last_output_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub controller: Option<AttachmentIdentity>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -90,6 +92,39 @@ pub struct ProcessInspect {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttachmentInspect {
     pub role: String,
+    #[serde(default)]
+    pub identity: AttachmentIdentity,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentKind {
+    #[default]
+    Principal,
+    Supervisor,
+    Tool,
+}
+
+impl AttachmentKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Principal => "principal",
+            Self::Supervisor => "supervisor",
+            Self::Tool => "tool",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttachmentIdentity {
+    pub kind: AttachmentKind,
+    pub name: String,
+}
+
+impl AttachmentIdentity {
+    pub fn display_name(&self) -> &str {
+        &self.name
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -112,6 +147,13 @@ const TAG_INPUT: u8 = 2;
 const TAG_OUTPUT: u8 = 3;
 const TAG_RESIZE: u8 = 4;
 const TAG_ERROR: u8 = 9;
+const TAG_SEAT_STATE: u8 = 10;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SeatState {
+    pub role: String,
+    pub controller: Option<AttachmentIdentity>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WaitCondition {
@@ -133,6 +175,7 @@ pub enum Frame {
     Output(Vec<u8>),
     Resize { cols: u16, rows: u16 },
     Error(String),
+    SeatState(SeatState),
 }
 
 impl Frame {
@@ -176,6 +219,10 @@ impl Frame {
             Frame::Input(bytes) => write_tagged(writer, TAG_INPUT, bytes),
             Frame::Output(bytes) => write_tagged(writer, TAG_OUTPUT, bytes),
             Frame::Error(message) => write_tagged(writer, TAG_ERROR, message.as_bytes()),
+            Frame::SeatState(state) => {
+                let payload = serde_json::to_vec(state).map_err(Error::other)?;
+                write_tagged(writer, TAG_SEAT_STATE, &payload)
+            }
         }
     }
 
@@ -186,6 +233,7 @@ impl Frame {
             Frame::Resize { .. } => 4,
             Frame::Input(bytes) | Frame::Output(bytes) => bytes.len(),
             Frame::Error(message) => message.len(),
+            Frame::SeatState(state) => serde_json::to_vec(state).map(|payload| payload.len()).unwrap_or(0),
         };
         WIRE_HEADER_LEN + payload_len
     }
@@ -210,6 +258,9 @@ impl Frame {
             TAG_ERROR => String::from_utf8(payload)
                 .map(Frame::Error)
                 .map_err(|err| Error::new(ErrorKind::InvalidData, format!("invalid error frame utf-8: {err}"))),
+            TAG_SEAT_STATE => serde_json::from_slice(&payload)
+                .map(Frame::SeatState)
+                .map_err(|err| Error::new(ErrorKind::InvalidData, format!("invalid seat state frame: {err}"))),
             _ => Err(Error::new(ErrorKind::InvalidData, format!("unknown frame tag {tag}"))),
         }
     }

--- a/crates/cleat/src/provider_daemon.rs
+++ b/crates/cleat/src/provider_daemon.rs
@@ -33,6 +33,7 @@ use crate::{
         PROTOCOL_VERSION,
     },
     platform::ipc::{try_connect_session_stream, SessionStream},
+    protocol::AttachmentIdentity,
     provider::{
         DirtyState, TerminalCursor, TerminalInputEvent, TerminalRenderUpdate, TerminalRenderUpdateOpKind, TerminalScrollbarState,
         TerminalViewportKind,
@@ -135,6 +136,7 @@ pub(crate) struct ChannelSlot {
     /// Role the caller wants; requested on every (re)open with take=false —
     /// control lost across a disconnect is re-taken explicitly, not silently.
     pub desired_role: ChannelRole,
+    pub identity: AttachmentIdentity,
     /// Role the daemon granted (None until the first RoleState arrives).
     pub granted_role: Option<ChannelRole>,
     /// Set when the daemon reported an error for this channel (e.g. the
@@ -262,6 +264,7 @@ impl DaemonConnection {
         cols: u16,
         rows: u16,
         role: ChannelRole,
+        identity: AttachmentIdentity,
     ) -> (u32, Arc<Mutex<ChannelSlot>>) {
         let slot = Arc::new(Mutex::new(ChannelSlot {
             session_id: session_id.clone(),
@@ -270,6 +273,7 @@ impl DaemonConnection {
             desired_cols: cols,
             desired_rows: rows,
             desired_role: role,
+            identity: identity.clone(),
             granted_role: None,
             closed: None,
         }));
@@ -281,7 +285,7 @@ impl DaemonConnection {
             (channel, state.connected)
         };
         if connected {
-            let _ = self.send_open_frame(channel, &session_id, cols, rows, role);
+            let _ = self.send_open_frame(channel, &session_id, cols, rows, role, &identity);
         } else {
             // The caller may have just spawned the daemon (session create);
             // cut the reconnect backoff short.
@@ -347,12 +351,21 @@ impl DaemonConnection {
         self.send_frame_result(PacketFrame::new(channel, MSG_SESSION_ACK, &crate::packet::Ack { generation }))
     }
 
-    fn send_open_frame(&self, channel: u32, session_id: &str, cols: u16, rows: u16, role: ChannelRole) -> Result<(), String> {
+    fn send_open_frame(
+        &self,
+        channel: u32,
+        session_id: &str,
+        cols: u16,
+        rows: u16,
+        role: ChannelRole,
+        identity: &AttachmentIdentity,
+    ) -> Result<(), String> {
         self.send_frame_result(PacketFrame::new(CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL, &OpenChannel {
             channel,
             session_id: session_id.to_string(),
             role,
             take: false,
+            identity: identity.clone(),
         }))?;
         // The daemon does not resize on channel open; assert the size this
         // client wants so a session created detached comes up at view size.
@@ -423,7 +436,7 @@ impl DaemonConnection {
             let mut state = recover_lock(&self.state);
             state.connected = true;
             state.directory.replace(snapshot);
-            let reopen: Vec<(u32, String, u16, u16, ChannelRole)> = state
+            let reopen: Vec<(u32, String, u16, u16, ChannelRole, AttachmentIdentity)> = state
                 .channels
                 .iter()
                 .filter_map(|(channel, slot)| {
@@ -436,13 +449,20 @@ impl DaemonConnection {
                     }
                     // the old grant died with the connection
                     slot.granted_role = None;
-                    Some((*channel, slot.session_id.clone(), slot.desired_cols, slot.desired_rows, slot.desired_role))
+                    Some((
+                        *channel,
+                        slot.session_id.clone(),
+                        slot.desired_cols,
+                        slot.desired_rows,
+                        slot.desired_role,
+                        slot.identity.clone(),
+                    ))
                 })
                 .collect();
             (reopen, std::mem::take(&mut state.queued_input))
         };
-        for (channel, session_id, cols, rows, role) in reopen {
-            let _ = self.send_open_frame(channel, &session_id, cols, rows, role);
+        for (channel, session_id, cols, rows, role, identity) in reopen {
+            let _ = self.send_open_frame(channel, &session_id, cols, rows, role, &identity);
         }
         for frame in queued_input {
             let _ = self.send_frame_result(Ok(frame));
@@ -666,6 +686,7 @@ mod tests {
             state: "running".to_string(),
             controller_count: 0,
             watcher_count: 0,
+            controller: None,
             recreatable: false,
             cols: 80,
             rows: 24,
@@ -702,14 +723,16 @@ mod tests {
         wait_until(|| connection.is_connected());
         assert_eq!(connection.with_directory(|directory| directory.entries.len()), 1);
 
-        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 100, 40, ChannelRole::Controller);
+        let (channel, slot) =
+            connection.open_session_channel("alpha".to_string(), 100, 40, ChannelRole::Controller, AttachmentIdentity::default());
         let open = PacketFrame::read(&mut server).expect("open frame");
         assert_eq!((open.channel, open.msg_type), (CHANNEL_CONTROL, MSG_CONTROL_OPEN_CHANNEL));
         assert_eq!(open.decode::<OpenChannel>().expect("open payload"), OpenChannel {
             channel,
             session_id: "alpha".to_string(),
             role: ChannelRole::Controller,
-            take: false
+            take: false,
+            identity: AttachmentIdentity::default(),
         });
         let resize = PacketFrame::read(&mut server).expect("resize frame");
         assert_eq!((resize.channel, resize.msg_type), (channel, MSG_SESSION_RESIZE));
@@ -748,7 +771,8 @@ mod tests {
 
         let mut server = daemon.accept(vec![directory_entry("alpha")]);
         wait_until(|| connection.is_connected());
-        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 80, 24, ChannelRole::Controller);
+        let (channel, slot) =
+            connection.open_session_channel("alpha".to_string(), 80, 24, ChannelRole::Controller, AttachmentIdentity::default());
         let _open = PacketFrame::read(&mut server).expect("open frame");
         let _resize = PacketFrame::read(&mut server).expect("resize frame");
 
@@ -769,7 +793,8 @@ mod tests {
             channel,
             session_id: "alpha".to_string(),
             role: ChannelRole::Controller,
-            take: false
+            take: false,
+            identity: AttachmentIdentity::default(),
         });
         let resize = PacketFrame::read(&mut server).expect("resize frame");
         assert_eq!(resize.decode::<Resize>().expect("resize payload"), Resize { cols: 120, rows: 50 });
@@ -788,8 +813,10 @@ mod tests {
 
         let mut server = daemon.accept(vec![directory_entry("alpha"), directory_entry("beta")]);
         wait_until(|| connection.is_connected());
-        let (closed_channel, closed_slot) = connection.open_session_channel("alpha".to_string(), 80, 24, ChannelRole::Controller);
-        let (live_channel, _live_slot) = connection.open_session_channel("beta".to_string(), 80, 24, ChannelRole::Controller);
+        let (closed_channel, closed_slot) =
+            connection.open_session_channel("alpha".to_string(), 80, 24, ChannelRole::Controller, AttachmentIdentity::default());
+        let (live_channel, _live_slot) =
+            connection.open_session_channel("beta".to_string(), 80, 24, ChannelRole::Controller, AttachmentIdentity::default());
         for _ in 0..4 {
             PacketFrame::read(&mut server).expect("initial open/resize frames");
         }
@@ -816,7 +843,8 @@ mod tests {
             channel: live_channel,
             session_id: "beta".to_string(),
             role: ChannelRole::Controller,
-            take: false
+            take: false,
+            identity: AttachmentIdentity::default(),
         });
         let resize = PacketFrame::read(&mut server).expect("resize frame");
         assert_eq!((resize.channel, resize.msg_type), (live_channel, MSG_SESSION_RESIZE));
@@ -870,7 +898,8 @@ mod tests {
     fn poisoned_client_mutexes_do_not_cascade_panics() {
         let (_temp, layout) = test_layout();
         let connection = DaemonConnection::open(layout, Vec::new(), Arc::new(|| {}));
-        let (channel, slot) = connection.open_session_channel("alpha".to_string(), 80, 24, ChannelRole::Controller);
+        let (channel, slot) =
+            connection.open_session_channel("alpha".to_string(), 80, 24, ChannelRole::Controller, AttachmentIdentity::default());
 
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _state = connection.state.lock().expect("state lock");

--- a/crates/cleat/src/provider_ffi.rs
+++ b/crates/cleat/src/provider_ffi.rs
@@ -9,6 +9,7 @@ use std::{
 use crate::{
     host::actor::{ObservationState, SessionActor, SessionCommand, SessionMouseEvent, SessionWheelEvent},
     keys,
+    protocol::{AttachmentIdentity, AttachmentKind},
     provider::{
         DirtyState, ProviderFeatures, TerminalCell, TerminalCellFlags, TerminalCellWidth, TerminalCursor, TerminalCursorStyle,
         TerminalFocusEvent, TerminalGeometry, TerminalImagePlacement, TerminalImageResource, TerminalInputEvent, TerminalModifiers,
@@ -24,7 +25,7 @@ use crate::{
     vt::{self, Rgb, TerminalColors, VtEngineKind},
 };
 
-pub const CLEAT_PROVIDER_ABI_VERSION: u32 = 7;
+pub const CLEAT_PROVIDER_ABI_VERSION: u32 = 8;
 pub const CLEAT_PROVIDER_BACKEND_MOCK: u32 = 0;
 pub const CLEAT_PROVIDER_BACKEND_IN_PROCESS: u32 = 1;
 pub const CLEAT_PROVIDER_BACKEND_DAEMON: u32 = 2;
@@ -38,6 +39,9 @@ pub const CLEAT_SESSION_CLOSED: u32 = 3;
 pub const CLEAT_ROLE_UNKNOWN: u32 = 0;
 pub const CLEAT_ROLE_WATCHER: u32 = 1;
 pub const CLEAT_ROLE_CONTROLLER: u32 = 2;
+pub const CLEAT_ATTACHMENT_PRINCIPAL: u32 = 0;
+pub const CLEAT_ATTACHMENT_SUPERVISOR: u32 = 1;
+pub const CLEAT_ATTACHMENT_TOOL: u32 = 2;
 pub const CLEAT_INPUT_KEY: u32 = 1;
 pub const CLEAT_INPUT_TEXT: u32 = 2;
 pub const CLEAT_INPUT_MOUSE: u32 = 3;
@@ -201,6 +205,11 @@ pub struct CleatSessionDesc {
     /// another controller holds the session); CLEAT_ROLE_WATCHER attaches
     /// read-only. Ignored by other backends.
     pub role: u32,
+    /// UTF-8 name used in seat status and watcher banners.
+    pub attachment_name: *const u8,
+    pub attachment_name_len: usize,
+    /// CLEAT_ATTACHMENT_PRINCIPAL / SUPERVISOR / TOOL.
+    pub attachment_kind: u32,
 }
 
 #[repr(C)]
@@ -1200,6 +1209,9 @@ pub unsafe extern "C" fn cleat_session_create(provider: *mut CleatProvider, desc
         tags: ptr::null(),
         tag_count: 0,
         role: CLEAT_ROLE_UNKNOWN,
+        attachment_name: ptr::null(),
+        attachment_name_len: 0,
+        attachment_kind: CLEAT_ATTACHMENT_TOOL,
     });
     let geometry = TerminalGeometry::from_cell_size(desc.cols.max(1), desc.rows.max(1), desc.cell_width_px, desc.cell_height_px);
     let backend = match provider.backend {
@@ -2171,7 +2183,13 @@ fn create_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Re
         tags,
         environment: Vec::new(),
     })?;
-    let (channel, slot) = connection.open_session_channel(metadata.id.clone(), cols, rows, channel_role_from_ffi(desc.role)?);
+    let (channel, slot) = connection.open_session_channel(
+        metadata.id.clone(),
+        cols,
+        rows,
+        channel_role_from_ffi(desc.role)?,
+        attachment_identity_from_desc(desc)?,
+    );
     Ok(DaemonSession { id: metadata.id, connection: Arc::clone(connection), channel, slot })
 }
 
@@ -2180,8 +2198,13 @@ fn attach_daemon_session(provider: &CleatProvider, desc: CleatSessionDesc) -> Re
     let id = read_optional_utf8(desc.id, desc.id_len)
         .map_err(|err| format!("id is not valid UTF-8: {err}"))?
         .ok_or_else(|| "attach requires a session id".to_string())?;
-    let (channel, slot) =
-        connection.open_session_channel(id.clone(), desc.cols.max(1), desc.rows.max(1), channel_role_from_ffi(desc.role)?);
+    let (channel, slot) = connection.open_session_channel(
+        id.clone(),
+        desc.cols.max(1),
+        desc.rows.max(1),
+        channel_role_from_ffi(desc.role)?,
+        attachment_identity_from_desc(desc)?,
+    );
     Ok(DaemonSession { id, connection: Arc::clone(connection), channel, slot })
 }
 
@@ -2191,6 +2214,20 @@ fn channel_role_from_ffi(role: u32) -> Result<crate::packet::ChannelRole, String
         CLEAT_ROLE_WATCHER => Ok(crate::packet::ChannelRole::Watcher),
         other => Err(format!("unsupported role tag {other}")),
     }
+}
+
+fn attachment_identity_from_desc(desc: CleatSessionDesc) -> Result<AttachmentIdentity, String> {
+    let name = read_optional_utf8(desc.attachment_name, desc.attachment_name_len)
+        .map_err(|err| format!("attachment name is not valid UTF-8: {err}"))?
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "provider".to_string());
+    let kind = match desc.attachment_kind {
+        CLEAT_ATTACHMENT_PRINCIPAL => AttachmentKind::Principal,
+        CLEAT_ATTACHMENT_SUPERVISOR => AttachmentKind::Supervisor,
+        CLEAT_ATTACHMENT_TOOL => AttachmentKind::Tool,
+        other => return Err(format!("unsupported attachment kind tag {other}")),
+    };
+    Ok(AttachmentIdentity { kind, name })
 }
 
 fn vt_engine_from_tag(tag: u32) -> Result<VtEngineKind, String> {

--- a/crates/cleat/src/server.rs
+++ b/crates/cleat/src/server.rs
@@ -14,7 +14,7 @@ use crate::{
         daemon::is_session_daemon_alive,
         ipc::{set_stream_read_timeout, try_connect_session_stream, SessionStream},
     },
-    protocol::{SessionInfo, SessionStatus},
+    protocol::{AttachmentIdentity, SessionInfo, SessionStatus},
     runtime::{discoverable_runtime_roots, validate_runtime_name, DaemonCoordinates, RuntimeLayout, TerminalSize},
     session::{
         attach_foreground, ensure_session_started, run_session_daemon, start_session_in_running_daemon, watch_foreground, ForegroundAttach,
@@ -68,6 +68,13 @@ pub struct SessionService {
 pub struct DaemonInstance {
     name: String,
     pid: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AttachOptions {
+    pub identity: AttachmentIdentity,
+    pub strict: bool,
+    pub take: bool,
 }
 
 impl DaemonInstance {
@@ -207,6 +214,7 @@ impl SessionService {
             screen_activity: crate::protocol::ScreenActivity::Stable,
             stable_since: None,
             last_output_at: None,
+            controller: None,
             error: None,
         }
     }
@@ -332,6 +340,7 @@ impl SessionService {
                         screen_activity: result.screen_activity,
                         stable_since: result.stable_since,
                         last_output_at: result.last_output_at,
+                        controller: controller_identity(&result.attachments),
                         error: None,
                     };
                     if session_matches_selectors(&info, selectors) {
@@ -533,6 +542,7 @@ impl SessionService {
         cwd: Option<std::path::PathBuf>,
         cmd: Option<String>,
         no_create: bool,
+        options: AttachOptions,
     ) -> Result<(SessionInfo, ForegroundAttach), String> {
         let session = if no_create {
             let id = name.ok_or_else(|| "attach --no-create requires a session id".to_string())?;
@@ -577,18 +587,19 @@ impl SessionService {
                 screen_activity: crate::protocol::ScreenActivity::Stable,
                 stable_since: None,
                 last_output_at: None,
+                controller: None,
                 error: None,
             }
         };
-        let attach = attach_foreground(&self.layout, &info.id)?;
+        let attach = attach_foreground(&self.layout, &info.id, options.identity, options.strict, options.take)?;
         Ok((info, attach))
     }
 
-    pub fn watch(&self, id: &str) -> Result<ForegroundAttach, String> {
+    pub fn watch(&self, id: &str, identity: AttachmentIdentity) -> Result<ForegroundAttach, String> {
         if !self.layout.session_dir(id).exists() {
             return Err(format!("missing session {id}"));
         }
-        watch_foreground(&self.layout, id)
+        watch_foreground(&self.layout, id, identity)
     }
 
     pub fn connect_packets(
@@ -912,6 +923,7 @@ fn sweep_dead_daemon_sessions(layout: &RuntimeLayout, err: String) -> Result<Vec
             screen_activity: crate::protocol::ScreenActivity::Stable,
             stable_since: None,
             last_output_at: None,
+            controller: None,
             error: Some(err.clone()),
         });
     }
@@ -988,12 +1000,17 @@ fn session_info_from_inspect(result: crate::protocol::InspectResult, status: Ses
         screen_activity: result.screen_activity,
         stable_since: result.stable_since,
         last_output_at: result.last_output_at,
+        controller: controller_identity(&result.attachments),
         error: None,
     }
 }
 
 fn has_controller_attachment(attachments: &[crate::protocol::AttachmentInspect]) -> bool {
     attachments.iter().any(|attachment| attachment.role == "controller")
+}
+
+fn controller_identity(attachments: &[crate::protocol::AttachmentInspect]) -> Option<AttachmentIdentity> {
+    attachments.iter().find(|attachment| attachment.role == "controller").map(|attachment| attachment.identity.clone())
 }
 
 fn signal_target_to_http(target: crate::protocol::SignalTarget) -> http_uds::SignalTargetRequest {

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -34,7 +34,7 @@ use crate::{
         },
         terminal::{attach_signal_exit_requested, current_terminal_size, stdout_is_tty, AttachSignalHandlers, ForegroundTerminal},
     },
-    protocol::Frame,
+    protocol::{AttachmentIdentity, Frame, SeatState},
     provider::{
         DirtyState, TerminalInputEvent, TerminalKey, TerminalMouseButton, TerminalMouseEventKind, TerminalNamedKey, TerminalRenderUpdate,
     },
@@ -92,10 +92,17 @@ impl ForegroundAttach {
         let alive_out = Arc::clone(&alive);
         let relay_out = thread::spawn(move || -> Result<(), String> {
             let mut stdout = std::io::stdout().lock();
+            let mut seat_state = SeatState { role: "controller".to_string(), controller: None };
             loop {
                 match Frame::read(&mut read_stream) {
                     Ok(Frame::Output(bytes)) => {
                         stdout.write_all(&bytes).map_err(|err| format!("write stdout: {err}"))?;
+                        render_seat_chrome(&mut stdout, &seat_state)?;
+                        stdout.flush().map_err(|err| format!("flush stdout: {err}"))?;
+                    }
+                    Ok(Frame::SeatState(state)) => {
+                        seat_state = state;
+                        render_seat_chrome(&mut stdout, &seat_state)?;
                         stdout.flush().map_err(|err| format!("flush stdout: {err}"))?;
                     }
                     Ok(_) => {}
@@ -174,6 +181,36 @@ impl ForegroundAttach {
         out_result?;
         resize_result
     }
+}
+
+fn render_seat_chrome(writer: &mut impl Write, state: &SeatState) -> Result<(), String> {
+    let (_, rows) = current_terminal_size();
+    render_seat_chrome_at_rows(writer, state, rows)
+}
+
+fn render_seat_chrome_at_rows(writer: &mut impl Write, state: &SeatState, rows: u16) -> Result<(), String> {
+    if rows == 0 {
+        return Ok(());
+    }
+    writer.write_all(b"\x1b7").map_err(|err| format!("save cursor for watcher banner: {err}"))?;
+    if state.role == "watcher" {
+        if rows > 1 {
+            write!(writer, "\x1b[1;{}r", rows - 1).map_err(|err| format!("reserve watcher banner row: {err}"))?;
+        }
+        write!(writer, "\x1b[{};1H\x1b[2K", rows).map_err(|err| format!("position watcher banner: {err}"))?;
+        let controller = state.controller.as_ref().map(AttachmentIdentity::display_name).unwrap_or("none");
+        write!(writer, "\x1b[7m watching — controller: {controller} \x1b[0m").map_err(|err| format!("write watcher banner: {err}"))?;
+    } else {
+        write!(writer, "\x1b[r\x1b[{};1H\x1b[2K", rows).map_err(|err| format!("clear watcher banner: {err}"))?;
+    }
+    writer.write_all(b"\x1b8").map_err(|err| format!("restore cursor after watcher banner: {err}"))
+}
+
+fn normalize_attachment_identity(mut identity: AttachmentIdentity) -> AttachmentIdentity {
+    if identity.name.trim().is_empty() {
+        identity.name = "unknown".to_string();
+    }
+    identity
 }
 
 fn is_graceful_socket_shutdown(err: &std::io::Error) -> bool {
@@ -322,15 +359,28 @@ fn start_session(
     Ok(response.session)
 }
 
-pub fn attach_foreground(layout: &RuntimeLayout, id: &str) -> Result<ForegroundAttach, String> {
-    connect_foreground_upgrade(layout, id, "attach")
+pub fn attach_foreground(
+    layout: &RuntimeLayout,
+    id: &str,
+    identity: AttachmentIdentity,
+    strict: bool,
+    take: bool,
+) -> Result<ForegroundAttach, String> {
+    connect_foreground_upgrade(layout, id, "attach", identity, strict, take)
 }
 
-pub fn watch_foreground(layout: &RuntimeLayout, id: &str) -> Result<ForegroundAttach, String> {
-    connect_foreground_upgrade(layout, id, "watch")
+pub fn watch_foreground(layout: &RuntimeLayout, id: &str, identity: AttachmentIdentity) -> Result<ForegroundAttach, String> {
+    connect_foreground_upgrade(layout, id, "watch", identity, false, false)
 }
 
-fn connect_foreground_upgrade(layout: &RuntimeLayout, id: &str, role: &str) -> Result<ForegroundAttach, String> {
+fn connect_foreground_upgrade(
+    layout: &RuntimeLayout,
+    id: &str,
+    role: &str,
+    identity: AttachmentIdentity,
+    strict: bool,
+    take: bool,
+) -> Result<ForegroundAttach, String> {
     let socket_path = layout.socket_path();
     let deadline = Instant::now() + Duration::from_millis(250);
     loop {
@@ -340,6 +390,9 @@ fn connect_foreground_upgrade(layout: &RuntimeLayout, id: &str, role: &str) -> R
             cols,
             rows,
             capabilities: attach_capabilities_to_http(attach_init_capabilities()),
+            identity: identity.clone(),
+            take,
+            strict,
         })
         .map_err(|err| format!("serialize attach request: {err}"))?;
         http_uds::write_attach_upgrade_request(&mut stream, &format!("/sessions/{id}/{role}"), &body)
@@ -347,11 +400,19 @@ fn connect_foreground_upgrade(layout: &RuntimeLayout, id: &str, role: &str) -> R
         let response = http_uds::read_response_head(&mut stream).map_err(|err| format!("read {role} upgrade response: {err}"))?;
         match response.status {
             StatusCode::SWITCHING_PROTOCOLS => return Ok(ForegroundAttach { stream: Arc::new(Mutex::new(stream)) }),
-            StatusCode::CONFLICT => {}
+            StatusCode::CONFLICT => {
+                let mut body = String::new();
+                let _ = stream.read_to_string(&mut body);
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&body) {
+                    if let Some(error) = value.get("error").and_then(serde_json::Value::as_str) {
+                        return Err(error.to_string());
+                    }
+                }
+            }
             other => return Err(format!("unexpected {role} response: {other}")),
         }
         if Instant::now() >= deadline {
-            return Err(format!("session {id} already has a foreground client"));
+            return Err(format!("session {id} controller seat is held"));
         }
         thread::sleep(Duration::from_millis(20));
     }
@@ -1124,12 +1185,84 @@ fn packet_role_counts(session_id: &str, packet_clients: &[PacketClient]) -> (u32
     (controllers, watchers)
 }
 
+fn packet_controller_identity(hosted: &HostedSession, packet_clients: &[PacketClient]) -> Option<AttachmentIdentity> {
+    let holder = hosted.packet_controller?;
+    packet_clients
+        .iter()
+        .find(|client| client.id == holder.client_id)
+        .and_then(|client| client.channels.get(&holder.channel))
+        .map(|channel| channel.identity.clone())
+}
+
+fn controller_identity(hosted: &HostedSession, packet_clients: &[PacketClient]) -> Option<AttachmentIdentity> {
+    hosted.active_client.as_ref().map(|client| client.identity.clone()).or_else(|| packet_controller_identity(hosted, packet_clients))
+}
+
+fn announce_seat_state(hosted: &mut HostedSession, packet_clients: &mut [PacketClient]) -> Result<(), String> {
+    announce_seat_state_except(hosted, packet_clients, None)
+}
+
+fn announce_seat_state_except(
+    hosted: &mut HostedSession,
+    packet_clients: &mut [PacketClient],
+    excluded: Option<PacketChannelRef>,
+) -> Result<(), String> {
+    let controller = controller_identity(hosted, packet_clients);
+    for watcher in &mut hosted.watchers {
+        watcher.enqueue_frame(&Frame::SeatState(SeatState { role: "watcher".to_string(), controller: controller.clone() }))?;
+    }
+    for client in packet_clients {
+        let channels: Vec<(u32, ChannelRole)> = client
+            .channels
+            .iter()
+            .filter(|(_, channel)| channel.session_id == hosted.metadata.id)
+            .map(|(id, channel)| (*id, channel.role))
+            .collect();
+        for (channel, role) in channels {
+            if excluded == Some(PacketChannelRef { client_id: client.id, channel }) {
+                continue;
+            }
+            client.enqueue_frame(
+                &PacketFrame::new(channel, MSG_SESSION_ROLE, &RoleState { role, controller: controller.clone() })
+                    .map_err(|err| format!("encode seat state packet: {err}"))?,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn inspect_hosted_session(hosted: &HostedSession, packet_clients: &[PacketClient]) -> Result<crate::protocol::InspectResult, String> {
+    let mut result = hosted.actor.inspect(false, 0)?;
+    if let Some(client) = hosted.active_client.as_ref() {
+        result.attachments.push(crate::protocol::AttachmentInspect { role: "controller".to_string(), identity: client.identity.clone() });
+    }
+    result.attachments.extend(
+        hosted
+            .watchers
+            .iter()
+            .map(|client| crate::protocol::AttachmentInspect { role: "watcher".to_string(), identity: client.identity.clone() }),
+    );
+    for client in packet_clients {
+        result.attachments.extend(client.channels.values().filter(|channel| channel.session_id == result.session.id).map(|channel| {
+            crate::protocol::AttachmentInspect {
+                role: match channel.role {
+                    ChannelRole::Controller => "controller",
+                    ChannelRole::Watcher => "watcher",
+                }
+                .to_string(),
+                identity: channel.identity.clone(),
+            }
+        }));
+    }
+    Ok(result)
+}
+
 fn directory_entry_for_session(
     layout: &RuntimeLayout,
     hosted: &HostedSession,
     packet_clients: &[PacketClient],
 ) -> Result<DirectoryEntry, String> {
-    let inspect = hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?;
+    let inspect = inspect_hosted_session(hosted, packet_clients)?;
     let (packet_controllers, packet_watchers) = packet_role_counts(&inspect.session.id, packet_clients);
     Ok(DirectoryEntry {
         session_id: inspect.session.id.clone(),
@@ -1137,6 +1270,7 @@ fn directory_entry_for_session(
         state: inspect.session.state,
         controller_count: (if hosted.active_client.is_some() { 1 } else { 0 }) + packet_controllers,
         watcher_count: u32::try_from(hosted.watchers.len()).unwrap_or(u32::MAX).saturating_add(packet_watchers),
+        controller: controller_identity(hosted, packet_clients),
         recreatable: crate::recreate::session_is_recreatable(&layout.session_dir(&inspect.session.id)),
         cols: inspect.terminal.cols,
         rows: inspect.terminal.rows,
@@ -1363,6 +1497,7 @@ fn service_hosted_session(
         hosted.actor.enqueue_screen_activity_flush()?;
     }
     if resized || previous_controller_count != hosted.active_client.is_some() || previous_watcher_count != hosted.watchers.len() {
+        announce_seat_state(hosted, packet_clients)?;
         broadcast_directory_upsert(directory_entry_for_session(layout, hosted, packet_clients)?, packet_clients)?;
     }
 
@@ -1649,7 +1784,7 @@ fn handle_http_request(
         http_uds::Route::Sessions => {
             let mut sessions = Vec::new();
             for hosted in state.sessions.values() {
-                sessions.push(hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?);
+                sessions.push(inspect_hosted_session(hosted, state.packet_clients)?);
             }
             sessions.sort_by(|a, b| a.session.id.cmp(&b.session.id));
             http_uds::write_json(stream, StatusCode::OK, &http_uds::SessionListResponse { sessions })
@@ -1738,7 +1873,7 @@ fn handle_http_request(
             let Some(hosted) = state.sessions.get(&id) else {
                 return write_http_not_found(stream);
             };
-            let result = hosted.actor.inspect(hosted.active_client.is_some(), hosted.watchers.len())?;
+            let result = inspect_hosted_session(hosted, state.packet_clients)?;
             http_uds::write_json(stream, StatusCode::OK, &result).map_err(|err| format!("write HTTP inspect response: {err}"))
         }
         http_uds::Route::SessionDelete { id } => {
@@ -1755,37 +1890,78 @@ fn handle_http_request(
             let body: http_uds::AttachRequest =
                 serde_json::from_slice(request.body()).map_err(|err| format!("parse HTTP attach request: {err}"))?;
             vacate_dead_packet_controller(hosted, state.packet_clients);
-            if hosted.active_client.is_some() || hosted.packet_controller.is_some() {
-                http_uds::write_error(stream, StatusCode::CONFLICT, "session already has a foreground client")
+            let seat_is_held = hosted.active_client.is_some() || hosted.packet_controller.is_some();
+            if seat_is_held && body.strict {
+                let holder = controller_identity(hosted, state.packet_clients)
+                    .map(|identity| format!("{} ({})", identity.name, identity.kind.as_str()))
+                    .unwrap_or_else(|| "unknown".to_string());
+                http_uds::write_error(stream, StatusCode::CONFLICT, &format!("session {id} controller seat is held by {holder}"))
                     .map_err(|err| format!("write HTTP attach busy response: {err}"))?;
                 break 'attach Ok(());
             }
+            if seat_is_held && body.take {
+                if let Some(controller) = hosted.active_client.take() {
+                    hosted.watchers.push(controller);
+                }
+                if let Some(current) = hosted.packet_controller.take() {
+                    for client in state.packet_clients.iter_mut() {
+                        if client.id == current.client_id {
+                            if let Some(channel) = client.channels.get_mut(&current.channel) {
+                                channel.role = ChannelRole::Watcher;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+            let grant_controller = !seat_is_held || body.take;
 
             let capabilities = attach_capabilities_from_http(body.capabilities);
-            let replay = hosted.actor.apply_attach_state(body.cols, body.rows, capabilities)?;
+            let replay = if grant_controller {
+                hosted.actor.apply_attach_state(body.cols, body.rows, capabilities)?
+            } else {
+                hosted.actor.replay_payload(capabilities)?
+            };
             let attach_stream = stream.try_clone().map_err(|err| format!("clone HTTP attach stream: {err}"))?;
-            let mut client = ActiveClient::new(attach_stream, capabilities)?;
+            let mut client = ActiveClient::new(attach_stream, capabilities, normalize_attachment_identity(body.identity))?;
             let replay_mode = if hosted.had_foreground_client { ReplayMode::ResetTerminal } else { ReplayMode::FreshTerminal };
+            let role = if grant_controller { "controller" } else { "watcher" };
+            let seat_controller =
+                if grant_controller { Some(client.identity.clone()) } else { controller_identity(hosted, state.packet_clients) };
+            if !grant_controller {
+                client.enqueue_frame(&Frame::SeatState(SeatState { role: role.to_string(), controller: seat_controller }))?;
+            }
             drain_raw_output_tap_before_client_install(state.layout, &id, hosted, &mut client, replay, replay_mode)?;
             *response_committed = true;
             http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP attach upgrade response: {err}"))?;
             maybe_fail_after_http_upgrade("attach")?;
             #[cfg(unix)]
             set_stream_nonblocking(&client.stream, true).map_err(|err| format!("set HTTP attach stream nonblocking: {err}"))?;
-            let _ = fs::write(state.layout.foreground_path(&id), b"1");
-            hosted.active_client = Some(client);
+            if grant_controller {
+                let _ = fs::write(state.layout.foreground_path(&id), b"1");
+                hosted.active_client = Some(client);
+            } else {
+                hosted.watchers.push(client);
+            }
             let activation = (|| {
-                hosted.actor.set_client_presence(true)?;
-                hosted.actor.record_attach()?;
+                if grant_controller {
+                    hosted.actor.set_client_presence(true)?;
+                    hosted.actor.record_attach()?;
+                }
+                announce_seat_state(hosted, state.packet_clients)?;
                 broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)
             })();
             if let Err(err) = activation {
-                hosted.active_client = None;
-                let _ = hosted.actor.set_client_presence(false);
-                let _ = fs::remove_file(state.layout.foreground_path(&id));
+                if grant_controller {
+                    hosted.active_client = None;
+                    let _ = hosted.actor.set_client_presence(false);
+                    let _ = fs::remove_file(state.layout.foreground_path(&id));
+                } else {
+                    hosted.watchers.pop();
+                }
                 return Err(err);
             }
-            hosted.had_foreground_client = true;
+            hosted.had_foreground_client |= grant_controller;
             Ok(())
         }
         http_uds::Route::SessionWatch { id } => {
@@ -1797,7 +1973,11 @@ fn handle_http_request(
             let capabilities = attach_capabilities_from_http(body.capabilities);
             let replay = hosted.actor.replay_payload(capabilities)?;
             let watch_stream = stream.try_clone().map_err(|err| format!("clone HTTP watch stream: {err}"))?;
-            let mut watcher = ActiveClient::new(watch_stream, capabilities)?;
+            let mut watcher = ActiveClient::new(watch_stream, capabilities, normalize_attachment_identity(body.identity))?;
+            watcher.enqueue_frame(&Frame::SeatState(SeatState {
+                role: "watcher".to_string(),
+                controller: controller_identity(hosted, state.packet_clients),
+            }))?;
             drain_raw_output_tap_before_client_install(state.layout, &id, hosted, &mut watcher, replay, ReplayMode::FreshTerminal)?;
             *response_committed = true;
             http_uds::write_switching_protocols(stream).map_err(|err| format!("write HTTP watch upgrade response: {err}"))?;
@@ -1824,6 +2004,7 @@ fn handle_http_request(
             }
             hosted.actor.set_client_presence(false)?;
             hosted.active_client = None;
+            announce_seat_state(hosted, state.packet_clients)?;
             broadcast_directory_upsert(directory_entry_for_session(state.layout, hosted, state.packet_clients)?, state.packet_clients)?;
             http_uds::write_no_content(stream).map_err(|err| format!("write HTTP detach response: {err}"))
         }
@@ -2183,6 +2364,7 @@ struct PacketClient {
 struct PacketSessionChannel {
     session_id: String,
     role: ChannelRole,
+    identity: AttachmentIdentity,
     in_flight_generation: Option<u64>,
     last_sent_generation: u64,
 }
@@ -2357,10 +2539,11 @@ fn release_packet_client_roles(
     affected.sort();
     affected.dedup();
     for session_id in affected {
-        if let Some(hosted) = sessions.get(session_id) {
+        if let Some(hosted) = sessions.get_mut(session_id) {
             // A failing session actor must not turn role release into a
             // daemon-fatal error; the session faults on its own servicing
             // pass and broadcasts its removal there.
+            let _ = announce_seat_state(hosted, packet_clients);
             match directory_entry_for_session(layout, hosted, packet_clients) {
                 Ok(entry) => broadcast_directory_upsert(entry, packet_clients)?,
                 Err(err) => eprintln!("skipping directory update for session {session_id}: {err}"),
@@ -2385,9 +2568,8 @@ fn packet_controller_holder_is_live(current: PacketChannelRef, packet_clients: &
 }
 
 /// Resolve a controller/watcher request for `requester`, demoting the current
-/// packet controller when `take` is set. A legacy stream controller is never
-/// preempted (a raw attach cannot be demoted to read-only), so requests grant
-/// Watcher while one is attached.
+/// controller when `take` is set. Legacy stream controllers are moved into the
+/// watcher set so their connection and output stream remain alive.
 fn grant_packet_role(
     hosted: &mut HostedSession,
     packet_clients: &mut [PacketClient],
@@ -2404,7 +2586,13 @@ fn grant_packet_role(
         }
         ChannelRole::Controller => {
             if hosted.active_client.is_some() {
-                return Ok(ChannelRole::Watcher);
+                if !take {
+                    return Ok(ChannelRole::Watcher);
+                }
+                if let Some(controller) = hosted.active_client.take() {
+                    hosted.watchers.push(controller);
+                    hosted.actor.set_client_presence(false)?;
+                }
             }
             vacate_dead_packet_controller(hosted, packet_clients);
             match hosted.packet_controller {
@@ -2425,8 +2613,11 @@ fn grant_packet_role(
                             session_channel.role = ChannelRole::Watcher;
                         }
                         client.enqueue_frame(
-                            &PacketFrame::new(current.channel, MSG_SESSION_ROLE, &RoleState { role: ChannelRole::Watcher })
-                                .map_err(|err| format!("encode role demotion packet: {err}"))?,
+                            &PacketFrame::new(current.channel, MSG_SESSION_ROLE, &RoleState {
+                                role: ChannelRole::Watcher,
+                                controller: None,
+                            })
+                            .map_err(|err| format!("encode role demotion packet: {err}"))?,
                         )?;
                         break;
                     }
@@ -2459,8 +2650,7 @@ fn handle_packet_frame(
                     if hosted.packet_controller == Some(PacketChannelRef { client_id, channel: close.channel }) {
                         hosted.packet_controller = None;
                     }
-                }
-                if let Some(hosted) = sessions.get(&removed.session_id) {
+                    announce_seat_state(hosted, packet_clients)?;
                     updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
                 }
             }
@@ -2541,18 +2731,25 @@ fn apply_packet_role_request(
     let Some(hosted) = sessions.get_mut(&session_id) else {
         return Ok(());
     };
+    let previous_controller = controller_identity(hosted, packet_clients);
     let requester = PacketChannelRef { client_id: packet_clients[index].id, channel };
     let granted = grant_packet_role(hosted, packet_clients, requester, request.role, request.take)?;
+    let controller = controller_identity(hosted, packet_clients);
     let client = &mut packet_clients[index];
     if let Some(session_channel) = client.channels.get_mut(&channel) {
         session_channel.role = granted;
     }
     client.enqueue_frame(
-        &PacketFrame::new(channel, MSG_SESSION_ROLE, &RoleState { role: granted })
+        &PacketFrame::new(channel, MSG_SESSION_ROLE, &RoleState { role: granted, controller })
             .map_err(|err| format!("encode role state packet: {err}"))?,
     )?;
     if let Some(hosted) = sessions.get(&session_id) {
         updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
+    }
+    if let Some(hosted) = sessions.get_mut(&session_id) {
+        if controller_identity(hosted, packet_clients) != previous_controller {
+            announce_seat_state_except(hosted, packet_clients, Some(requester))?;
+        }
     }
     Ok(())
 }
@@ -2572,6 +2769,8 @@ fn open_packet_channel(
         })?;
         return Ok(());
     }
+    let mut open = open;
+    open.identity = normalize_attachment_identity(open.identity);
     let Some(hosted) = sessions.get_mut(&open.session_id) else {
         packet_clients[index].enqueue_control(MSG_CONTROL_ERROR, &ControlError {
             channel: open.channel,
@@ -2593,14 +2792,17 @@ fn open_packet_channel(
             return Ok(());
         }
     };
+    let previous_controller = controller_identity(hosted, packet_clients);
     let requester = PacketChannelRef { client_id: packet_clients[index].id, channel: open.channel };
     let granted = grant_packet_role(hosted, packet_clients, requester, open.role, open.take)?;
     let session_id = open.session_id;
     let generation = update.render_generation;
+    let controller =
+        if granted == ChannelRole::Controller { Some(open.identity.clone()) } else { controller_identity(hosted, packet_clients) };
     hosted.packet_render_cache.store(update.clone());
     let client = &mut packet_clients[index];
     client.enqueue_frame(
-        &PacketFrame::new(open.channel, MSG_SESSION_ROLE, &RoleState { role: granted })
+        &PacketFrame::new(open.channel, MSG_SESSION_ROLE, &RoleState { role: granted, controller })
             .map_err(|err| format!("encode role state packet: {err}"))?,
     )?;
     client.enqueue_frame(
@@ -2610,11 +2812,17 @@ fn open_packet_channel(
     client.channels.insert(open.channel, PacketSessionChannel {
         session_id: session_id.clone(),
         role: granted,
+        identity: open.identity,
         in_flight_generation: Some(generation),
         last_sent_generation: generation,
     });
     if let Some(hosted) = sessions.get(&session_id) {
         updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
+    }
+    if let Some(hosted) = sessions.get_mut(&session_id) {
+        if controller_identity(hosted, packet_clients) != previous_controller {
+            announce_seat_state_except(hosted, packet_clients, Some(requester))?;
+        }
     }
     Ok(())
 }
@@ -2877,12 +3085,13 @@ struct ActiveClient {
     input_reader: ActiveClientReader,
     input_buffer: Vec<u8>,
     capabilities: vt::ClientCapabilities,
+    identity: AttachmentIdentity,
 }
 
 impl ActiveClient {
-    fn new(stream: SessionStream, capabilities: vt::ClientCapabilities) -> Result<Self, String> {
+    fn new(stream: SessionStream, capabilities: vt::ClientCapabilities, identity: AttachmentIdentity) -> Result<Self, String> {
         let input_reader = ActiveClientReader::new(&stream)?;
-        Ok(Self { stream, pending_output: PendingOutput::new(), input_reader, input_buffer: Vec::new(), capabilities })
+        Ok(Self { stream, pending_output: PendingOutput::new(), input_reader, input_buffer: Vec::new(), capabilities, identity })
     }
 
     fn drain_input_frames(&mut self, pending: &mut VecDeque<Frame>, timeout: Duration) -> Result<bool, std::io::Error> {
@@ -3045,6 +3254,7 @@ mod tests {
     };
     use crate::{
         http_uds::read_http_request_for_test,
+        protocol::AttachmentIdentity,
         runtime::{RuntimeLayout, SessionMetadata, TerminalSize},
         vt::{self, VtEngine},
     };
@@ -3072,7 +3282,7 @@ mod tests {
                 .expect("write response");
         });
 
-        let attach = attach_foreground(&layout, "alpha").expect("attach");
+        let attach = attach_foreground(&layout, "alpha", AttachmentIdentity::default(), false, false).expect("attach");
         drop(attach);
         let request = rx.recv_timeout(Duration::from_secs(1)).expect("receive request");
 
@@ -3084,7 +3294,8 @@ mod tests {
         // against the serialization of whatever detection currently reports.
         let expected_capabilities =
             serde_json::to_string(&super::attach_capabilities_to_http(attach_init_capabilities())).expect("serialize capabilities");
-        assert!(request.ends_with(&format!(r#""capabilities":{expected_capabilities}}}"#)), "{request}");
+        assert!(request.contains(&format!(r#""capabilities":{expected_capabilities}"#)), "{request}");
+        assert!(request.contains(r#""identity":{"kind":"principal","name":""}"#), "{request}");
     }
 
     #[test]
@@ -3112,6 +3323,28 @@ mod tests {
             *output.lock().expect("lock output"),
             b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1004l\x1b[<u\x1b[r\x1b[0m\x1b[?25h\x1b[2J\x1b[H\x1b[?1049l"
         );
+    }
+
+    #[test]
+    fn watcher_chrome_reserves_the_last_row_and_names_the_controller() {
+        let mut output = Vec::new();
+        super::render_seat_chrome_at_rows(
+            &mut output,
+            &crate::protocol::SeatState {
+                role: "watcher".to_string(),
+                controller: Some(crate::protocol::AttachmentIdentity {
+                    kind: crate::protocol::AttachmentKind::Supervisor,
+                    name: "crew-runner".to_string(),
+                }),
+            },
+            24,
+        )
+        .expect("render watcher chrome");
+
+        let output = String::from_utf8(output).expect("watcher chrome is utf8");
+        assert!(output.contains("\u{1b}[1;23r"));
+        assert!(output.contains("\u{1b}[24;1H"));
+        assert!(output.contains("watching — controller: crew-runner"));
     }
 
     #[test]
@@ -3207,8 +3440,8 @@ mod tests {
         let (stream_a, _peer_a) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
         let (stream_b, _peer_b) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
         let capabilities = crate::vt::ClientCapabilities::conservative_fallback();
-        let mut via_output = super::ActiveClient::new(stream_a, capabilities).expect("create active client");
-        let mut via_frame = super::ActiveClient::new(stream_b, capabilities).expect("create active client");
+        let mut via_output = super::ActiveClient::new(stream_a, capabilities, AttachmentIdentity::default()).expect("create active client");
+        let mut via_frame = super::ActiveClient::new(stream_b, capabilities, AttachmentIdentity::default()).expect("create active client");
 
         let payload = b"\x1b[1mchunk\x00\xff";
         via_output.enqueue_output(payload).expect("enqueue output payload");
@@ -3222,7 +3455,8 @@ mod tests {
     fn active_client_rejects_unbounded_output_backlog() {
         let (stream, _peer) = std::os::unix::net::UnixStream::pair().expect("unix stream pair");
         let mut client =
-            super::ActiveClient::new(stream, crate::vt::ClientCapabilities::conservative_fallback()).expect("create active client");
+            super::ActiveClient::new(stream, crate::vt::ClientCapabilities::conservative_fallback(), AttachmentIdentity::default())
+                .expect("create active client");
         client.pending_output = super::PendingOutput::from(vec![0; super::MAX_PENDING_CLIENT_OUTPUT_BYTES - 1]);
 
         let err = client.enqueue_frame(&super::Frame::Output(vec![1])).expect_err("backlog should overflow");

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -92,17 +92,15 @@ impl ForegroundAttach {
         let alive_out = Arc::clone(&alive);
         let relay_out = thread::spawn(move || -> Result<(), String> {
             let mut stdout = std::io::stdout().lock();
-            let mut seat_state = SeatState { role: "controller".to_string(), controller: None };
+            let mut watcher_state = None;
             loop {
                 match Frame::read(&mut read_stream) {
                     Ok(Frame::Output(bytes)) => {
-                        stdout.write_all(&bytes).map_err(|err| format!("write stdout: {err}"))?;
-                        render_seat_chrome(&mut stdout, &seat_state)?;
+                        write_attach_output(&mut stdout, &bytes, watcher_state.as_ref())?;
                         stdout.flush().map_err(|err| format!("flush stdout: {err}"))?;
                     }
                     Ok(Frame::SeatState(state)) => {
-                        seat_state = state;
-                        render_seat_chrome(&mut stdout, &seat_state)?;
+                        update_watcher_chrome(&mut stdout, &mut watcher_state, state)?;
                         stdout.flush().map_err(|err| format!("flush stdout: {err}"))?;
                     }
                     Ok(_) => {}
@@ -181,6 +179,24 @@ impl ForegroundAttach {
         out_result?;
         resize_result
     }
+}
+
+fn write_attach_output(writer: &mut impl Write, bytes: &[u8], watcher_state: Option<&SeatState>) -> Result<(), String> {
+    writer.write_all(bytes).map_err(|err| format!("write stdout: {err}"))?;
+    if let Some(state) = watcher_state {
+        render_seat_chrome(writer, state)?;
+    }
+    Ok(())
+}
+
+fn update_watcher_chrome(writer: &mut impl Write, watcher_state: &mut Option<SeatState>, state: SeatState) -> Result<(), String> {
+    if state.role == "watcher" {
+        render_seat_chrome(writer, &state)?;
+        *watcher_state = Some(state);
+    } else if watcher_state.take().is_some() {
+        render_seat_chrome(writer, &state)?;
+    }
+    Ok(())
 }
 
 fn render_seat_chrome(writer: &mut impl Write, state: &SeatState) -> Result<(), String> {
@@ -3373,6 +3389,14 @@ mod tests {
         assert!(!output.contains('\u{7}'));
         assert!(!output.contains('\n'));
         assert!(output.contains("watching — controller: bad]2;injectedname"));
+    }
+
+    #[test]
+    fn controller_output_does_not_render_watcher_chrome() {
+        let mut output = Vec::new();
+        super::write_attach_output(&mut output, b"last terminal row", None).expect("relay controller output");
+
+        assert_eq!(output, b"last terminal row");
     }
 
     #[test]

--- a/crates/cleat/src/session.rs
+++ b/crates/cleat/src/session.rs
@@ -198,7 +198,11 @@ fn render_seat_chrome_at_rows(writer: &mut impl Write, state: &SeatState, rows: 
             write!(writer, "\x1b[1;{}r", rows - 1).map_err(|err| format!("reserve watcher banner row: {err}"))?;
         }
         write!(writer, "\x1b[{};1H\x1b[2K", rows).map_err(|err| format!("position watcher banner: {err}"))?;
-        let controller = state.controller.as_ref().map(AttachmentIdentity::display_name).unwrap_or("none");
+        let controller = state
+            .controller
+            .as_ref()
+            .map(|identity| sanitize_attachment_name(identity.display_name()))
+            .unwrap_or_else(|| "none".to_string());
         write!(writer, "\x1b[7m watching — controller: {controller} \x1b[0m").map_err(|err| format!("write watcher banner: {err}"))?;
     } else {
         write!(writer, "\x1b[r\x1b[{};1H\x1b[2K", rows).map_err(|err| format!("clear watcher banner: {err}"))?;
@@ -207,10 +211,18 @@ fn render_seat_chrome_at_rows(writer: &mut impl Write, state: &SeatState, rows: 
 }
 
 fn normalize_attachment_identity(mut identity: AttachmentIdentity) -> AttachmentIdentity {
-    if identity.name.trim().is_empty() {
-        identity.name = "unknown".to_string();
-    }
+    identity.name = sanitize_attachment_name(&identity.name);
     identity
+}
+
+fn sanitize_attachment_name(name: &str) -> String {
+    let name = name.chars().filter(|character| !character.is_control()).take(128).collect::<String>();
+    let name = name.trim();
+    if name.is_empty() {
+        "unknown".to_string()
+    } else {
+        name.to_string()
+    }
 }
 
 fn is_graceful_socket_shutdown(err: &std::io::Error) -> bool {
@@ -2612,13 +2624,6 @@ fn grant_packet_role(
                         if let Some(session_channel) = client.channels.get_mut(&current.channel) {
                             session_channel.role = ChannelRole::Watcher;
                         }
-                        client.enqueue_frame(
-                            &PacketFrame::new(current.channel, MSG_SESSION_ROLE, &RoleState {
-                                role: ChannelRole::Watcher,
-                                controller: None,
-                            })
-                            .map_err(|err| format!("encode role demotion packet: {err}"))?,
-                        )?;
                         break;
                     }
                     hosted.packet_controller = Some(requester);
@@ -2731,7 +2736,7 @@ fn apply_packet_role_request(
     let Some(hosted) = sessions.get_mut(&session_id) else {
         return Ok(());
     };
-    let previous_controller = controller_identity(hosted, packet_clients);
+    let previous_controller = (hosted.active_client.is_some(), hosted.packet_controller);
     let requester = PacketChannelRef { client_id: packet_clients[index].id, channel };
     let granted = grant_packet_role(hosted, packet_clients, requester, request.role, request.take)?;
     let controller = controller_identity(hosted, packet_clients);
@@ -2747,7 +2752,7 @@ fn apply_packet_role_request(
         updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
     }
     if let Some(hosted) = sessions.get_mut(&session_id) {
-        if controller_identity(hosted, packet_clients) != previous_controller {
+        if (hosted.active_client.is_some(), hosted.packet_controller) != previous_controller {
             announce_seat_state_except(hosted, packet_clients, Some(requester))?;
         }
     }
@@ -2792,7 +2797,7 @@ fn open_packet_channel(
             return Ok(());
         }
     };
-    let previous_controller = controller_identity(hosted, packet_clients);
+    let previous_controller = (hosted.active_client.is_some(), hosted.packet_controller);
     let requester = PacketChannelRef { client_id: packet_clients[index].id, channel: open.channel };
     let granted = grant_packet_role(hosted, packet_clients, requester, open.role, open.take)?;
     let session_id = open.session_id;
@@ -2820,7 +2825,7 @@ fn open_packet_channel(
         updates.push(directory_entry_for_session(layout, hosted, packet_clients)?);
     }
     if let Some(hosted) = sessions.get_mut(&session_id) {
-        if controller_identity(hosted, packet_clients) != previous_controller {
+        if (hosted.active_client.is_some(), hosted.packet_controller) != previous_controller {
             announce_seat_state_except(hosted, packet_clients, Some(requester))?;
         }
     }
@@ -3345,6 +3350,29 @@ mod tests {
         assert!(output.contains("\u{1b}[1;23r"));
         assert!(output.contains("\u{1b}[24;1H"));
         assert!(output.contains("watching — controller: crew-runner"));
+    }
+
+    #[test]
+    fn watcher_chrome_strips_control_sequences_from_controller_identity() {
+        let mut output = Vec::new();
+        super::render_seat_chrome_at_rows(
+            &mut output,
+            &crate::protocol::SeatState {
+                role: "watcher".to_string(),
+                controller: Some(crate::protocol::AttachmentIdentity {
+                    kind: crate::protocol::AttachmentKind::Tool,
+                    name: "bad\u{1b}]2;injected\u{7}\nname".to_string(),
+                }),
+            },
+            24,
+        )
+        .expect("render sanitized watcher chrome");
+
+        let output = String::from_utf8(output).expect("watcher chrome is utf8");
+        assert!(!output.contains("\u{1b}]2;injected"));
+        assert!(!output.contains('\u{7}'));
+        assert!(!output.contains('\n'));
+        assert!(output.contains("watching — controller: bad]2;injectedname"));
     }
 
     #[test]

--- a/crates/cleat/src/session_runtime.rs
+++ b/crates/cleat/src/session_runtime.rs
@@ -318,9 +318,15 @@ impl SessionRuntime {
         let foreground_pgid = self.pty_child.foreground_pgid();
         let mut attachments = Vec::new();
         if has_controller {
-            attachments.push(crate::protocol::AttachmentInspect { role: "controller".to_string() });
+            attachments.push(crate::protocol::AttachmentInspect {
+                role: "controller".to_string(),
+                identity: crate::protocol::AttachmentIdentity::default(),
+            });
         }
-        attachments.extend((0..watcher_count).map(|_| crate::protocol::AttachmentInspect { role: "watcher".to_string() }));
+        attachments.extend((0..watcher_count).map(|_| crate::protocol::AttachmentInspect {
+            role: "watcher".to_string(),
+            identity: crate::protocol::AttachmentIdentity::default(),
+        }));
 
         let activity = self.screen_activity.json_snapshot(Instant::now());
         InspectResult {

--- a/crates/cleat/tests/cli.rs
+++ b/crates/cleat/tests/cli.rs
@@ -1,6 +1,7 @@
 use clap::CommandFactory;
 use cleat::{
-    cli::{self, execute, resolve_daemon_target, Cli, Command, ExecResult, RecordFlags},
+    cli::{self, execute, resolve_daemon_target, AttachmentFlags, Cli, Command, ExecResult, RecordFlags},
+    protocol::AttachmentKind,
     runtime::{RuntimeLayout, TerminalSize},
     server::SessionService,
     session::session_socket_path,
@@ -122,6 +123,9 @@ fn attach_command_parses() {
         vt: None,
         cwd: None,
         cmd: None,
+        strict: false,
+        take: false,
+        attachment: AttachmentFlags::default(),
         record: RecordFlags::default()
     });
 }
@@ -135,6 +139,9 @@ fn attach_command_parses_no_create() {
         vt: None,
         cwd: None,
         cmd: None,
+        strict: false,
+        take: false,
+        attachment: AttachmentFlags::default(),
         record: RecordFlags::default()
     });
 }
@@ -148,6 +155,9 @@ fn attach_command_parses_vt() {
         vt: Some(VtEngineKind::Passthrough),
         cwd: None,
         cmd: None,
+        strict: false,
+        take: false,
+        attachment: AttachmentFlags::default(),
         record: RecordFlags::default()
     });
 }
@@ -155,7 +165,30 @@ fn attach_command_parses_vt() {
 #[test]
 fn watch_command_parses() {
     let cli = Cli::try_parse_from(["cleat", "watch", "demo"]).expect("watch parses");
-    assert_eq!(cli.command, Command::Watch { id: "demo".into() });
+    assert_eq!(cli.command, Command::Watch { id: "demo".into(), attachment: AttachmentFlags::default() });
+}
+
+#[test]
+fn attach_command_parses_seat_control_and_identity_flags() {
+    let cli = Cli::try_parse_from(["cleat", "attach", "--take", "--identity", "crew-runner", "--identity-kind", "supervisor", "demo"])
+        .expect("attach seat flags parse");
+    assert!(matches!(
+        cli.command,
+        Command::Attach {
+            take: true,
+            strict: false,
+            attachment: AttachmentFlags {
+                identity: Some(ref name),
+                identity_kind: AttachmentKind::Supervisor,
+            },
+            ..
+        } if name == "crew-runner"
+    ));
+}
+
+#[test]
+fn attach_command_rejects_strict_with_take() {
+    assert!(Cli::try_parse_from(["cleat", "attach", "--strict", "--take", "demo"]).is_err());
 }
 
 #[test]

--- a/crates/cleat/tests/lifecycle.rs
+++ b/crates/cleat/tests/lifecycle.rs
@@ -25,7 +25,7 @@ use cleat::{
         MSG_CONTROL_ACTIVITY_EVENT, MSG_CONTROL_ACTIVITY_SNAPSHOT, MSG_CONTROL_DIRECTORY_DELTA, MSG_CONTROL_DIRECTORY_SNAPSHOT,
         MSG_CONTROL_HELLO, PROTOCOL_VERSION,
     },
-    protocol::{Frame, SessionInfo},
+    protocol::{AttachmentIdentity, AttachmentKind, Frame, SeatState, SessionInfo},
     provider::ProviderFeatures,
     provider_ffi::{
         cleat_provider_close, cleat_provider_directory_generation, cleat_provider_directory_release, cleat_provider_directory_snapshot,
@@ -35,7 +35,7 @@ use cleat::{
     },
     recording::{SessionRecorder, CAST_FILE_NAME},
     runtime::{RuntimeLayout, TerminalSize, DEFAULT_DAEMON_NAME},
-    server::{EndBound, SessionService, StartBound},
+    server::{AttachOptions, EndBound, SessionService, StartBound},
     session::{daemon_pid_path, ensure_session_started, run_session_daemon, session_socket_path, SessionStartOptions},
     vt::{self, ClientCapabilities, ColorLevel, VtEngineKind},
 };
@@ -179,6 +179,7 @@ fn packet_open_channel_role(stream: &mut UnixStream, channel: u32, session_id: &
         session_id: session_id.to_string(),
         role,
         take,
+        identity: AttachmentIdentity::default(),
     });
 }
 
@@ -394,6 +395,49 @@ fn http_upgrade_stream(
     let response = read_http_response_head(&mut stream);
     assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{response}");
     stream
+}
+
+fn http_attach_with_seat_options(
+    root: &std::path::Path,
+    id: &str,
+    identity: AttachmentIdentity,
+    strict: bool,
+    take: bool,
+) -> (UnixStream, String) {
+    let socket_path = session_socket_path(root, id);
+    let mut stream = UnixStream::connect(&socket_path).expect("connect session socket");
+    let body = serde_json::json!({
+        "cols": 80,
+        "rows": 24,
+        "capabilities": {
+            "color_level": "sixteen",
+            "kitty_keyboard": false
+        },
+        "identity": identity,
+        "strict": strict,
+        "take": take
+    })
+    .to_string();
+    write!(
+        stream,
+        "POST /sessions/{id}/attach HTTP/1.1\r\nHost: cleat\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: Upgrade\r\nUpgrade: cleat-attach/1\r\n\r\n{}",
+        body.len(),
+        body
+    )
+    .expect("write seat-aware attach request");
+    let response = read_http_response_head(&mut stream);
+    (stream, response)
+}
+
+fn read_until_seat_state(stream: &mut UnixStream, timeout: Duration) -> SeatState {
+    stream.set_read_timeout(Some(timeout)).expect("set seat state timeout");
+    loop {
+        match Frame::read(stream).expect("read attachment frame") {
+            Frame::SeatState(state) => return state,
+            Frame::Output(_) => {}
+            other => panic!("unexpected attachment frame before seat state: {other:?}"),
+        }
+    }
 }
 
 fn read_http_response_head(stream: &mut UnixStream) -> String {
@@ -1166,7 +1210,7 @@ fn directory_subscription_filters_and_emits_lifecycle_deltas() {
     let delta = read_directory_delta_named(&mut stream, &mut buffer, Duration::from_secs(30), "beta retag delta");
     assert_eq!(delta.upserted.iter().map(|entry| entry.session_id.as_str()).collect::<Vec<_>>(), vec!["beta"]);
 
-    let (_info, attach) = service.attach(Some("beta".into()), None, None, None, true).expect("attach beta");
+    let (_info, attach) = service.attach(Some("beta".into()), None, None, None, true, AttachOptions::default()).expect("attach beta");
     let delta = read_directory_delta_named(&mut stream, &mut buffer, Duration::from_secs(30), "beta attach delta");
     assert_eq!(delta.upserted[0].session_id, "beta");
     assert_eq!(delta.upserted[0].controller_count, 1);
@@ -1820,6 +1864,7 @@ fn packet_connect_emits_hello_and_directory_snapshot() {
             state: "running".to_string(),
             controller_count: 0,
             watcher_count: 0,
+            controller: None,
             recreatable: false,
             cols: 80,
             rows: 24,
@@ -1830,6 +1875,7 @@ fn packet_connect_emits_hello_and_directory_snapshot() {
             state: "running".to_string(),
             controller_count: 0,
             watcher_count: 0,
+            controller: None,
             recreatable: false,
             cols: 80,
             rows: 24,
@@ -2294,14 +2340,17 @@ fn attach_creates_session_lazily_and_reuses_it_on_later_attach() {
     let temp = tempfile::tempdir().expect("tempdir");
     let service = service_for(temp.path());
 
-    let (first, attach) = service.attach(Some("alpha".into()), None, None, Some("sleep 5".into()), false).expect("first attach");
+    let (first, attach) =
+        service.attach(Some("alpha".into()), None, None, Some("sleep 5".into()), false, AttachOptions::default()).expect("first attach");
     assert_eq!(first.id, "alpha");
     assert_eq!(first.vt_engine, vt::default_vt_engine_kind());
     assert!(daemon_pid_path(temp.path(), "alpha").exists());
 
     drop(attach);
 
-    let (second, _attach2) = service.attach(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, None, false).expect("reattach");
+    let (second, _attach2) = service
+        .attach(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, None, false, AttachOptions::default())
+        .expect("reattach");
     assert_eq!(second.id, "alpha");
     assert_eq!(second.vt_engine, vt::default_vt_engine_kind());
 }
@@ -2326,32 +2375,96 @@ fn attach_vt_only_applies_when_creating_new_session() {
     let temp = tempfile::tempdir().expect("tempdir");
     let service = service_for(temp.path());
 
-    let (created, attach) =
-        service.attach(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 5".into()), false).expect("first attach");
+    let (created, attach) = service
+        .attach(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("sleep 5".into()), false, AttachOptions::default())
+        .expect("first attach");
     assert_eq!(created.vt_engine, VtEngineKind::Passthrough);
     drop(attach);
 
-    let (reattached, _attach2) =
-        service.attach(Some("alpha".into()), Some(vt::default_vt_engine_kind()), None, None, false).expect("reattach");
+    let (reattached, _attach2) = service
+        .attach(Some("alpha".into()), Some(vt::default_vt_engine_kind()), None, None, false, AttachOptions::default())
+        .expect("reattach");
     assert_eq!(reattached.vt_engine, VtEngineKind::Passthrough);
+}
+
+#[test]
+fn attach_falls_back_strictly_refuses_and_take_demotes_without_losing_session_state() {
+    let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let service = service_for(temp.path());
+    service.create(Some("alpha".into()), Some(VtEngineKind::Passthrough), None, Some("cat".into()), true).expect("create alpha");
+
+    let alice = AttachmentIdentity { kind: AttachmentKind::Principal, name: "alice".to_string() };
+    let bob = AttachmentIdentity { kind: AttachmentKind::Supervisor, name: "bob".to_string() };
+    let carol = AttachmentIdentity { kind: AttachmentKind::Tool, name: "carol".to_string() };
+
+    let (mut controller, first_response) = http_attach_with_seat_options(temp.path(), "alpha", alice.clone(), false, false);
+    assert!(first_response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{first_response}");
+
+    let (mut strict_stream, strict_response) = http_attach_with_seat_options(temp.path(), "alpha", bob.clone(), true, false);
+    assert!(strict_response.starts_with("HTTP/1.1 409 Conflict\r\n"), "{strict_response}");
+    let mut strict_body = String::new();
+    strict_stream.read_to_string(&mut strict_body).expect("read strict error body");
+    assert!(strict_body.contains("alice (principal)"), "{strict_body}");
+
+    let (mut watcher, fallback_response) = http_attach_with_seat_options(temp.path(), "alpha", bob.clone(), false, false);
+    assert!(fallback_response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{fallback_response}");
+    assert_eq!(read_until_seat_state(&mut watcher, Duration::from_secs(2)), SeatState {
+        role: "watcher".to_string(),
+        controller: Some(alice.clone())
+    });
+
+    let before = service.inspect("alpha").expect("inspect before take");
+    assert!(before.recording.active);
+    assert_eq!(before.attachments, vec![
+        cleat::protocol::AttachmentInspect { role: "controller".to_string(), identity: alice },
+        cleat::protocol::AttachmentInspect { role: "watcher".to_string(), identity: bob },
+    ]);
+
+    let (_new_controller, take_response) = http_attach_with_seat_options(temp.path(), "alpha", carol.clone(), false, true);
+    assert!(take_response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"), "{take_response}");
+    assert_eq!(read_until_seat_state(&mut controller, Duration::from_secs(2)), SeatState {
+        role: "watcher".to_string(),
+        controller: Some(carol.clone())
+    });
+
+    let after = service.inspect("alpha").expect("inspect after take");
+    assert_eq!(after.session.state, "running");
+    assert!(after.recording.active);
+    assert_eq!(after.attachments.iter().filter(|attachment| attachment.role == "controller").collect::<Vec<_>>(), vec![
+        &cleat::protocol::AttachmentInspect { role: "controller".to_string(), identity: carol.clone() }
+    ]);
+    assert_eq!(service.list().expect("list sessions")[0].controller, Some(carol));
 }
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
-fn attach_rejects_second_foreground_client_while_one_is_active() {
+fn attach_strict_rejects_second_foreground_client_while_one_is_active() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");
     let service = service_for(temp.path());
 
-    let (_session, _attach) = service.attach(Some("alpha".into()), None, None, Some("sleep 5".into()), false).expect("first attach");
-    let err = service.attach(Some("alpha".into()), None, None, None, false).expect_err("second attach should fail");
+    let (_session, _attach) = service
+        .attach(Some("alpha".into()), None, None, Some("sleep 5".into()), false, AttachOptions {
+            identity: AttachmentIdentity { kind: AttachmentKind::Principal, name: "first".to_string() },
+            strict: false,
+            take: false,
+        })
+        .expect("first attach");
+    let err = service
+        .attach(Some("alpha".into()), None, None, None, false, AttachOptions {
+            identity: AttachmentIdentity { kind: AttachmentKind::Principal, name: "second".to_string() },
+            strict: true,
+            take: false,
+        })
+        .expect_err("second strict attach should fail");
 
-    assert!(err.contains("foreground client"));
+    assert!(err.contains("first (principal)"));
 }
 
 #[cfg(feature = "ghostty-vt")]
 #[test]
-fn lifecycle_attach_init_with_capabilities_is_accepted_without_changing_single_client_policy() {
+fn lifecycle_attach_init_with_capabilities_is_accepted_with_strict_seat_policy() {
     let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
     let temp = tempfile::tempdir().expect("tempdir");
     let service = service_for(temp.path());
@@ -2360,8 +2473,14 @@ fn lifecycle_attach_init_with_capabilities_is_accepted_without_changing_single_c
 
     let _stream = http_attach_stream(temp.path(), "alpha", 100, 30, ClientCapabilities::new(ColorLevel::Ansi256, true));
 
-    let err = service.attach(Some("alpha".into()), None, None, None, false).expect_err("second attach should fail");
-    assert!(err.contains("foreground client"));
+    let err = service
+        .attach(Some("alpha".into()), None, None, None, false, AttachOptions {
+            identity: AttachmentIdentity::default(),
+            strict: true,
+            take: false,
+        })
+        .expect_err("second attach should fail");
+    assert!(err.contains("controller seat is held by unknown (principal)"));
 }
 
 #[test]
@@ -2417,6 +2536,8 @@ fn lifecycle_watch_gets_replay_without_resizing_session() {
 
     let mut stream = http_watch_stream(temp.path(), "alpha", 100, 30, ClientCapabilities::new(ColorLevel::Ansi256, true));
 
+    let seat = Frame::read(&mut stream).expect("read watcher seat state");
+    assert_eq!(seat, Frame::SeatState(SeatState { role: "watcher".to_string(), controller: None }));
     let replay = Frame::read(&mut stream).expect("read watch replay output");
     assert_eq!(replay, Frame::Output(b"Ansi256:true".to_vec()));
     let result = service.inspect("alpha").expect("inspect watched session");
@@ -2731,13 +2852,15 @@ fn dropping_foreground_attach_keeps_session_alive_for_later_attach() {
     let temp = tempfile::tempdir().expect("tempdir");
     let service = service_for(temp.path());
 
-    let (_session, attach) = service.attach(Some("alpha".into()), None, None, Some("sleep 5".into()), false).expect("first attach");
+    let (_session, attach) =
+        service.attach(Some("alpha".into()), None, None, Some("sleep 5".into()), false, AttachOptions::default()).expect("first attach");
     let pid_path = daemon_pid_path(temp.path(), "alpha");
     assert!(pid_path.exists());
 
     drop(attach);
 
-    let (_session, _reattach) = service.attach(Some("alpha".into()), None, None, None, false).expect("reattach after disconnect");
+    let (_session, _reattach) =
+        service.attach(Some("alpha".into()), None, None, None, false, AttachOptions::default()).expect("reattach after disconnect");
     assert!(pid_path.exists());
 }
 
@@ -2751,7 +2874,9 @@ fn stale_foreground_file_does_not_block_attach() {
     service.create(Some("alpha".into()), None, None, Some("sleep 5".into()), false).expect("create alpha");
     std::fs::write(foreground_path(temp.path(), "alpha"), b"999999").expect("write stale foreground marker");
 
-    let (_session, _attach) = service.attach(Some("alpha".into()), None, None, None, false).expect("attach with stale foreground marker");
+    let (_session, _attach) = service
+        .attach(Some("alpha".into()), None, None, None, false, AttachOptions::default())
+        .expect("attach with stale foreground marker");
 }
 
 // A session flooding output at PTY saturation (`yes`) must not starve the

--- a/docs/skills/cleat-sessions/README.md
+++ b/docs/skills/cleat-sessions/README.md
@@ -53,7 +53,7 @@ cleat kill build                     # ends it; recording survives
 | Wait for readiness | `wait <id> --text "str" --screen-stable 30 --idle-time 5 --timeout 600` — conditions OR together |
 | Structured state | `inspect <id>` — size, leader pid, **foreground pgid** (`fg_pgid != leader_pid` ⇒ a command is running), attachments, recording |
 | Recorded output since a point | `mark <id> name` … `transcript <id> --since-marker name` ; `expect <id> "text"` blocks on recorded output |
-| Interactive use (human) | `attach <id>` (controller), `watch <id>` (read-only) |
+| Interactive use (human) | `attach <id>` (controller, or automatic watcher fallback), `attach --take <id>` (claim control), `watch <id>` (read-only) |
 | Signals | `interrupt <id>` (byte Ctrl-C) vs `signal <id> INT` (real signal, `--target foreground|leader`; `tree` not yet implemented) |
 | End it | `kill <id>` — **recording is preserved**; `kill --purge` discards |
 | Enumerate | `list [--selector k=v]... [--watch] [--all]` |
@@ -187,9 +187,12 @@ section is the honest way to work remotely.
   real terminal. Programs that branch on capability detection can behave
   differently detached vs attached; recordings faithfully capture whichever
   actually happened.
-- **Controller vs watcher**: one controller (input + resize) at a time;
-  watchers are read-only and never affect the session. A watcher smaller
-  than the session grid sees wrap artifacts (byte-tee limitation).
+- **Controller vs watcher**: one controller (input + resize) at a time.
+  A plain `attach` falls back to watcher when that seat is occupied;
+  `attach --strict` refuses, while `attach --take` demotes the holder without
+  disconnecting it. Watchers are read-only and never affect the session. A
+  watcher smaller than the session grid sees wrap artifacts (byte-tee
+  limitation).
 - **The passthrough engine is test-only.** A functional binary is built
   with `--features ghostty-vt`; `capture`/`wait --text` error on
   passthrough builds.


### PR DESCRIPTION
## Summary

- make `cleat attach` fall back to a named read-only watcher when the controller seat is occupied
- add `--strict` refusal and `--take` transfer semantics that demote the prior controller without disconnecting it
- carry structured principal/supervisor/tool identities through stream and packet attachment handshakes
- render live watcher chrome naming the controller, and expose controller identity through `inspect`, `list`, directory state, and the provider ABI
- preserve session and recording state across seat transfers

Closes #177

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `./tools/prepare-ghostty-vt.sh` (with the repository-pinned Zig 0.15.2 toolchain)
- `cargo build -p cleat --locked --features ghostty-vt`
- `cargo test -p cleat --locked --features ghostty-vt`