### PR TITLE
chore: add Forgejo Darwin CI

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: Forgejo CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Format and Clippy remain platform-independent gates in GitHub CI. This
+  # workflow exercises Cleat's functional Darwin build and test surface.
+  # One-job guests are destroyed after each run, so build caches are not
+  # persisted between jobs.
+  CARGO_INCREMENTAL: "0"
+  DYLD_LIBRARY_PATH: ${{ forgejo.workspace }}/.tools/ghostty-install/lib
+  GIT_SSH_COMMAND: "ssh -o BatchMode=yes -o ConnectTimeout=5 -o ConnectionAttempts=1"
+
+jobs:
+  darwin:
+    name: Darwin build and test
+    runs-on: darwin-aarch64
+    timeout-minutes: 90
+    steps:
+      - name: Check out the repository
+        uses: https://data.forgejo.org/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Verify the credential-free worker
+        shell: /bin/sh -e {0}
+        run: |
+          test "$(uname -s)" = Darwin
+          test "$(uname -m)" = arm64
+          test "$(zig version)" = 0.15.2
+          security find-identity -v -p codesigning | grep -Eq '^[[:space:]]*0 valid identities found[[:space:]]*$'
+          test ! -e "$HOME/.config/forgejo-runner/.runner"
+          test -z "${FLEET_CODESIGN_IDENTITY:-}"
+          test -z "${FORGEJO_ADMIN_TOKEN:-}"
+          ! git --no-pager config --local --get-regexp 'http\..*\.extraheader'
+
+      - name: Prepare Ghostty VT
+        run: |
+          ./tools/prepare-ghostty-vt.sh
+          test -f .tools/ghostty-install/lib/libghostty-vt.dylib
+
+      - name: Build functional binary
+        run: |
+          cargo build -p cleat --locked --features ghostty-vt
+          otool -L target/debug/cleat | grep -Fq libghostty-vt.dylib
+
+      - name: Test workspace with Ghostty VT
+        run: cargo test --workspace --locked --features ghostty-vt


### PR DESCRIPTION
Adds the credential-free `darwin-aarch64` Forgejo build/test gate for the pull-mirrored lab repository.

Cleat prepares the pinned Ghostty VT dependency, requires the macOS dylib, builds the functional binary, verifies that the executable dynamically links `libghostty-vt.dylib`, and runs the workspace tests with that library available. This intentionally does not require static Ghostty linkage or perform signing/publishing.

The worker checks match the proved disposable Comte runner boundary: no signing identity, runner registration, release identity, or persisted checkout credential.

Local verification:
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build -p cleat --locked --features ghostty-vt`
- `otool -L target/debug/cleat` (dynamic `@rpath/libghostty-vt.dylib`)
- `cargo test --workspace --locked --features ghostty-vt`
- `yq eval . .forgejo/workflows/ci.yml`