### PR TITLE
chore: allow flotilla-crew bot PRs through claude review guard

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Crew convoys open PRs as the flotilla-crew GitHub App; the action's
+          # human-actor guard would otherwise refuse to review them.
+          allowed_bots: "flotilla-crew"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Ports flotilla's `allowed_bots: "flotilla-crew"` setting to cleat's claude-code-review workflow. Without it, the action's human-actor guard silently skips reviewing crew-opened PRs — relevant now that cleat convoys dispatch with GitHub credentials (dirty-row-render is the first).

https://claude.ai/code/session_01LVK2W5iQmQQgLQTmFa7k9z
