### PR TITLE
feat: make ghostty-vt a default feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
       - uses: actions/cache@v4
         with:
           path: |
@@ -37,32 +40,15 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.lock') }}
+            .tools/ghostty-src/.zig-cache/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.lock', 'tools/ghostty-toolchain.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-clippy-
+      - run: ./tools/prepare-ghostty-vt.sh
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
   test:
     name: Test
-    runs-on: ubuntu-latest
-    needs: fmt
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-test-
-      - run: cargo test --workspace --locked
-
-  ghostty-vt:
-    name: Ghostty VT
     runs-on: ubuntu-latest
     needs: fmt
     env:
@@ -81,9 +67,28 @@ jobs:
             ~/.cargo/git/db/
             target/
             .tools/ghostty-src/.zig-cache/
-          key: ${{ runner.os }}-cargo-ghostty-vt-${{ hashFiles('Cargo.lock', 'tools/ghostty-toolchain.toml') }}
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock', 'tools/ghostty-toolchain.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-ghostty-vt-
+            ${{ runner.os }}-cargo-test-
       - run: ./tools/prepare-ghostty-vt.sh
-      - run: cargo build -p cleat --locked --features ghostty-vt
-      - run: cargo test -p cleat --locked --features ghostty-vt
+      - run: cargo test --workspace --locked
+
+  no-vt:
+    name: No-VT variant
+    runs-on: ubuntu-latest
+    needs: fmt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-no-vt-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-no-vt-
+      - run: cargo build -p cleat --locked --no-default-features
+      - run: cargo test -p cleat --locked --no-default-features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Core commands
 
 ```bash
+./tools/prepare-ghostty-vt.sh   # once per checkout; fetches + builds the pinned Ghostty VT
 cargo build --locked
 cargo +nightly-2026-03-12 fmt --check
 cargo clippy --workspace --all-targets --locked -- -D warnings
@@ -11,5 +12,5 @@ cargo test --workspace --locked
 
 ## Notes
 
-- `ghostty-vt` is optional and should stay out of the default build.
-- When validating Ghostty integration changes, run feature-on checks explicitly.
+- `ghostty-vt` is a **default feature**: a plain `cargo build` produces a functional binary, and fails with an actionable message if the prepared Ghostty install is missing (run the prepare script above).
+- The VT-less placeholder variant (testing only) is an explicit opt-out: `cargo build -p cleat --locked --no-default-features`. CI's `no-vt` job keeps it building.

--- a/README.md
+++ b/README.md
@@ -17,38 +17,35 @@ A future Rust VT engine may be added later. Until then, treat Ghostty as the onl
 Default development builds still compile without Ghostty so contributors can work in the repo, but those binaries are intentionally incomplete for real use.
 
 ```bash
+./tools/prepare-ghostty-vt.sh   # once per checkout (fetches + builds the pinned Ghostty VT)
 cargo build --locked
 cargo +nightly-2026-03-12 fmt --check
 cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --locked
 ```
 
+The `ghostty-vt` feature is a **default feature**: a plain `cargo build` produces a functional binary, and fails with an actionable message if the prepared Ghostty install is missing. Build the VT-less variant (placeholder engine, testing only) with `--no-default-features`.
+
 ## Functional Ghostty Build
 
-Use the repo-local helper to fetch the pinned Ghostty ref and build a local install prefix under `.tools/`, then build `cleat` with `ghostty-vt` enabled.
+Use the repo-local helper to fetch the pinned Ghostty ref and build a local install prefix under `.tools/`; `ghostty-vt` is enabled by default, so a normal build picks it up.
 
 ```bash
 ./tools/prepare-ghostty-vt.sh
 ```
 
-On **Linux**:
+On **Linux** and **macOS**:
 ```bash
-cargo build -p cleat --locked --features ghostty-vt
-cargo test -p cleat --locked --features ghostty-vt
-```
-
-On **macOS**:
-```bash
-cargo build -p cleat --locked --features ghostty-vt
-cargo test -p cleat --locked --features ghostty-vt
+cargo build -p cleat --locked
+cargo test -p cleat --locked
 ```
 
 On **Windows**:
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File tools\prepare-ghostty-vt.ps1
 $env:CLEAT_GHOSTTY_PREFIX = (Resolve-Path .tools\ghostty-install).Path
-cargo build -p cleat --locked --features ghostty-vt
-cargo test -p cleat --locked --features ghostty-vt
+cargo build -p cleat --locked
+cargo test -p cleat --locked
 ```
 
 The helpers read pinned inputs from [`tools/ghostty-toolchain.toml`](tools/ghostty-toolchain.toml), verify or install Zig `0.15.2`, clone or refresh Ghostty into `.tools/ghostty-src`, and install the Ghostty VT headers and libraries into `.tools/ghostty-install`.

--- a/crates/cleat/Cargo.toml
+++ b/crates/cleat/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 crate-type = ["rlib", "cdylib"]
 
 [features]
-default = []
+default = ["ghostty-vt"]
 ghostty-vt = ["dep:png"]
 
 [dependencies]

--- a/crates/cleat/build.rs
+++ b/crates/cleat/build.rs
@@ -8,13 +8,13 @@ fn main() {
 
     if env::var_os("CARGO_FEATURE_GHOSTTY_VT").is_none() {
         println!("cargo:rustc-env=CLEAT_FUNCTIONAL_VT_AVAILABLE=0");
-        println!("cargo:warning=building cleat without ghostty-vt; this binary is non-functional for real terminal usage");
+        println!("cargo:warning=building cleat without ghostty-vt (--no-default-features); this binary is non-functional for real terminal usage");
         println!("cargo:warning=Ghostty is currently the only functional VT engine");
         println!("cargo:warning=passthrough is a placeholder/testing engine only");
         if cfg!(target_os = "windows") {
-            println!("cargo:warning=run ./tools/prepare-ghostty-vt.ps1 and rebuild with --features ghostty-vt for a functional binary");
+            println!("cargo:warning=run ./tools/prepare-ghostty-vt.ps1 and rebuild with default features for a functional binary");
         } else {
-            println!("cargo:warning=run ./tools/prepare-ghostty-vt.sh and rebuild with --features ghostty-vt for a functional binary");
+            println!("cargo:warning=run ./tools/prepare-ghostty-vt.sh and rebuild with default features for a functional binary");
         }
         return;
     }
@@ -139,7 +139,7 @@ fn missing_ghostty_install_message(prefix: &Path, reason: String) -> String {
         format!(
             "ghostty-vt feature requires a prepared Ghostty install prefix. {reason}.\n\
 run ./tools/prepare-ghostty-vt.ps1 and retry with:\n\
-$env:CLEAT_GHOSTTY_PREFIX=\"{}\"; $env:PATH=\"{}\\bin;{}\\lib;$env:PATH\"; cargo build -p cleat --locked --features ghostty-vt",
+$env:CLEAT_GHOSTTY_PREFIX=\"{}\"; $env:PATH=\"{}\\bin;{}\\lib;$env:PATH\"; cargo build -p cleat --locked",
             prefix.display(),
             prefix.display(),
             prefix.display()
@@ -148,7 +148,7 @@ $env:CLEAT_GHOSTTY_PREFIX=\"{}\"; $env:PATH=\"{}\\bin;{}\\lib;$env:PATH\"; cargo
         format!(
             "ghostty-vt feature requires a prepared Ghostty install prefix. {reason}.\n\
 run ./tools/prepare-ghostty-vt.sh and retry with:\n\
-CLEAT_GHOSTTY_PREFIX=\"{}\" cargo build -p cleat --locked --features ghostty-vt",
+CLEAT_GHOSTTY_PREFIX=\"{}\" cargo build -p cleat --locked",
             prefix.display()
         )
     }


### PR DESCRIPTION
Closes #182. Ruled 2026-08-01 after the second VT-dead-binary production incident.

## What changes

- `default = ["ghostty-vt"]`: a plain `cargo build` now produces a functional binary, or fails **at build time** with the existing actionable message naming `./tools/prepare-ghostty-vt.sh` — instead of succeeding and dying at first launch. The VT-less placeholder variant becomes an explicit `--no-default-features` choice; build.rs warnings updated to say so.
- **CI inverted to test what ships**: the main Clippy and Test jobs now run the prepare script (with the zig setup and ghostty caches the old side-job used; Test keeps `LD_LIBRARY_PATH` for the dynamic-link fallback), exercising the default. The old `ghostty-vt` side job becomes a light `no-vt` job proving the opt-out variant builds and tests without any prepared install.
- README: quick start leads with the prepare script; per-platform sections drop the now-redundant `--features ghostty-vt`.

## Deliberately not done (per #182)

Multi-engine feature design (e.g. a future pure-Rust VT). Features stay additive; when a second engine lands, engines compile in side by side and runtime selects. This flip doesn't prejudice that.

## Verified locally (macOS)

fmt clean; clippy `-D warnings` clean; `cargo build`/`cargo test` green with the new default (feature-gated lifecycle suite included); `--no-default-features` variant builds.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp