### PR TITLE
chore: satisfy chunks_exact_to_as_chunks lint on current clippy

### DIFF
--- a/crates/cleat/src/vt/ghostty_ffi.rs
+++ b/crates/cleat/src/vt/ghostty_ffi.rs
@@ -1227,14 +1227,14 @@ fn decode_png_rgba(data: &[u8]) -> Result<DecodedPng, String> {
         png::ColorType::Rgba => bytes.to_vec(),
         png::ColorType::Rgb => {
             let mut out = Vec::with_capacity(pixel_count(info.width, info.height)? * 4);
-            for rgb in bytes.chunks_exact(3) {
+            for rgb in bytes.as_chunks::<3>().0 {
                 out.extend_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
             }
             out
         }
         png::ColorType::GrayscaleAlpha => {
             let mut out = Vec::with_capacity(pixel_count(info.width, info.height)? * 4);
-            for gray_alpha in bytes.chunks_exact(2) {
+            for gray_alpha in bytes.as_chunks::<2>().0 {
                 out.extend_from_slice(&[gray_alpha[0], gray_alpha[0], gray_alpha[0], gray_alpha[1]]);
             }
             out


### PR DESCRIPTION
Main is red on CI: the floating clippy toolchain now enforces `chunks_exact_to_as_chunks`, flagging two loops in `ghostty_ffi.rs` PNG conversion. Mechanical fix to `as_chunks::<N>().0` as clippy suggests. Unblocks #192 (which fails Clippy only on these pre-existing lints).

https://claude.ai/code/session_01LVK2W5iQmQQgLQTmFa7k9z
